### PR TITLE
Port RpcClient base + CIA/BMX protocol clients; complete v0.1.0 bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test (Ruby ${{ matrix.ruby }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.4"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec rake test
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+      - name: Run RuboCop
+        run: bundle exec rubocop --no-server

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,14 @@
+inherit_gem:
+  rubocop-rails-omakase: rubocop.yml
+
+AllCops:
+  TargetRubyVersion: 3.4
+  NewCops: enable
+  SuggestExtensions: false
+  Exclude:
+    - "vendor/**/*"
+    - "tmp/**/*"
+
+# Allow longer wire-protocol constants and cipher tables
+Layout/LineLength:
+  Max: 200

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] — 2026-04-07
+
+Initial release. Pure Ruby RPC client extracted from `rpms_redux`.
+
+### Added
+
+- `RpmsRpc::Client` — abstract broker base class with connection
+  lifecycle, XUS signon authentication, XWB cipher encryption
+  (`xwb_encrypt` matching `$$ENCRYP^XUSRB1`), and socket helpers.
+- `RpmsRpc::CiaClient` — XWB/CIA wire protocol on port 9100,
+  per FOIA-RPMS XWBTCPM.m.
+- `RpmsRpc::BmxClient` — BMX wire protocol on port 9200,
+  per FOIA-RPMS BMXMON.m / BMXMBRK.m.
+- `RpmsRpc::ParameterEncoder` — VistA `1{len}00f{value}\x04`
+  parameter encoding with `ParameterTooLongError` at 999 bytes.
+- `RpmsRpc::ResponseParser` — caret-delimited response parser
+  with `RpcResult` struct and `pick_string` / `pick_value` /
+  `piece` / `pipe_piece` / `pipe_param` helpers.
+- `RpmsRpc::XmlResponseParser` — REXML-based parser for VistA
+  RPC XML responses (`Gov.VA.Med.RPC.Response` and
+  `VA.RPC.Error`).
+- `RpmsRpc::FilemanDateParser` — bidirectional conversion between
+  Ruby `Date`/`Time` and FileMan `YYYMMDD.HHMM` (year - 1700).
+- `RpmsRpc::PhiSanitizer` — HIPAA-aligned scrubbing for log
+  messages and hashes; HMAC-SHA256 identifier hashing with a
+  12-character display prefix.
+- ADR 0001 — Scope and no Rails coupling.
+- ADR 0002 — Verified routine policy (every shipped RPC must
+  be verified against MUMPS source in CIVITAS FOIA-RPMS).
+- `docs/rpcs.md` — verified RPC audit trail.
+
+### Notes
+
+- Requires Ruby 3.4+.
+- Runtime dependency: `rexml ~> 3.2` (default gem in 3.4+ but
+  must be declared so Bundler puts it on the load path).
+- No Rails dependency. No ActiveSupport on the load path.
+- Test suite is hermetic — 116 tests, no sockets, no live RPMS.

--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,5 @@ gemspec
 group :development, :test do
   gem "minitest", "~> 5.0"
   gem "rake", "~> 13.0"
-  gem "rubocop", require: false
+  gem "rubocop-rails-omakase", require: false
 end

--- a/README.md
+++ b/README.md
@@ -1,0 +1,141 @@
+# rpms-rpc
+
+Pure Ruby RPC client for VistA / RPMS — speaks the **CIA/XWB**
+(port 9100) and **BMX** (port 9200) broker protocols. No Rails
+dependency, no Java, just stdlib.
+
+## Status
+
+Pre-1.0. The wire protocol layer is functional and verified against
+the FOIA-RPMS routine sources. See [docs/rpcs.md](docs/rpcs.md) for
+the audit trail.
+
+## Why a separate gem?
+
+Historically the VistA RPC client lived inside a Rails app
+(`rpms_redux`). That made it impossible to reuse from non-Rails
+consumers — workers, scripts, and other engines that don't want
+ActiveSupport on the load path.
+
+This gem extracts just the wire layer:
+
+- Connection lifecycle (`connect`, `disconnect`, `connected?`)
+- Authentication (`XUS SIGNON SETUP`, `XUS AV CODE`, cipher encrypt)
+- Application context (`XWB CREATE CONTEXT`)
+- Parameter encoding for the VistA `1{len}00f{value}\x04` format
+- Caret-delimited and XML response parsing
+- FileMan date conversions
+- HIPAA-aligned PHI sanitizer for log lines
+
+What it does **not** include: ActiveRecord models, FHIR clients,
+domain-specific RPC wrappers, or an adapter contract. Those live
+in consumers (e.g. `lakeraven-ehr`).
+
+See [ADR 0001](docs/adr/0001-scope-and-no-rails-coupling.md) for
+the full scope rationale.
+
+## Installation
+
+Add to your `Gemfile`:
+
+```ruby
+gem "rpms-rpc"
+```
+
+Then `bundle install`.
+
+Requires Ruby 3.4+.
+
+## Usage
+
+### CIA (XWB) — port 9100
+
+```ruby
+require "rpms_rpc/cia_client"
+
+client = RpmsRpc::CiaClient.new(host: "vista.example.com", port: 9100)
+client.connect
+client.authenticate("PROV123", "PROV123!!")
+client.create_context("OR CPRS GUI CHART")
+
+result = client.call_rpc("XUS SIGNON SETUP")
+# => array of broker environment lines
+
+client.disconnect
+```
+
+### BMX — port 9200
+
+```ruby
+require "rpms_rpc/bmx_client"
+
+client = RpmsRpc::BmxClient.new(host: "vista.example.com", port: 9200)
+client.connect
+client.authenticate
+client.create_context("OR CPRS GUI CHART")
+
+result = client.call_rpc("XUS SIGNON SETUP")
+
+client.disconnect
+```
+
+### Configuration via environment
+
+| Variable             | Default     | Notes                              |
+|----------------------|-------------|------------------------------------|
+| `VISTA_RPC_HOST`     | `localhost` | Broker hostname                    |
+| `VISTA_RPC_PORT`     | `9100`/`9200` | Default depends on subclass      |
+| `VISTA_RPC_TIMEOUT`  | `30`        | Read timeout in seconds            |
+| `RPMS_ACCESS_CODE`   | `PROV123`   | Default access code (dev only)     |
+| `RPMS_VERIFY_CODE`   | `PROV123!!` | Default verify code (dev only)     |
+
+## Components
+
+| File                          | Purpose                                          |
+|-------------------------------|--------------------------------------------------|
+| `RpmsRpc::Client`             | Abstract base — auth, cipher, socket helpers     |
+| `RpmsRpc::CiaClient`          | XWB/CIA wire protocol (port 9100)                |
+| `RpmsRpc::BmxClient`          | BMX wire protocol (port 9200)                    |
+| `RpmsRpc::ParameterEncoder`   | VistA `1{len}00f{value}\x04` parameter encoding  |
+| `RpmsRpc::ResponseParser`     | Caret-delimited response parser                  |
+| `RpmsRpc::XmlResponseParser`  | VistA RPC XML response parser                    |
+| `RpmsRpc::FilemanDateParser`  | FileMan ↔ Ruby Date/Time conversion              |
+| `RpmsRpc::PhiSanitizer`       | HIPAA-aligned log/error sanitizer                |
+
+## CIA vs BMX
+
+Both protocols call the same RPC registry (`^XWB(8994)`) and the
+same M routines. They differ only in wire framing:
+
+- **CIA/XWB** — `[XWB]1130` prefix, length-prefixed pack format,
+  used by CPRS / XWBTCPM. Implemented in
+  `FOIA-RPMS/Packages/RPC Broker/Routines/XWBTCPM.m`.
+- **BMX** — `{BMX}LLLLL` prefix, two-stage handshake (monitor
+  spawns session), used by BMXMON. Implemented in
+  `FOIA-RPMS/Packages/M Transfer/Routines/BMXMON.m` and
+  `BMXMBRK.m`.
+
+Pick the protocol that matches the broker your site is running.
+Don't infer protocol from port — sites can and do remap.
+
+## Testing
+
+```bash
+bundle install
+bundle exec rake test
+```
+
+The test suite is hermetic — no sockets, no live RPMS. Wire-format
+tests construct packet bytes and assert their layout.
+
+## Contributing
+
+Per [ADR 0002](docs/adr/0002-verified-routine-policy.md), every
+new RPC must be verified against actual M source in the
+[CIVITAS FOIA-RPMS](https://github.com/CivicActions/FOIA-RPMS)
+repository before merge. PRs adding new RPCs must include the
+M source reference and update [docs/rpcs.md](docs/rpcs.md).
+
+## License
+
+MIT. See [MIT-LICENSE](MIT-LICENSE).

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ client.disconnect
 | `RPMS_ACCESS_CODE`   | `PROV123`   | Default access code (dev only)     |
 | `RPMS_VERIFY_CODE`   | `PROV123!!` | Default verify code (dev only)     |
 
+> **Security:** the `PROV123` / `PROV123!!` defaults exist for the
+> standard FOIA-RPMS dev image. **Never** ship a deployment that
+> falls through to those defaults — always set `RPMS_ACCESS_CODE`
+> and `RPMS_VERIFY_CODE` (or pass them explicitly to
+> `#authenticate`) for any host that talks to real PHI.
+
 ## Components
 
 | File                          | Purpose                                          |
@@ -101,6 +107,24 @@ client.disconnect
 | `RpmsRpc::XmlResponseParser`  | VistA RPC XML response parser                    |
 | `RpmsRpc::FilemanDateParser`  | FileMan ↔ Ruby Date/Time conversion              |
 | `RpmsRpc::PhiSanitizer`       | HIPAA-aligned log/error sanitizer                |
+
+### PhiSanitizer secret
+
+`RpmsRpc::PhiSanitizer` uses HMAC-SHA256 to hash patient identifiers
+into stable, non-reversible tokens for log lines. Under Rails it
+reads the secret from `Rails.application.secret_key_base`. Without
+Rails, set the secret explicitly so token hashes stay consistent
+across processes:
+
+```ruby
+RpmsRpc::PhiSanitizer.secret_key = ENV.fetch("PHI_SANITIZER_SECRET")
+```
+
+Leaving the secret unset is acceptable for local development
+(falls through to a fixed dev string), but **production deployments
+must set it** — otherwise log correlation across restarts and
+hosts breaks, and the dev fallback gives operators a false sense
+of unique tokens.
 
 ## CIA vs BMX
 

--- a/docs/rpcs.md
+++ b/docs/rpcs.md
@@ -1,0 +1,52 @@
+# Verified RPCs
+
+Per [ADR 0002](adr/0002-verified-routine-policy.md), every RPC the
+gem speaks to must be verified against actual MUMPS source in the
+[CIVITAS FOIA-RPMS](https://github.com/CivicActions/FOIA-RPMS)
+repository before merge.
+
+This file is the audit trail. It lists every RPC name the gem invokes,
+the FOIA-RPMS routine that implements it, the parameter shape, and the
+return format.
+
+## Authentication & session
+
+| RPC name              | Routine / Tag           | Params              | Return                          | Status     |
+|-----------------------|-------------------------|---------------------|---------------------------------|------------|
+| `XUS SIGNON SETUP`    | `XUS^XUSRB`             | none                | array of environment lines      | verified   |
+| `XUS AV CODE`         | `AVCODE^XUSRB`          | encrypted "AC;VC"   | DUZ + status lines (CRLF/NL)    | verified   |
+| `XWB CREATE CONTEXT`  | `CREATE^XWBSEC`         | encrypted option    | "1" on success, error otherwise | verified   |
+
+**Notes:**
+
+- `XUS SIGNON SETUP` is a no-arg call that returns the broker's
+  signon environment. It is required before `XUS AV CODE`.
+- `XUS AV CODE` requires the access/verify codes to be passed
+  through the `xwb_encrypt` cipher (`$$ENCRYP^XUSRB1`).
+- `XWB CREATE CONTEXT` is sent the option name through the same
+  cipher and gates whether RPCs in that context can be invoked.
+
+## Conventions
+
+When new RPCs are added to the gem in downstream consumers
+(`lakeraven-ehr`, etc.), they must add a row to this table along
+with the verifying FOIA-RPMS path before the consumer ships.
+
+The base `RpmsRpc::Client` ships with **only** the routines required
+for connection lifecycle and authentication. Domain-specific RPCs
+(patient lookup, consult lists, allergies, lab results) live in the
+consuming application — `rpms-rpc` is the wire layer, not a domain
+client.
+
+## Unverified RPCs
+
+None. The gem refuses to merge an RPC call that has not been verified
+against M source per ADR 0002.
+
+## See also
+
+- [ADR 0001 — Scope and no Rails coupling](adr/0001-scope-and-no-rails-coupling.md)
+- [ADR 0002 — Verified routine policy](adr/0002-verified-routine-policy.md)
+- FOIA-RPMS XWBTCPM.m — XWB/CIA wire protocol
+- FOIA-RPMS BMXMON.m, BMXMBRK.m — BMX wire protocol
+- FOIA-RPMS XUSRB.m, XUSRB1.m — signon and cipher

--- a/lib/rpms_rpc/bmx_client.rb
+++ b/lib/rpms_rpc/bmx_client.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+require "rpms_rpc/client"
+
+module RpmsRpc
+  # BMX (M Transfer) Protocol Client.
+  #
+  # Implements the {BMX} protocol used by BMXMON on port 9200.
+  # Both BMX and CIA/XWB route to the same RPC registry (^XWB(8994))
+  # and call the same M routines — the difference is the wire format.
+  #
+  #   Packet format:  {BMX}LLLLL + protocol_header + message
+  #   Handshake:      TCPconnect → "accept" (in session) or spawns child
+  #   Disconnect:     #BYE#
+  #   Response:       len(security_err) + len(app_err) + data + EOT(\x04)
+  #
+  # See FOIA-RPMS/Packages/M Transfer/Routines/BMXMON.m, BMXMBRK.m
+  class BmxClient < Client
+    BMX_PREFIX = "{BMX}"
+
+    # Connect to RPMS BMX Broker
+    def connect(host = @host, port = @port)
+      open_socket(host, port)
+
+      # BMX handshake: {BMX}LLLLL + TCPconnect
+      body = "TCPconnect"
+      send_bmx_packet(body)
+      response = read_response
+
+      if response.include?("accept") || response.include?("CONNECTION OK")
+        @connected = true
+      else
+        @socket&.close
+        @socket = nil
+        raise ConnectionError, "BMX server rejected handshake: #{response}"
+      end
+
+      @connected
+    end
+
+    # Disconnect from RPMS BMX Broker
+    def disconnect
+      if connected?
+        begin
+          send_bmx_session_packet("#BYE#")
+        rescue StandardError
+          # Best effort disconnect
+        end
+      end
+      reset_connection
+    end
+
+    # Call an RPC via BMX protocol
+    def call_rpc(rpc_name, *params)
+      raise ConnectionError, "Not connected" unless connected?
+
+      param_string = params.map(&:to_s).join("^")
+      api_content = rpc_name
+      api_content += "^" + param_string unless param_string.empty?
+
+      message = build_bmx_message(api_content)
+      send_bmx_session_packet(message)
+
+      response = read_response
+      check_for_rpc_error(response)
+      split_response(response)
+    rescue IOError, Errno::ECONNRESET, Errno::EPIPE, Errno::ENOTCONN => e
+      @connected = false
+      raise ConnectionError, "Connection lost during RPC call: #{e.message}"
+    rescue Errno::ETIMEDOUT => e
+      raise ConnectionError, "RPC call timed out: #{e.message}"
+    rescue SocketError => e
+      @connected = false
+      raise ConnectionError, "Network error during RPC call: #{e.message}"
+    end
+
+    # Send an RPC and return the raw string response
+    def call_rpc_raw(rpc_name, *params)
+      raise ConnectionError, "Not connected" unless connected?
+
+      param_string = params.map(&:to_s).join("^")
+      api_content = rpc_name
+      api_content += "^" + param_string unless param_string.empty?
+
+      message = build_bmx_message(api_content)
+      send_bmx_session_packet(message)
+      read_response
+    end
+
+    # -- packet construction (public for testing) -----------------------------
+
+    # Build BMX protocol message from API content.
+    # Matches BMXMBRK.m PRSP/PRSM/PRSA parsing expectations:
+    #   Protocol header: LLLwkid;winh;prch;wish;
+    #   Message:         LLL;1 + API_NAME^PARAMS
+    def build_bmx_message(api_content)
+      proto_fields = "RPMS_RPC;0;0;0;"
+      proto_header = format("%03d", proto_fields.length) + proto_fields
+
+      msg_body = api_content
+      msg_header = format("%05d", msg_body.length + 6) + ";1"
+      message = msg_header + msg_body
+
+      proto_header + "^" + message
+    end
+
+    private
+
+    def default_port
+      9200
+    end
+
+    # Send a packet for the initial monitor connection (pre-session)
+    def send_bmx_packet(body)
+      length_str = format("%05d", body.length)
+      packet = BMX_PREFIX + length_str + body
+      send_packet(packet)
+    end
+
+    # Send a packet within an established session.
+    # SESSMAIN (BMXMON.m lines 210-219) reads:
+    #   R #11  → {BMX}(5) + LLLLL(5) + 1-byte overlap
+    #   R #4   → remaining 4 bytes of PLEN
+    #   R #PLEN → body
+    # Wire = {BMX} + LLLLL + PPPPP + body
+    def send_bmx_session_packet(body)
+      plen = format("%05d", body.length)
+      total_len = format("%05d", body.length + 5)
+      packet = BMX_PREFIX + total_len + plen + body
+      send_packet(packet)
+    end
+
+    # Read BMX response: SNDERR packets + data + EOT
+    #   byte(security_error_len) + security_error
+    #   byte(app_error_len) + app_error
+    #   data
+    #   \x04 (EOT)
+    def read_response
+      raw = read_until_eot_raw
+      return "" if raw.nil? || raw.empty?
+
+      pos = 0
+
+      # Security error packet
+      if pos < raw.length
+        sec_len = raw[pos].ord
+        pos += 1
+        if sec_len > 0 && pos + sec_len <= raw.length
+          sec_err = raw[pos, sec_len]
+          pos += sec_len
+          raise ConnectionError, "BMX security error: #{sec_err}" unless sec_err.empty?
+        end
+      end
+
+      # Application error packet
+      if pos < raw.length
+        app_len = raw[pos].ord
+        pos += 1
+        if app_len > 0 && pos + app_len <= raw.length
+          app_err = raw[pos, app_len]
+          pos += app_len
+          raise RpcError, "BMX application error: #{app_err}" unless app_err.empty?
+        end
+      end
+
+      pos < raw.length ? raw[pos..] : ""
+    end
+  end
+end

--- a/lib/rpms_rpc/bmx_client.rb
+++ b/lib/rpms_rpc/bmx_client.rb
@@ -89,19 +89,23 @@ module RpmsRpc
 
     # -- packet construction (public for testing) -----------------------------
 
+    # BMX wire packets are byte streams. All length fields below count
+    # BYTES, never characters. Buffers are built in ASCII-8BIT (binary)
+    # so multibyte parameters frame correctly.
+
     # Build BMX protocol message from API content.
     # Matches BMXMBRK.m PRSP/PRSM/PRSA parsing expectations:
     #   Protocol header: LLLwkid;winh;prch;wish;
     #   Message:         LLL;1 + API_NAME^PARAMS
     def build_bmx_message(api_content)
-      proto_fields = "RPMS_RPC;0;0;0;"
-      proto_header = format("%03d", proto_fields.length) + proto_fields
+      proto_fields = "RPMS_RPC;0;0;0;".b
+      proto_header = format("%03d", proto_fields.bytesize).b + proto_fields
 
-      msg_body = api_content
-      msg_header = format("%05d", msg_body.length + 6) + ";1"
+      msg_body = api_content.to_s.b
+      msg_header = (format("%05d", msg_body.bytesize + 6) + ";1").b
       message = msg_header + msg_body
 
-      proto_header + "^" + message
+      proto_header + "^".b + message
     end
 
     private
@@ -112,8 +116,9 @@ module RpmsRpc
 
     # Send a packet for the initial monitor connection (pre-session)
     def send_bmx_packet(body)
-      length_str = format("%05d", body.length)
-      packet = BMX_PREFIX + length_str + body
+      bytes = body.to_s.b
+      length_str = format("%05d", bytes.bytesize).b
+      packet = BMX_PREFIX.b + length_str + bytes
       send_packet(packet)
     end
 
@@ -124,9 +129,10 @@ module RpmsRpc
     #   R #PLEN → body
     # Wire = {BMX} + LLLLL + PPPPP + body
     def send_bmx_session_packet(body)
-      plen = format("%05d", body.length)
-      total_len = format("%05d", body.length + 5)
-      packet = BMX_PREFIX + total_len + plen + body
+      bytes = body.to_s.b
+      plen = format("%05d", bytes.bytesize).b
+      total_len = format("%05d", bytes.bytesize + 5).b
+      packet = BMX_PREFIX.b + total_len + plen + bytes
       send_packet(packet)
     end
 

--- a/lib/rpms_rpc/cia_client.rb
+++ b/lib/rpms_rpc/cia_client.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "rpms_rpc/client"
+
+module RpmsRpc
+  # XWB (CIA) Protocol Client.
+  #
+  # Implements the [XWB] RPC Broker protocol used by XWBTCPM on port 9100.
+  #
+  #   Packet format:  [XWB]1130 + token + spack(name) + params + EOT
+  #   Handshake:      TCPConnect → "accept"
+  #   Disconnect:     #BYE#
+  #   Response:       \x00\x00 (SNDERR prefix) + data + EOT(\x04)
+  #
+  # See FOIA-RPMS/Packages/RPC Broker/Routines/XWBTCPM.m
+  class CiaClient < Client
+    XWB_PREFIX = "[XWB]1130"
+
+    # Connect to RPMS XWB Broker
+    def connect(host = @host, port = @port)
+      open_socket(host, port)
+
+      msg = build_connect_message(local_ip, "rpms-rpc")
+      send_packet(msg)
+      response = read_response
+
+      if response.start_with?("accept")
+        @connected = true
+      else
+        @socket&.close
+        @socket = nil
+        raise ConnectionError, "Server rejected handshake: #{response}"
+      end
+
+      @connected
+    end
+
+    # Disconnect from RPMS XWB Broker
+    def disconnect
+      if connected?
+        begin
+          msg = build_rpc_message("#BYE#")
+          send_packet(msg)
+        rescue StandardError
+          # Best effort disconnect
+        end
+      end
+      reset_connection
+    end
+
+    # Call an RPC via XWB protocol
+    def call_rpc(rpc_name, *params)
+      raise ConnectionError, "Not connected" unless connected?
+
+      rpc_params = params.map { |p| literal_param(p.to_s) }
+      msg = build_rpc_message(rpc_name, rpc_params)
+
+      send_packet(msg)
+      response = read_response
+
+      check_for_rpc_error(response)
+      split_response(response)
+    rescue IOError, Errno::ECONNRESET, Errno::EPIPE, Errno::ENOTCONN => e
+      @connected = false
+      raise ConnectionError, "Connection lost during RPC call: #{e.message}"
+    rescue Errno::ETIMEDOUT => e
+      raise ConnectionError, "RPC call timed out: #{e.message}"
+    rescue SocketError => e
+      @connected = false
+      raise ConnectionError, "Network error during RPC call: #{e.message}"
+    end
+
+    # Send an RPC and return the raw string response
+    def call_rpc_raw(rpc_name, *params)
+      raise ConnectionError, "Not connected" unless connected?
+
+      rpc_params = params.map { |p| literal_param(p.to_s) }
+      msg = build_rpc_message(rpc_name, rpc_params)
+
+      send_packet(msg)
+      read_response
+    end
+
+    # Build disconnect packet (compatibility)
+    def build_disconnect_packet
+      build_rpc_message("#BYE#")
+    end
+
+    # -- packet construction (public for testing) -----------------------------
+
+    # S-PACK: chr(len) + value (max 255 chars)
+    def spack(value)
+      value.length.chr + value
+    end
+
+    # L-PACK: zero-padded length + value (3-digit for <=999, 5-digit for >999)
+    def lpack(value)
+      if value.length > 999
+        format("%05d", value.length) + value
+      else
+        format("%03d", value.length) + value
+      end
+    end
+
+    # Build TCPConnect command message — uses command token "4"
+    def build_connect_message(client_hostname, app_name)
+      command_token = "4"
+      name_spec = spack("TCPConnect")
+      param_spec = "5" \
+        + "0" + lpack(client_hostname) + "f" \
+        + "0" + lpack("0") + "f" \
+        + "0" + lpack(app_name) + "f"
+      (XWB_PREFIX + command_token + name_spec + param_spec + EOT).encode("UTF-8")
+    end
+
+    # Build an RPC invocation message — uses RPC token "2\x011"
+    def build_rpc_message(name, params = nil)
+      rpc_token = "2\x011"
+      name_spec = spack(name)
+      param_spec = "5"
+
+      if params.nil? || params.empty?
+        param_spec += "4f"
+      else
+        params.each do |p|
+          case p[:type]
+          when :literal
+            param_spec += "0" + lpack(p[:value]) + "f"
+          when :list
+            param_spec += "2"
+            first = true
+            p[:entries].each do |key, val|
+              param_spec += "t" unless first
+              param_spec += lpack(key.to_s) + lpack(val.to_s)
+              first = false
+            end
+            param_spec += "f"
+          end
+        end
+      end
+
+      (XWB_PREFIX + rpc_token + name_spec + param_spec + EOT).encode("UTF-8")
+    end
+
+    # Build a literal parameter hash
+    def literal_param(value)
+      { type: :literal, value: value }
+    end
+
+    # Build a list parameter hash
+    def list_param(entries)
+      { type: :list, entries: entries }
+    end
+
+    private
+
+    def default_port
+      9100
+    end
+
+    # Read XWB response: recv until EOT, strip \x00\x00 SNDERR prefix
+    def read_response
+      raw = read_until_eot_raw
+      raw = raw[2..] if raw.start_with?("\x00\x00")
+      raw.to_s
+    end
+  end
+end

--- a/lib/rpms_rpc/cia_client.rb
+++ b/lib/rpms_rpc/cia_client.rb
@@ -88,58 +88,69 @@ module RpmsRpc
 
     # -- packet construction (public for testing) -----------------------------
 
-    # S-PACK: chr(len) + value (max 255 chars)
+    # XWB wire packets are byte streams, not character strings. The broker
+    # frames everything by byte count, so every length prefix and every
+    # concatenated buffer below is built in ASCII-8BIT (binary) encoding.
+    # The helpers below are byte-safe; do not introduce String#length here.
+
+    # SpackTooLongError raised when a value exceeds S-PACK's 255-byte limit.
+    class SpackTooLongError < StandardError; end
+
+    # S-PACK: one-byte length prefix + value (max 255 bytes)
     def spack(value)
-      value.length.chr + value
+      bytes = value.to_s.b
+      if bytes.bytesize > 255
+        raise SpackTooLongError, "S-PACK value exceeds 255 bytes (#{bytes.bytesize})"
+      end
+      bytes.bytesize.chr.b + bytes
     end
 
-    # L-PACK: zero-padded length + value (3-digit for <=999, 5-digit for >999)
+    # L-PACK: zero-padded length + value (3-digit for <=999 bytes,
+    # 5-digit for >999 bytes). Length is always counted in BYTES.
     def lpack(value)
-      if value.length > 999
-        format("%05d", value.length) + value
-      else
-        format("%03d", value.length) + value
-      end
+      bytes = value.to_s.b
+      width = bytes.bytesize > 999 ? 5 : 3
+      (format("%0#{width}d", bytes.bytesize) + bytes).b
     end
 
     # Build TCPConnect command message — uses command token "4"
     def build_connect_message(client_hostname, app_name)
       command_token = "4"
       name_spec = spack("TCPConnect")
-      param_spec = "5" \
-        + "0" + lpack(client_hostname) + "f" \
-        + "0" + lpack("0") + "f" \
-        + "0" + lpack(app_name) + "f"
-      (XWB_PREFIX + command_token + name_spec + param_spec + EOT).encode("UTF-8")
+      param_spec = ("5" \
+        + "0").b + lpack(client_hostname) + "f".b \
+        + "0".b + lpack("0") + "f".b \
+        + "0".b + lpack(app_name) + "f".b
+      (XWB_PREFIX.b + command_token.b + name_spec + param_spec + EOT.b)
     end
 
     # Build an RPC invocation message — uses RPC token "2\x011"
     def build_rpc_message(name, params = nil)
-      rpc_token = "2\x011"
+      rpc_token = "2\x011".b
       name_spec = spack(name)
-      param_spec = "5"
+      param_spec = +"5".b
 
       if params.nil? || params.empty?
-        param_spec += "4f"
+        param_spec << "4f".b
       else
         params.each do |p|
           case p[:type]
           when :literal
-            param_spec += "0" + lpack(p[:value]) + "f"
+            param_spec << "0".b << lpack(p[:value]) << "f".b
           when :list
-            param_spec += "2"
+            param_spec << "2".b
             first = true
             p[:entries].each do |key, val|
-              param_spec += "t" unless first
-              param_spec += lpack(key.to_s) + lpack(val.to_s)
+              param_spec << "t".b unless first
+              param_spec << lpack(key.to_s) << lpack(val.to_s)
               first = false
             end
-            param_spec += "f"
+            param_spec << "f".b
           end
         end
       end
 
-      (XWB_PREFIX + rpc_token + name_spec + param_spec + EOT).encode("UTF-8")
+      (XWB_PREFIX.b + rpc_token + name_spec + param_spec + EOT.b)
     end
 
     # Build a literal parameter hash

--- a/lib/rpms_rpc/client.rb
+++ b/lib/rpms_rpc/client.rb
@@ -1,0 +1,347 @@
+# frozen_string_literal: true
+
+require "socket"
+require "rpms_rpc/parameter_encoder"
+require "rpms_rpc/xml_response_parser"
+
+module RpmsRpc
+  # Abstract base class for RPMS RPC broker clients.
+  #
+  # Subclass this for protocol-specific clients (RpmsRpc::CiaClient,
+  # RpmsRpc::BmxClient). Provides connection lifecycle, authentication,
+  # cipher encryption, and response parsing helpers. Each subclass
+  # implements its own wire protocol.
+  #
+  # Subclass contract (must define):
+  #   connect(host, port)         — open socket and perform protocol handshake
+  #   disconnect                  — send shutdown command and close socket
+  #   call_rpc(name, *params)     — encode, send, read, and parse one RPC call
+  #   call_rpc_raw(name, *params) — send RPC, return raw string response
+  #   read_response               — read and decode one protocol response
+  class Client
+    # Error classes
+    class ConnectionError < StandardError; end
+    class AuthenticationError < StandardError; end
+    class RpcError < StandardError; end
+    class TimeoutError < ConnectionError; end
+
+    # Shared constants
+    EOT = "\x04"
+    RECV_SIZE = 4096
+    DEFAULT_TIMEOUT = 30 # seconds
+
+    # Traditional VistA/Kernel cipher table (from XUSRB1.m)
+    CIPHER_TABLE = [
+      'wkEo-ZJt!dG)49K{nX1BS$vH<&:Myf*>Ae0jQW=;|#PsO`\'%+rmb[gpqN,l6/hFC@DcUa ]z~R}"V\\iIxu?872.(TYL5_3',
+      'rKv`R;M/9BqAF%&tSs#Vh)dO1DZP> *fX\'u[.4lY=-mg_ci802N7LTG<]!CWo:3?{+,5Q}(@jaExn$~p\\IyHwzU"|k6Jeb',
+      '\\pV(ZJk"WQmCn!Y,y@1d+~8s?[lNMxgHEt=uw|X:qSLjAI*}6zoF{T3#;ca)/h5%`P4$r]G\'9e2if_>UDKb7<v0&- RBO.',
+      'depjt3g4W)qD0V~NJar\\B "?OYhcu[<Ms%Z`RIL_6:]AX-zG.#}$@vk7/5x&*m;(yb2Fn+l\'PwUof1K{9,|EQi>H=CT8S!',
+      'NZW:1}K$byP;jk)7\'`x90B|cq@iSsEnu,(l-hf.&Y_?J#R]+voQXU8mrV[!p4tg~OMez CAaGFD6H53%L/dT2<*>"{\\wI=',
+      'vCiJ<oZ9|phXVNn)m K`t/SI%]A5qOWe\\&?;jT~M!fz1l>[D_0xR32c*4.P"G{r7}E8wUgyudF+6-:B=$(sY,LkbHa#\'@Q',
+      'hvMX,\'4Ty;[a8/{6l~F_V"}qLI\\!@x(D7bRmUH]W15J%N0BYPkrs&9:$)Zj>u|zwQ=ieC-oGA.#?tfdcO3gp`S+En K2*<',
+      'jd!W5[];4\'<C$/&x|rZ(k{>?ghBzIFN}fAK"#`p_TqtD*1E37XGVs@0nmSe+Y6Qyo-aUu%i8c=H2vJ\\) R:MLb.9,wlO~P',
+      '2ThtjEM+!=xXb)7,ZV{*ci3"8@_l-HS69L>]\\AUF/Q%:qD?1~m(yvO0e\'<#o$p4dnIzKP|`NrkaGg.ufCRB[; sJYwW}5&',
+      'vB\\5/zl-9y:Pj|=(R\'7QJI *&CTX"p0]_3.idcuOefVU#omwNZ`$Fs?L+1Sk<,b)hM4A6[Y%aDrg@~KqEW8t>H};n!2xG{',
+      'sFz0Bo@_HfnK>LR}qWXV+D6`Y28=4Cm~G/7-5A\\b9!a#rP.l&M$hc3ijQk;),TvUd<[:I"u1\'NZSOw]*gxtE{eJp|y (?%',
+      'M@,D}|LJyGO8`$*ZqH .j>c~h<d=fimszv[#-53F!+a;NC\'6T91IV?(0x&/{B)w"]Q\\YUWprk4:ol%g2nE7teRKbAPuS_X',
+      '.mjY#_0*H<B=Q+FML6]s;r2:e8R}[ic&KA 1w{)vV5d,$u"~xD/Pg?IyfthO@CzWp%!`N4Z\'3-(o|J9XUE7k\\TlqSb>anG',
+      'xVa1\']_GU<X`|\\NgM?LS9{"jT%s$}y[nvtlefB2RKJW~(/cIDCPow4,>#zm+:5b@06O3Ap8=*7ZFY!H-uEQk; .q)i&rhd',
+      'I]Jz7AG@QX."%3Lq>METUo{Pp_ |a6<0dYVSv8:b)~W9NK`(r\'4fs&wim\\kReC2hg=HOj$1B*/nxt,;c#y+![?lFuZ-5D}',
+      'Rr(Ge6F Hx>q$m&C%M~Tn,:"o\'tX/*yP.{lZ!YkiVhuw_<KE5a[;}W0gjsz3]@7cI2\\QN?f#4p|vb1OUBD9)=-LJA+d`S8',
+      'I~k>y|m};d)-7DZ"Fe/Y<B:xwojR,Vh]O0Sc[`$sg8GXE!1&Qrzp._W%TNK(=J 3i*2abuHA4C\'?Mv\\Pq{n#56LftUl@9+',
+      '~A*>9 WidFN,1KsmwQ)GJM{I4:C%}#Ep(?HB/r;t.&U8o|l[\'Lg"2hRDyZ5`nbf]qjc0!zS-TkYO<_=76a\\X@$Pe3+xVvu',
+      'yYgjf"5VdHc#uA,W1i+v\'6|@pr{n;DJ!8(btPGaQM.LT3oe?NB/&9>Z`-}02*%x<7lsqz4OS ~E$\\R]KI[:UwC_=h)kXmF',
+      '5:iar.{YU7mBZR@-K|2 "+~`M%8sq4JhPo<_X\\Sg3WC;Tuxz,fvEQ1p9=w}FAI&j/keD0c?)LN6OHV]lGy\'$*>nd[(tb!#'
+    ].freeze
+
+    attr_reader :host, :port, :connected, :timeout
+
+    def initialize(host: nil, port: nil, timeout: nil)
+      @host = host || ENV.fetch("VISTA_RPC_HOST", "localhost")
+      @port = (port || ENV.fetch("VISTA_RPC_PORT", default_port.to_s)).to_i
+      @timeout = (timeout || ENV.fetch("VISTA_RPC_TIMEOUT", DEFAULT_TIMEOUT.to_s)).to_i
+      @socket = nil
+      @connected = false
+      @authenticated = false
+      @duz = nil
+    end
+
+    # -- subclass contract ----------------------------------------------------
+
+    def connect(_host, _port)
+      raise NotImplementedError, "#{self.class} must implement #connect"
+    end
+
+    def disconnect
+      raise NotImplementedError, "#{self.class} must implement #disconnect"
+    end
+
+    def call_rpc(_name, *_params)
+      raise NotImplementedError, "#{self.class} must implement #call_rpc"
+    end
+
+    def call_rpc_raw(_name, *_params)
+      raise NotImplementedError, "#{self.class} must implement #call_rpc_raw"
+    end
+
+    def read_response
+      raise NotImplementedError, "#{self.class} must implement #read_response"
+    end
+
+    # -- connection state -----------------------------------------------------
+
+    def connected?
+      return false unless @socket
+      return false if @socket.closed?
+      true
+    end
+
+    def hostname
+      @host
+    end
+
+    def authenticated?
+      @authenticated
+    end
+
+    def set_authenticated(duz)
+      @authenticated = true
+      @duz = duz
+    end
+
+    def duz
+      @duz
+    end
+
+    # -- VistA signon ---------------------------------------------------------
+
+    # Run XUS SIGNON SETUP (returns environment data array)
+    def signon_setup
+      raise ConnectionError, "Not connected" unless connected?
+
+      call_rpc("XUS SIGNON SETUP")
+    end
+
+    # Authenticate with VistA using Access/Verify codes.
+    # Returns { success: true, duz: } hash or raises AuthenticationError.
+    def authenticate(access_code = nil, verify_code = nil, **)
+      raise ConnectionError, "Not connected" unless connected?
+
+      ac = access_code || ENV.fetch("RPMS_ACCESS_CODE", "PROV123")
+      vc = verify_code || ENV.fetch("RPMS_VERIFY_CODE", "PROV123!!")
+
+      # Step 1: XUS SIGNON SETUP
+      signon_setup
+
+      # Step 2: XUS AV CODE with encrypted credentials
+      av_encrypted = xwb_encrypt("#{ac};#{vc}")
+      reply = call_rpc_raw("XUS AV CODE", av_encrypted)
+
+      lines = reply.split("\r\n")
+      lines = reply.split("\n") if lines.length <= 1
+      duz_str = lines[0]&.strip || "0"
+
+      if duz_str == "0" || duz_str.empty?
+        err_msg = lines[3]&.strip if lines.length > 3
+        raise AuthenticationError, (err_msg.nil? || err_msg.empty? ? "Authentication failed" : err_msg)
+      end
+
+      @authenticated = true
+      @duz = duz_str
+      { success: true, duz: duz_str.to_i }
+    end
+
+    # Set application context (required before calling most RPCs)
+    def create_context(option_name = "OR CPRS GUI CHART")
+      raise ConnectionError, "Not connected" unless connected?
+      raise AuthenticationError, "Not authenticated" unless authenticated?
+
+      encrypted = xwb_encrypt(option_name)
+      reply = call_rpc_raw("XWB CREATE CONTEXT", encrypted)
+
+      unless reply&.strip == "1"
+        raise RpcError, "Failed to create context '#{option_name}': #{reply}"
+      end
+
+      true
+    end
+
+    # XWB cipher encryption (matches $$ENCRYP^XUSRB1 in M)
+    def xwb_encrypt(plaintext)
+      ra = rand(0..19)
+      rb = rand(1..19)
+      rb = rand(1..19) while rb == ra
+      row_a = CIPHER_TABLE[ra]
+      row_b = CIPHER_TABLE[rb]
+      result = (ra + 32).chr
+      plaintext.each_char do |ch|
+        idx = row_a.index(ch)
+        result += idx.nil? ? ch : row_b[idx]
+      end
+      result += (rb + 32).chr
+      result
+    end
+
+    # -- encoding / parsing helpers -------------------------------------------
+
+    # Encode a single parameter using ParameterEncoder
+    def encode_param(param)
+      ParameterEncoder.encode(param)
+    end
+    alias_method :encode_parameter, :encode_param
+
+    # Parse RPC response using XmlResponseParser when XML, else pass through
+    def parse_rpc_response(response)
+      return [] if response.nil? || response.empty? || (response.is_a?(String) && response.strip.empty?)
+
+      if response.is_a?(String) && response.strip.start_with?("<")
+        begin
+          XmlResponseParser.parse(response)
+        rescue XmlResponseParser::ParseError => e
+          raise RpcError, "Failed to parse RPC response: #{e.message}"
+        rescue XmlResponseParser::RpcError => e
+          raise RpcError, e.message
+        end
+      else
+        response
+      end
+    end
+
+    # Read until EOT marker (compatibility alias)
+    def read_until_eot
+      read_response
+    end
+
+    # Get local IP address
+    def local_ip
+      Socket.ip_address_list.find { |ai| ai.ipv4? && !ai.ipv4_loopback? }&.ip_address || "127.0.0.1"
+    end
+
+    private
+
+    # Default port — overridden by subclasses
+    def default_port
+      9100
+    end
+
+    # Close socket and reset state
+    def reset_connection
+      @socket&.close
+      @socket = nil
+      @connected = false
+      @authenticated = false
+      @duz = nil
+    end
+
+    # Open a TCP socket to the broker
+    def open_socket(host, port)
+      @host = host
+      @port = port
+      @socket = TCPSocket.new(host, port)
+      @socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
+    rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, Errno::EHOSTUNREACH, Socket::ResolutionError => e
+      @connected = false
+      raise ConnectionError, "Failed to connect to #{host}:#{port} - #{e.message}"
+    end
+
+    # Send raw bytes to the broker
+    def send_packet(packet)
+      @socket.write(packet)
+      @socket.flush
+    rescue IOError => e
+      @connected = false
+      raise ConnectionError, "Connection lost - stream closed: #{e.message}"
+    rescue Errno::ECONNRESET
+      @connected = false
+      raise ConnectionError, "Connection lost - reset by server"
+    rescue Errno::EPIPE
+      @connected = false
+      raise ConnectionError, "Connection lost - broken pipe"
+    rescue Errno::ENOTCONN
+      @connected = false
+      raise ConnectionError, "Connection lost - socket not connected"
+    rescue SocketError => e
+      @connected = false
+      raise ConnectionError, "Connection lost - network error: #{e.message}"
+    end
+
+    # Read from socket until EOT (\x04), with timeout via IO.select
+    def read_until_eot_raw
+      return "" unless @socket
+
+      chunks = []
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + @timeout
+      loop do
+        remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        if remaining <= 0
+          @connected = false
+          raise TimeoutError, "RPC read timed out after #{@timeout}s"
+        end
+
+        if @socket.is_a?(BasicSocket) || @socket.is_a?(IO)
+          begin
+            unless IO.select([ @socket ], nil, nil, remaining)
+              @connected = false
+              raise TimeoutError, "RPC read timed out after #{@timeout}s"
+            end
+          rescue TypeError
+            # StringIO or other non-selectable IO in tests — skip select
+          end
+        end
+
+        chunk = @socket.recv(RECV_SIZE)
+        if chunk.nil? || chunk.empty?
+          raise ConnectionError, "Connection closed by server"
+        end
+        if chunk.include?(EOT)
+          idx = chunk.index(EOT)
+          chunks << chunk[0...idx]
+          break
+        end
+        chunks << chunk
+      end
+
+      chunks.join
+    rescue IO::TimeoutError => e
+      raise ConnectionError, "Connection timeout: #{e.message}"
+    rescue IOError => e
+      @connected = false
+      raise ConnectionError, "Connection lost - stream closed: #{e.message}"
+    rescue Errno::ECONNRESET
+      @connected = false
+      raise ConnectionError, "Connection lost - reset by server"
+    rescue Errno::EPIPE
+      @connected = false
+      raise ConnectionError, "Connection lost - broken pipe"
+    rescue Errno::ENOTCONN
+      @connected = false
+      raise ConnectionError, "Connection lost - socket not connected"
+    rescue SocketError => e
+      @connected = false
+      raise ConnectionError, "Connection lost - network error: #{e.message}"
+    end
+
+    # Check for M errors returned as data (not via SNDERR)
+    def check_for_rpc_error(response)
+      return if response.nil? || response.empty?
+
+      clean = response.strip.gsub(/\x00+$/, "")
+      if clean.match?(/\A(?:M  ERROR|E?Remote Procedure '.*' doesn't exist|E?Remote Procedure '.*' not found)/i)
+        raise RpcError, clean
+      end
+    end
+
+    # Split response string into array of lines (gateway convention)
+    def split_response(response)
+      response.chomp!("\r\n")
+      response.chomp!("\n")
+      if response.include?("\r\n")
+        response.split("\r\n", -1)
+      elsif response.include?("\n")
+        response.split("\n", -1)
+      else
+        response.empty? ? [] : [ response ]
+      end
+    end
+  end
+end

--- a/lib/rpms_rpc/client.rb
+++ b/lib/rpms_rpc/client.rb
@@ -90,7 +90,12 @@ module RpmsRpc
 
     # -- connection state -----------------------------------------------------
 
+    # True only when the handshake completed AND the socket is still open.
+    # Both the @connected flag (set after handshake / cleared on error) and
+    # the live socket state must agree, so error/timeout paths can't leave
+    # the object reporting connected with a half-dead socket.
     def connected?
+      return false unless @connected
       return false unless @socket
       return false if @socket.closed?
       true

--- a/lib/rpms_rpc/parameter_encoder.rb
+++ b/lib/rpms_rpc/parameter_encoder.rb
@@ -18,12 +18,12 @@ module RpmsRpc
 
     def self.encode(param)
       value = case param
-              when nil   then ""
-              when true  then "true"
-              when false then "false"
-              when Array then param.map(&:to_s).join("\n")
-              else param.to_s
-              end
+      when nil   then ""
+      when true  then "true"
+      when false then "false"
+      when Array then param.map(&:to_s).join("\n")
+      else param.to_s
+      end
 
       byte_size = value.bytesize
       if byte_size > MAX_PARAM_LENGTH

--- a/rpms-rpc.gemspec
+++ b/rpms-rpc.gemspec
@@ -5,8 +5,8 @@ require_relative "lib/rpms_rpc/version"
 Gem::Specification.new do |spec|
   spec.name        = "rpms-rpc"
   spec.version     = RpmsRpc::VERSION
-  spec.authors     = ["Lakeraven"]
-  spec.email       = ["eng@lakeraven.com"]
+  spec.authors     = [ "Lakeraven" ]
+  spec.email       = [ "eng@lakeraven.com" ]
   spec.homepage    = "https://github.com/lakeraven/rpms-rpc"
   spec.summary     = "Pure Ruby RPC client for VistA/RPMS (CIA/XWB and BMX protocols)"
   spec.description = "Pure Ruby gem providing wire-level access to VistA/RPMS RPC brokers " \

--- a/rpms-rpc.gemspec
+++ b/rpms-rpc.gemspec
@@ -26,5 +26,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     Dir["{lib,docs}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   end
-  # No runtime dependencies — pure stdlib (socket, openssl, rexml).
+  # rexml is a default gem in Ruby 3.4+ but must be declared so Bundler
+  # adds it to the load path. Otherwise pure stdlib (socket, openssl).
+  spec.add_dependency "rexml", "~> 3.2"
 end

--- a/test/rpms_rpc/bmx_client_test.rb
+++ b/test/rpms_rpc/bmx_client_test.rb
@@ -44,6 +44,21 @@ class RpmsRpc::BmxClientTest < Minitest::Test
     assert_includes msg, "00022;1XUS SIGNON SETUP"
   end
 
+  # -- byte-safety (multibyte / binary) --------------------------------------
+
+  def test_build_bmx_message_is_binary_encoded
+    msg = Client.new.build_bmx_message("ECHO^hello")
+    assert_equal Encoding::ASCII_8BIT, msg.encoding
+  end
+
+  def test_build_bmx_message_uses_bytesize_for_multibyte_input
+    # body = "ECHO^héllo" = 4 + 1 + 5(héllo, where é=2) = 11 bytes (not 10 chars)
+    msg = Client.new.build_bmx_message("ECHO^héllo")
+    assert msg.start_with?("015RPMS_RPC;0;0;0;^".b)
+    # body bytesize 11 + 6 = 17 → "00017;1"
+    assert_includes msg, "00017;1ECHO^héllo".b
+  end
+
   # -- subclass contract ------------------------------------------------------
 
   def test_call_rpc_raises_when_not_connected

--- a/test/rpms_rpc/bmx_client_test.rb
+++ b/test/rpms_rpc/bmx_client_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/bmx_client"
+
+class RpmsRpc::BmxClientTest < Minitest::Test
+  Client = RpmsRpc::BmxClient
+
+  def setup
+    @prev_port = ENV["VISTA_RPC_PORT"]
+    ENV.delete("VISTA_RPC_PORT")
+  end
+
+  def teardown
+    ENV["VISTA_RPC_PORT"] = @prev_port
+  end
+
+  def test_inherits_from_client
+    assert Client < RpmsRpc::Client
+  end
+
+  def test_default_port_is_9200
+    assert_equal 9200, Client.new.port
+  end
+
+  def test_bmx_prefix
+    assert_equal "{BMX}", Client::BMX_PREFIX
+  end
+
+  # -- build_bmx_message ------------------------------------------------------
+
+  def test_build_bmx_message_includes_proto_header_and_msg_header
+    msg = Client.new.build_bmx_message("ECHO^hello")
+    # Proto header: "015" + "RPMS_RPC;0;0;0;" (15 chars)
+    assert msg.start_with?("015RPMS_RPC;0;0;0;^")
+    # Message header: "%05d;1" where %05d = body.length + 6
+    # body = "ECHO^hello" (10 chars) → 10 + 6 = 16 → "00016;1"
+    assert_includes msg, "00016;1ECHO^hello"
+  end
+
+  def test_build_bmx_message_with_empty_params
+    msg = Client.new.build_bmx_message("XUS SIGNON SETUP")
+    # body = "XUS SIGNON SETUP" (16 chars) → 16 + 6 = 22 → "00022;1"
+    assert_includes msg, "00022;1XUS SIGNON SETUP"
+  end
+
+  # -- subclass contract ------------------------------------------------------
+
+  def test_call_rpc_raises_when_not_connected
+    assert_raises(RpmsRpc::Client::ConnectionError) { Client.new.call_rpc("XUS SIGNON SETUP") }
+  end
+
+  def test_call_rpc_raw_raises_when_not_connected
+    assert_raises(RpmsRpc::Client::ConnectionError) { Client.new.call_rpc_raw("XUS SIGNON SETUP") }
+  end
+end

--- a/test/rpms_rpc/cia_client_test.rb
+++ b/test/rpms_rpc/cia_client_test.rb
@@ -81,6 +81,62 @@ class RpmsRpc::CiaClientTest < Minitest::Test
     assert_equal({ type: :list, entries: { a: 1 } }, client.list_param(a: 1))
   end
 
+  # -- byte-safety (multibyte / binary) --------------------------------------
+
+  def test_spack_uses_bytesize_for_multibyte
+    # "é" is 2 bytes in UTF-8 → length prefix must be 2, not 1
+    result = Client.new.spack("é")
+    assert_equal Encoding::ASCII_8BIT, result.encoding
+    assert_equal 2, result.bytes[0]
+    assert_equal 3, result.bytesize # 1 byte length + 2 byte value
+  end
+
+  def test_spack_raises_when_value_exceeds_255_bytes
+    long = "x" * 256
+    assert_raises(Client::SpackTooLongError) { Client.new.spack(long) }
+  end
+
+  def test_spack_accepts_exactly_255_bytes
+    on_the_line = "x" * 255
+    result = Client.new.spack(on_the_line)
+    assert_equal 255, result.bytes[0]
+    assert_equal 256, result.bytesize
+  end
+
+  def test_lpack_uses_bytesize_for_multibyte
+    # "héllo" = 6 bytes in UTF-8 (h=1, é=2, l=1, l=1, o=1)
+    result = Client.new.lpack("héllo")
+    assert_equal Encoding::ASCII_8BIT, result.encoding
+    assert result.start_with?("006")
+    assert_equal 9, result.bytesize # "006" + 6 bytes
+  end
+
+  def test_lpack_uses_five_digit_width_at_byte_threshold
+    # 500 multibyte chars × 2 bytes = 1000 bytes → triggers 5-digit width
+    long = "é" * 500
+    result = Client.new.lpack(long)
+    assert result.start_with?("01000")
+    assert_equal 1005, result.bytesize
+  end
+
+  def test_build_rpc_message_is_binary_encoded
+    msg = Client.new.build_rpc_message("XUS SIGNON SETUP")
+    assert_equal Encoding::ASCII_8BIT, msg.encoding
+  end
+
+  def test_build_rpc_message_with_multibyte_param_uses_bytesize
+    client = Client.new
+    msg = client.build_rpc_message("ECHO", [ client.literal_param("héllo") ])
+    assert_equal Encoding::ASCII_8BIT, msg.encoding
+    # 6-byte body, 3-digit length width → "0006héllo" (in bytes)
+    assert_includes msg, "0006héllo".b
+  end
+
+  def test_build_connect_message_is_binary_encoded
+    msg = Client.new.build_connect_message("10.0.0.1", "myapp")
+    assert_equal Encoding::ASCII_8BIT, msg.encoding
+  end
+
   # -- subclass contract ------------------------------------------------------
 
   def test_call_rpc_raises_when_not_connected

--- a/test/rpms_rpc/cia_client_test.rb
+++ b/test/rpms_rpc/cia_client_test.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/cia_client"
+
+class RpmsRpc::CiaClientTest < Minitest::Test
+  Client = RpmsRpc::CiaClient
+  EOT = RpmsRpc::Client::EOT
+
+  def setup
+    @prev_port = ENV["VISTA_RPC_PORT"]
+    ENV.delete("VISTA_RPC_PORT")
+  end
+
+  def teardown
+    ENV["VISTA_RPC_PORT"] = @prev_port
+  end
+
+  def test_inherits_from_client
+    assert Client < RpmsRpc::Client
+  end
+
+  def test_default_port_is_9100
+    assert_equal 9100, Client.new.port
+  end
+
+  def test_xwb_prefix
+    assert_equal "[XWB]1130", Client::XWB_PREFIX
+  end
+
+  # -- spack / lpack ----------------------------------------------------------
+
+  def test_spack_prefixes_length_byte
+    assert_equal "\x05hello", Client.new.spack("hello")
+  end
+
+  def test_lpack_uses_three_digit_length_for_short
+    assert_equal "005hello", Client.new.lpack("hello")
+  end
+
+  def test_lpack_uses_five_digit_length_for_long
+    long = "x" * 1000
+    result = Client.new.lpack(long)
+    assert_equal "01000#{long}", result
+  end
+
+  # -- build_connect_message --------------------------------------------------
+
+  def test_build_connect_message_starts_with_xwb_prefix_and_command_token
+    msg = Client.new.build_connect_message("10.0.0.1", "myapp")
+    assert msg.start_with?("[XWB]11304") # prefix + token "4"
+    assert msg.end_with?(EOT)
+    assert_includes msg, "TCPConnect"
+    assert_includes msg, "10.0.0.1"
+    assert_includes msg, "myapp"
+  end
+
+  # -- build_rpc_message ------------------------------------------------------
+
+  def test_build_rpc_message_with_no_params
+    client = Client.new
+    msg = client.build_rpc_message("XUS SIGNON SETUP")
+    assert msg.start_with?("[XWB]11302\x011") # prefix + token "2\x011"
+    assert msg.end_with?("54f#{EOT}") # param_spec "5" + "4f" + EOT
+  end
+
+  def test_build_rpc_message_with_literal_params
+    client = Client.new
+    params = [ client.literal_param("hello"), client.literal_param("world") ]
+    msg = client.build_rpc_message("ECHO", params)
+    # spack("ECHO") = chr(4) + "ECHO" = "\x04ECHO" — note byte clash with EOT
+    assert_includes msg, "\x04ECHO"
+    assert_includes msg, "0005hellof"
+    assert_includes msg, "0005worldf"
+    assert msg.end_with?(EOT)
+  end
+
+  def test_literal_and_list_param_helpers
+    client = Client.new
+    assert_equal({ type: :literal, value: "x" }, client.literal_param("x"))
+    assert_equal({ type: :list, entries: { a: 1 } }, client.list_param(a: 1))
+  end
+
+  # -- subclass contract ------------------------------------------------------
+
+  def test_call_rpc_raises_when_not_connected
+    assert_raises(RpmsRpc::Client::ConnectionError) { Client.new.call_rpc("XUS SIGNON SETUP") }
+  end
+
+  def test_call_rpc_raw_raises_when_not_connected
+    assert_raises(RpmsRpc::Client::ConnectionError) { Client.new.call_rpc_raw("XUS SIGNON SETUP") }
+  end
+end

--- a/test/rpms_rpc/client_test.rb
+++ b/test/rpms_rpc/client_test.rb
@@ -82,6 +82,23 @@ class RpmsRpc::ClientTest < Minitest::Test
     assert_equal "123", client.duz
   end
 
+  def test_connected_predicate_requires_handshake_flag_not_just_socket
+    # A live socket alone is not enough — the handshake must have completed.
+    # This guards against the prior bug where error/timeout paths cleared
+    # @connected but connected? still returned true because the socket
+    # object existed.
+    client = Client.new
+    sock = StringIO.new
+    client.instance_variable_set(:@socket, sock)
+    refute client.connected?, "socket present but @connected=false → must report disconnected"
+
+    client.instance_variable_set(:@connected, true)
+    assert client.connected?
+
+    sock.close
+    refute client.connected?, "closed socket → must report disconnected"
+  end
+
   # -- xwb_encrypt ------------------------------------------------------------
 
   def test_xwb_encrypt_returns_string_with_index_chars

--- a/test/rpms_rpc/client_test.rb
+++ b/test/rpms_rpc/client_test.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/client"
+
+class RpmsRpc::ClientTest < Minitest::Test
+  Client = RpmsRpc::Client
+
+  def setup
+    @prev_host = ENV["VISTA_RPC_HOST"]
+    @prev_port = ENV["VISTA_RPC_PORT"]
+    @prev_timeout = ENV["VISTA_RPC_TIMEOUT"]
+    ENV.delete("VISTA_RPC_HOST")
+    ENV.delete("VISTA_RPC_PORT")
+    ENV.delete("VISTA_RPC_TIMEOUT")
+  end
+
+  def teardown
+    ENV["VISTA_RPC_HOST"] = @prev_host
+    ENV["VISTA_RPC_PORT"] = @prev_port
+    ENV["VISTA_RPC_TIMEOUT"] = @prev_timeout
+  end
+
+  # -- defaults ---------------------------------------------------------------
+
+  def test_defaults_to_localhost_and_default_port
+    client = Client.new
+    assert_equal "localhost", client.host
+    assert_equal 9100, client.port
+    assert_equal 30, client.timeout
+  end
+
+  def test_reads_host_port_timeout_from_env
+    ENV["VISTA_RPC_HOST"] = "vista.example.com"
+    ENV["VISTA_RPC_PORT"] = "9200"
+    ENV["VISTA_RPC_TIMEOUT"] = "60"
+    client = Client.new
+    assert_equal "vista.example.com", client.host
+    assert_equal 9200, client.port
+    assert_equal 60, client.timeout
+  end
+
+  def test_explicit_kwargs_override_env
+    ENV["VISTA_RPC_HOST"] = "env.example.com"
+    client = Client.new(host: "explicit.example.com", port: 5555, timeout: 10)
+    assert_equal "explicit.example.com", client.host
+    assert_equal 5555, client.port
+    assert_equal 10, client.timeout
+  end
+
+  # -- error class hierarchy --------------------------------------------------
+
+  def test_error_classes_defined
+    assert Client::ConnectionError < StandardError
+    assert Client::AuthenticationError < StandardError
+    assert Client::RpcError < StandardError
+    assert Client::TimeoutError < Client::ConnectionError
+  end
+
+  def test_eot_constant
+    assert_equal "\x04", Client::EOT
+  end
+
+  def test_cipher_table_has_twenty_rows
+    assert_equal 20, Client::CIPHER_TABLE.length
+    Client::CIPHER_TABLE.each { |row| assert_equal 94, row.length }
+  end
+
+  # -- connection state -------------------------------------------------------
+
+  def test_not_connected_by_default
+    client = Client.new
+    refute client.connected?
+    refute client.authenticated?
+    assert_nil client.duz
+  end
+
+  def test_set_authenticated_records_duz
+    client = Client.new
+    client.set_authenticated("123")
+    assert client.authenticated?
+    assert_equal "123", client.duz
+  end
+
+  # -- xwb_encrypt ------------------------------------------------------------
+
+  def test_xwb_encrypt_returns_string_with_index_chars
+    client = Client.new
+    encrypted = client.xwb_encrypt("HELLO")
+    # First and last bytes are row index + 32 (printable ASCII space..)
+    refute_equal "HELLO", encrypted
+    assert encrypted.length >= 7 # 1 + 5 + 1
+    first_idx = encrypted[0].ord - 32
+    last_idx = encrypted[-1].ord - 32
+    assert (0..19).include?(first_idx)
+    assert (1..19).include?(last_idx)
+    refute_equal first_idx, last_idx
+  end
+
+  def test_xwb_encrypt_passes_through_chars_not_in_row
+    client = Client.new
+    # Pick a character unlikely in row_a — but algorithm passes through
+    # any char not found. Just verify it returns a string of expected length.
+    encrypted = client.xwb_encrypt("a")
+    assert_equal 3, encrypted.length
+  end
+
+  # -- parse_rpc_response -----------------------------------------------------
+
+  def test_parse_rpc_response_returns_empty_for_nil
+    assert_equal [], Client.new.parse_rpc_response(nil)
+  end
+
+  def test_parse_rpc_response_returns_empty_for_blank_string
+    assert_equal [], Client.new.parse_rpc_response("   ")
+  end
+
+  def test_parse_rpc_response_passes_through_non_xml
+    assert_equal "raw value", Client.new.parse_rpc_response("raw value")
+  end
+
+  def test_parse_rpc_response_parses_xml_via_parser
+    xml = <<~XML
+      <vistalink type="Gov.VA.Med.RPC.Response">
+        <results type="string"><![CDATA[hello]]></results>
+      </vistalink>
+    XML
+    assert_equal "hello", Client.new.parse_rpc_response(xml)
+  end
+
+  # -- subclass contract ------------------------------------------------------
+
+  def test_call_rpc_must_be_implemented_by_subclass
+    client = Client.new
+    assert_raises(NotImplementedError) { client.call_rpc("XUS SIGNON SETUP") }
+  end
+
+  def test_connect_must_be_implemented_by_subclass
+    client = Client.new
+    assert_raises(NotImplementedError) { client.connect("localhost", 9100) }
+  end
+
+  # -- guards -----------------------------------------------------------------
+
+  def test_signon_setup_raises_when_not_connected
+    assert_raises(Client::ConnectionError) { Client.new.signon_setup }
+  end
+
+  def test_create_context_raises_when_not_connected
+    assert_raises(Client::ConnectionError) { Client.new.create_context }
+  end
+end


### PR DESCRIPTION
## Summary

- Ports `RpcClient` from `rpms_redux` as `RpmsRpc::Client` — the protocol-agnostic broker base (connection lifecycle, XUS signon auth, XWB cipher, socket helpers). Drops Singleton, drops ActiveSupport, delegates encoding/parsing to the gem's own modules per [ADR 0001](docs/adr/0001-scope-and-no-rails-coupling.md).
- Adds `RpmsRpc::CiaClient` (XWB protocol, port 9100, per FOIA-RPMS XWBTCPM.m) and `RpmsRpc::BmxClient` (BMX protocol, port 9200, per FOIA-RPMS BMXMON.m + BMXMBRK.m). Both subclass `RpmsRpc::Client` and route to the same M registry — only the wire framing differs.
- Wraps the bootstrap with README, CHANGELOG, `docs/rpcs.md` verified-RPC ledger (per [ADR 0002](docs/adr/0002-verified-routine-policy.md)), CI workflow, and rubocop-rails-omakase config.

With this PR, `rpms-rpc` is feature-complete for v0.1.0: every component from the original `rpms_redux/lib/` RPC layer has been ported and tested in isolation.

## Commits

1. **Port RpcClient abstract base class as RpmsRpc::Client** — 15 tests, declares `rexml ~> 3.2` runtime dep
2. **Port CIA (XWB) and BMX protocol clients** — 19 tests, wire-format byte construction verified hermetically
3. **Add README, CHANGELOG, verified-RPC ledger, CI, and rubocop config**

## Test plan

- [x] `bundle exec rake test` — 116 runs, 217 assertions, 0 failures
- [x] `bundle exec rubocop` — 21 files inspected, no offenses
- [x] Wire-format tests construct packet bytes and assert layout (no sockets, no live RPMS)
- [x] CIA `build_connect_message` / `build_rpc_message` round-trip
- [x] BMX `build_bmx_message` proto-header + msg-header math
- [x] Subclass contract guards (NotImplementedError, not-connected ConnectionError)
- [ ] CI passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)