### PR TITLE
DataMapper DSL for declarative RPC response parsing

### DIFF
--- a/lib/rpms_rpc/data_mapper.rb
+++ b/lib/rpms_rpc/data_mapper.rb
@@ -53,6 +53,26 @@ module RpmsRpc
         @fields << Field.new(position: position, attribute: attribute, type: type)
       end
 
+      # Declare a line-based field (one field per response line, not per caret).
+      # Used for RPCs like XUS AV CODE where each line has a distinct meaning.
+      def line_field(line_number, attribute, type = :string)
+        @line_fields ||= []
+        @line_fields << Field.new(position: line_number, attribute: attribute, type: type)
+      end
+
+      # Declare a scalar response (single value, no structure).
+      # Used for RPCs like ORWPT DIEDON that return one value.
+      def scalar(attribute, type = :string)
+        @scalar_attribute = attribute
+        @scalar_type = type
+      end
+
+      # Declare a text blob response (array of lines joined with newlines).
+      # Used for RPCs like ORWRP REPORT TEXT that return free text.
+      def text_blob(attribute)
+        @text_attribute = attribute
+      end
+
       # Parse a single-line RPC response into a hash.
       def parse_one(response, extras: {})
         line = normalize_line(response)
@@ -78,6 +98,38 @@ module RpmsRpc
           next if line.nil? || line.to_s.empty?
           parse_one(line)
         end
+      end
+
+      # Parse a line-based response where each LINE is a different field.
+      def parse_lines(response, extras: {})
+        return nil if response.nil? || response.empty?
+
+        result = {}
+        (@line_fields || []).each do |f|
+          raw = response[f.position]
+          result[f.attribute] = raw.nil? ? nil : coerce(raw.to_s, f.type)
+        end
+
+        extras.each { |k, v| result[k] = v }
+        result
+      end
+
+      # Parse a scalar response (single value).
+      def parse_scalar(response)
+        line = normalize_line(response)
+        return nil if line.nil? || line.empty?
+
+        coerce(line, @scalar_type || :string)
+      end
+
+      # Parse a text blob response (join lines with newlines).
+      def parse_text(response)
+        return nil if response.nil?
+        return nil if response.is_a?(Array) && response.empty?
+        return response if response.is_a?(String) && !response.empty?
+        return nil if response.is_a?(String) && response.empty?
+
+        response.join("\n")
       end
 
       private

--- a/lib/rpms_rpc/data_mapper.rb
+++ b/lib/rpms_rpc/data_mapper.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require_relative "fileman_date_parser"
+
+module RpmsRpc
+  # Declarative mapping from RPMS RPC caret-delimited responses to hashes.
+  #
+  # Define a mapping once:
+  #
+  #   RpmsRpc::DataMapper.define(:patient_select) do |m|
+  #     m.rpc "ORWPT SELECT"
+  #     m.field 0, :name
+  #     m.field 1, :sex
+  #     m.field 2, :dob, :fileman_date
+  #     m.field 3, :ssn
+  #     m.field 14, :age, :integer
+  #   end
+  #
+  # Parse a single-line response:
+  #
+  #   RpmsRpc::DataMapper[:patient_select].parse_one(response, extras: { dfn: 42 })
+  #   # => { name: "DOE,JOHN", sex: "M", dob: #<Date: 1980-01-15>, ssn: "111223333", age: 45, dfn: 42 }
+  #
+  # Parse a multi-line response (search results):
+  #
+  #   RpmsRpc::DataMapper[:patient_list].parse_many(response)
+  #   # => [{ dfn: 1, name: "DOE,JOHN" }, { dfn: 2, name: "SMITH,JANE" }]
+  #
+  module DataMapper
+    Field = Struct.new(:position, :attribute, :type, keyword_init: true)
+
+    class Mapping
+      attr_reader :name, :rpc_name, :fields
+
+      def initialize(name)
+        @name = name
+        @rpc_name = nil
+        @fields = []
+      end
+
+      # Configure this mapping using a block.
+      # Uses instance_exec so the block can call rpc/field directly.
+      # Safe: blocks are developer-defined at load time, not user input.
+      def configure(&block)
+        instance_exec(&block) # rubocop:disable Security/Eval
+      end
+
+      def rpc(name)
+        @rpc_name = name
+      end
+
+      def field(position, attribute, type = :string)
+        @fields << Field.new(position: position, attribute: attribute, type: type)
+      end
+
+      # Parse a single-line RPC response into a hash.
+      def parse_one(response, extras: {})
+        line = normalize_line(response)
+        return nil if line.nil? || line.empty?
+
+        parts = line.split("^", -1)
+        result = {}
+
+        @fields.each do |f|
+          raw = parts[f.position]
+          result[f.attribute] = coerce(raw, f.type)
+        end
+
+        extras.each { |k, v| result[k] = v }
+        result
+      end
+
+      # Parse a multi-line RPC response into an array of hashes.
+      def parse_many(response)
+        return [] if response.nil? || response.empty?
+
+        response.filter_map do |line|
+          next if line.nil? || line.to_s.empty?
+          parse_one(line)
+        end
+      end
+
+      private
+
+      def normalize_line(response)
+        return nil if response.nil?
+        return nil if response.is_a?(String) && response.empty?
+
+        if response.is_a?(Array)
+          return nil if response.empty?
+          return response.first.to_s
+        end
+
+        response.to_s
+      end
+
+      def coerce(raw, type)
+        return nil if raw.nil? || raw.empty?
+
+        case type
+        when :string
+          raw
+        when :integer
+          raw.to_i
+        when :fileman_date
+          FilemanDateParser.parse_date(raw)
+        when :boolean
+          raw == "1" || raw.casecmp?("yes")
+        else
+          raw
+        end
+      end
+    end
+
+    @registry = {}
+
+    def self.define(name, &block)
+      mapping = Mapping.new(name)
+      if block.arity == 1
+        block.call(mapping)
+      else
+        mapping.configure(&block)
+      end
+      @registry[name] = mapping
+      mapping
+    end
+
+    def self.[](name)
+      @registry.fetch(name)
+    end
+  end
+end

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -1,0 +1,402 @@
+# frozen_string_literal: true
+
+require_relative "data_mapper"
+
+# Built-in RPMS RPC response mappings.
+#
+# Each mapping declares the caret-delimited field positions for a specific
+# RPC response format. Gateways use these to parse responses into hashes
+# without hand-written split/index code.
+#
+# Mappings are registered in the DataMapper registry and looked up by name:
+#
+#   RpmsRpc::DataMapper[:patient_select].parse_one(response, extras: { dfn: 42 })
+#
+module RpmsRpc
+  module Mappings
+    # ========================================================================
+    # PATIENT (ORWPT*, BHDPTRPC*)
+    # ========================================================================
+
+    # ORWPT SELECT — core patient demographics
+    # Format: NAME^SEX^DOB^SSN^LOCIEN^LOCNM^RMBD^CWAD^SENSITIVE^ADMITTED^CONV^SC^SC%^ICN^AGE^TS
+    DataMapper.define(:patient_select) do |m|
+      m.rpc "ORWPT SELECT"
+      m.field 0,  :name
+      m.field 1,  :sex
+      m.field 2,  :dob,       :fileman_date
+      m.field 3,  :ssn
+      m.field 14, :age,       :integer
+    end
+
+    # ORWPT ID INFO — extended patient demographics
+    # Format: NAME^SEX^DOB^SSN^RACE^ADDRESS^CITY^STATE^ZIP^PHONE^TRIBAL_NUM^SERVICE_AREA^COVERAGE
+    DataMapper.define(:patient_id_info) do |m|
+      m.rpc "ORWPT ID INFO"
+      m.field 4,  :race
+      m.field 5,  :address_line1
+      m.field 6,  :city
+      m.field 7,  :state
+      m.field 8,  :zip_code
+      m.field 9,  :phone
+      m.field 10, :tribal_enrollment_number
+      m.field 11, :service_area
+      m.field 12, :coverage_type
+    end
+
+    # ORWPT LIST ALL — patient search results (multi-line)
+    # Format per line: DFN^NAME
+    DataMapper.define(:patient_list) do |m|
+      m.rpc "ORWPT LIST ALL"
+      m.field 0, :dfn, :integer
+      m.field 1, :name
+    end
+
+    # ORWPT FULLSSN — SSN lookup
+    # Format: DFN^NAME^DOB_TEXT^SSN
+    DataMapper.define(:patient_ssn) do |m|
+      m.rpc "ORWPT FULLSSN"
+      m.field 0, :dfn,  :integer
+      m.field 1, :name
+      m.field 3, :ssn
+    end
+
+    # ORWPT APPTLST — patient appointments (multi-line)
+    # Format: APPTTIME^LOCIEN^LOCNAME^EXTSTATUS
+    DataMapper.define(:patient_appointments) do |m|
+      m.rpc "ORWPT APPTLST"
+      m.field 0, :datetime,     :fileman_date
+      m.field 1, :location_ien, :integer
+      m.field 2, :location
+      m.field 3, :status
+    end
+
+    # ORQQAL LIST — patient allergies (multi-line)
+    # Format: ALLERGEN^REACTION^SEVERITY
+    DataMapper.define(:allergy_list) do |m|
+      m.rpc "ORQQAL LIST"
+      m.field 0, :allergen
+      m.field 1, :reaction
+      m.field 2, :severity
+    end
+
+    # ORQQPL LIST — patient problem list (multi-line)
+    # Format: IEN^STATUS^DESCRIPTION^ICD_CODE^ONSET_DATE^RECORDED_DATE^PROVIDER_DUZ
+    DataMapper.define(:problem_list) do |m|
+      m.rpc "ORQQPL LIST"
+      m.field 0, :ien
+      m.field 1, :status
+      m.field 2, :description
+      m.field 3, :icd_code
+      m.field 4, :onset_date,    :fileman_date
+      m.field 5, :recorded_date, :fileman_date
+      m.field 6, :provider_duz
+    end
+
+    # ORQQVI VITALS — patient vitals (multi-line)
+    # Format: TYPE^VALUE^UNITS^DATE
+    DataMapper.define(:vitals) do |m|
+      m.rpc "ORQQVI VITALS"
+      m.field 0, :type
+      m.field 1, :value
+      m.field 2, :units
+      m.field 3, :recorded_date, :fileman_date
+    end
+
+    # BHDPTRPC TRIBAL — tribal enrollment details
+    # Format: ENROLLMENT_NUMBER^TRIBE_NAME^ENROLLMENT_DATE^STATUS^SERVICE_UNIT^TRIBE_CODE
+    DataMapper.define(:tribal_enrollment) do |m|
+      m.rpc "BHDPTRPC TRIBAL"
+      m.field 0, :enrollment_number
+      m.field 1, :tribe_name
+      m.field 2, :enrollment_date, :fileman_date
+      m.field 3, :status
+      m.field 4, :service_unit
+      m.field 5, :tribe_code
+    end
+
+    # BHDPTRPC TRIBALVAL — tribal enrollment validation
+    # Format: VALID^TRIBE_CODE^ENROLLMENT_NUMBER^STATUS^MESSAGE
+    DataMapper.define(:tribal_validation) do |m|
+      m.rpc "BHDPTRPC TRIBALVAL"
+      m.field 0, :valid,             :boolean
+      m.field 1, :tribe_code
+      m.field 2, :enrollment_number
+      m.field 3, :status
+      m.field 4, :message
+    end
+
+    # BHDPTRPC TRIBELIST — tribe info lookup
+    # Format: IEN^NAME^CODE^SERVICE_UNIT^REGION^AREA
+    DataMapper.define(:tribe_info) do |m|
+      m.rpc "BHDPTRPC TRIBELIST"
+      m.field 0, :ien,          :integer
+      m.field 1, :name
+      m.field 2, :code
+      m.field 3, :service_unit
+      m.field 4, :region
+      m.field 5, :area
+    end
+
+    # BHDPTRPC TRIBALELG — enrollment eligibility
+    # Format: ACTIVE^ELIGIBLE_FOR_IHS^SERVICE_UNIT^MESSAGE^BENEFIT_PACKAGE
+    DataMapper.define(:enrollment_eligibility) do |m|
+      m.rpc "BHDPTRPC TRIBALELG"
+      m.field 0, :active,          :boolean
+      m.field 1, :eligible_for_ihs, :boolean
+      m.field 2, :service_unit
+      m.field 3, :message
+      m.field 4, :benefit_package
+    end
+
+    # BHDPTRPC SU — service unit lookup
+    # Format: SERVICE_UNIT_IEN^SERVICE_UNIT_NAME^REGION
+    DataMapper.define(:service_unit) do |m|
+      m.rpc "BHDPTRPC SU"
+      m.field 0, :ien,    :integer
+      m.field 1, :name
+      m.field 2, :region
+    end
+
+    # BHDPTRPC REGISTER — patient registration result
+    # Format: "1^DFN" (success) or "0^error_message" (failure)
+    DataMapper.define(:patient_register) do |m|
+      m.rpc "BHDPTRPC REGISTER"
+      m.field 0, :success, :boolean
+      m.field 1, :dfn_or_error
+    end
+
+    # BHDPTRPC UPDATE — patient update result
+    # Format: "1^" (success) or "0^error_message" (failure)
+    DataMapper.define(:patient_update) do |m|
+      m.rpc "BHDPTRPC UPDATE"
+      m.field 0, :success, :boolean
+      m.field 1, :error
+    end
+
+    # BHDPTRPC NEWVISIT — encounter creation result
+    # Format: "1^VISIT_IEN" (success) or "0^error_message" (failure)
+    DataMapper.define(:encounter_create) do |m|
+      m.rpc "BHDPTRPC NEWVISIT"
+      m.field 0, :success,   :boolean
+      m.field 1, :visit_ien_or_error
+    end
+
+    # ========================================================================
+    # PRACTITIONER (ORWU*)
+    # ========================================================================
+
+    # ORWU USERINFO — practitioner demographics
+    # Format: NAME^TITLE^SERVICE_SECTION^SPECIALTY^NPI^DEA^PHONE^PROVIDER_CLASS^SERVICE
+    DataMapper.define(:practitioner_info) do |m|
+      m.rpc "ORWU USERINFO"
+      m.field 0, :name
+      m.field 1, :title
+      m.field 2, :service_section
+      m.field 3, :specialty
+      m.field 4, :npi
+      m.field 5, :dea_number
+      m.field 6, :phone
+      m.field 7, :provider_class
+    end
+
+    # ORWU NEWPERS — practitioner search results (multi-line)
+    # Format per line: IEN^NAME^TITLE
+    DataMapper.define(:practitioner_list) do |m|
+      m.rpc "ORWU NEWPERS"
+      m.field 0, :ien, :integer
+      m.field 1, :name
+      m.field 2, :title
+    end
+
+    # ========================================================================
+    # CLINICAL DATA (ORQQPS*, ORQQCP*, ORQQCT*, ORQQGO*, ORWPCE*)
+    # ========================================================================
+
+    # ORQQPS LIST — medication list (multi-line)
+    # Format: IEN^DRUG_NAME^SIG^STATUS^LAST_FILL^REFILLS^PROVIDER
+    DataMapper.define(:medication_list) do |m|
+      m.rpc "ORQQPS LIST"
+      m.field 0, :ien
+      m.field 1, :drug_name
+      m.field 2, :sig
+      m.field 3, :status
+      m.field 4, :last_fill,   :fileman_date
+      m.field 5, :refills,     :integer
+      m.field 6, :provider
+    end
+
+    # ORQQCP LIST — care plan list (multi-line)
+    # Format: IEN^TITLE^STATUS^START_DATE^AUTHOR
+    DataMapper.define(:care_plan_list) do |m|
+      m.rpc "ORQQCP LIST"
+      m.field 0, :ien
+      m.field 1, :title
+      m.field 2, :status
+      m.field 3, :start_date, :fileman_date
+      m.field 4, :author
+    end
+
+    # ORQQCT LIST — care team list (multi-line)
+    # Format: IEN^NAME^ROLE^START_DATE
+    DataMapper.define(:care_team_list) do |m|
+      m.rpc "ORQQCT LIST"
+      m.field 0, :ien
+      m.field 1, :name
+      m.field 2, :role
+      m.field 3, :start_date, :fileman_date
+    end
+
+    # ORQQGO LIST — goal list (multi-line)
+    # Format: IEN^DESCRIPTION^STATUS^TARGET_DATE
+    DataMapper.define(:goal_list) do |m|
+      m.rpc "ORQQGO LIST"
+      m.field 0, :ien
+      m.field 1, :description
+      m.field 2, :status
+      m.field 3, :target_date, :fileman_date
+    end
+
+    # ORWPCE PROCEDURE LIST — procedure list (multi-line)
+    # Format: IEN^NAME^DATE^PROVIDER^STATUS
+    DataMapper.define(:procedure_list) do |m|
+      m.rpc "ORWPCE PROCEDURE LIST"
+      m.field 0, :ien
+      m.field 1, :name
+      m.field 2, :date,     :fileman_date
+      m.field 3, :provider
+      m.field 4, :status
+    end
+
+    # ORWPCE IMPLANT LIST — implanted device list (multi-line)
+    # Format: IEN^DEVICE_NAME^IMPLANT_DATE^STATUS^UDI
+    DataMapper.define(:device_list) do |m|
+      m.rpc "ORWPCE IMPLANT LIST"
+      m.field 0, :ien
+      m.field 1, :device_name
+      m.field 2, :implant_date, :fileman_date
+      m.field 3, :status
+      m.field 4, :udi
+    end
+
+    # ========================================================================
+    # LAB & RADIOLOGY (ORWLRR*, ORWRA*)
+    # ========================================================================
+
+    # ORWLRR RESULT LIST — lab result list (multi-line)
+    # Format: IEN^TEST_NAME^RESULT^UNITS^REF_RANGE^FLAG^DATE
+    DataMapper.define(:lab_result_list) do |m|
+      m.rpc "ORWLRR RESULT LIST"
+      m.field 0, :ien
+      m.field 1, :test_name
+      m.field 2, :result
+      m.field 3, :units
+      m.field 4, :ref_range
+      m.field 5, :flag
+      m.field 6, :date, :fileman_date
+    end
+
+    # ORWRA REPORT LIST — radiology report list (multi-line)
+    # Format: IEN^EXAM_NAME^DATE^STATUS^IMPRESSION
+    DataMapper.define(:radiology_list) do |m|
+      m.rpc "ORWRA REPORT LIST"
+      m.field 0, :ien
+      m.field 1, :exam_name
+      m.field 2, :date,   :fileman_date
+      m.field 3, :status
+      m.field 4, :impression
+    end
+
+    # ========================================================================
+    # LOCATION & ORGANIZATION (BHDO*)
+    # ========================================================================
+
+    # BHDO HOSP LOC DATA — hospital location
+    # Format: IEN^NAME^ABBREVIATION^TYPE^DIVISION
+    DataMapper.define(:hospital_location) do |m|
+      m.rpc "BHDO HOSP LOC DATA"
+      m.field 0, :ien, :integer
+      m.field 1, :name
+      m.field 2, :abbreviation
+      m.field 3, :type
+      m.field 4, :division
+    end
+
+    # BHDO INST DATA — institution data
+    # Format: IEN^NAME^STATION_NUMBER^ADDRESS^CITY^STATE^ZIP^PHONE
+    DataMapper.define(:institution) do |m|
+      m.rpc "BHDO INST DATA"
+      m.field 0, :ien, :integer
+      m.field 1, :name
+      m.field 2, :station_number
+      m.field 3, :address
+      m.field 4, :city
+      m.field 5, :state
+      m.field 6, :zip_code
+      m.field 7, :phone
+    end
+
+    # ========================================================================
+    # SERVICE REQUESTS / REFERRALS (BMCRPC*)
+    # ========================================================================
+
+    # BMCRPC SRCHREF — referral search (multi-line)
+    # Format: IEN^PATIENT_DFN^STATUS^TYPE^DATE^PROVIDER
+    DataMapper.define(:referral_search) do |m|
+      m.rpc "BMCRPC SRCHREF"
+      m.field 0, :ien
+      m.field 1, :patient_dfn, :integer
+      m.field 2, :status
+      m.field 3, :type
+      m.field 4, :date,     :fileman_date
+      m.field 5, :provider
+    end
+
+    # BMCRPC GTSITPRM — RCIS site parameters
+    DataMapper.define(:site_params) do |m|
+      m.rpc "BMCRPC GTSITPRM"
+      m.field 0, :site_name
+      m.field 1, :station_number
+      m.field 2, :service_area
+    end
+
+    # ========================================================================
+    # AUTHENTICATION (XUS*)
+    # ========================================================================
+
+    # XUS GET USER INFO — authenticated user info
+    # Format: DUZ^NAME^USERCL^CANSIGN^ISPROVIDER^ORDERROLE
+    DataMapper.define(:user_info) do |m|
+      m.rpc "XUS GET USER INFO"
+      m.field 0, :duz, :integer
+      m.field 1, :name
+      m.field 2, :user_class
+      m.field 3, :can_sign,    :boolean
+      m.field 4, :is_provider, :boolean
+      m.field 5, :order_role
+    end
+
+    # ========================================================================
+    # HEALTH SUMMARY & REMINDERS (ORWRP*, GMTS*, ORQQPX*)
+    # ========================================================================
+
+    # ORWRP TYPES — report type list (multi-line)
+    # Format: IEN^NAME
+    DataMapper.define(:report_types) do |m|
+      m.rpc "ORWRP TYPES"
+      m.field 0, :ien, :integer
+      m.field 1, :name
+    end
+
+    # ORQQPX REMINDERS LIST — clinical reminders (multi-line)
+    # Format: IEN^NAME^DUE_DATE^STATUS^LAST_DONE
+    DataMapper.define(:reminders_list) do |m|
+      m.rpc "ORQQPX REMINDERS LIST"
+      m.field 0, :ien
+      m.field 1, :name
+      m.field 2, :due_date,  :fileman_date
+      m.field 3, :status
+      m.field 4, :last_done, :fileman_date
+    end
+  end
+end

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -398,5 +398,370 @@ module RpmsRpc
       m.field 3, :status
       m.field 4, :last_done, :fileman_date
     end
+
+    # ORQQPX REMINDER DETAIL — single reminder detail (text blob)
+    DataMapper.define(:reminder_detail) do |m|
+      m.rpc "ORQQPX REMINDER DETAIL"
+      m.text_blob :detail_text
+    end
+
+    # ========================================================================
+    # SCALAR / BOOLEAN RPCs
+    # ========================================================================
+
+    # ORWPT DIEDON — deceased check (FileMan date or "0")
+    DataMapper.define(:patient_deceased) do |m|
+      m.rpc "ORWPT DIEDON"
+      m.scalar :deceased_date, :fileman_date
+    end
+
+    # ORWPT SELCHK — sensitive record check ("1" if sensitive)
+    DataMapper.define(:patient_sensitive) do |m|
+      m.rpc "ORWPT SELCHK"
+      m.scalar :sensitive, :boolean
+    end
+
+    # ORWU HASKEY — security key check
+    DataMapper.define(:user_has_key) do |m|
+      m.rpc "ORWU HASKEY"
+      m.scalar :has_key, :boolean
+    end
+
+    # ========================================================================
+    # LINE-BASED RESPONSES
+    # ========================================================================
+
+    # XUS SIGNON SETUP — signon setup (returns "OK" or error)
+    DataMapper.define(:signon_setup) do |m|
+      m.rpc "XUS SIGNON SETUP"
+      m.scalar :status, :string
+    end
+
+    # XUS AV CODE — authentication result (line-based)
+    # Line 0: DUZ (or 0 for failure)
+    # Line 1: 0
+    # Line 2: 0
+    # Line 3: greeting message
+    # Line 4: (blank)
+    # Line 5: number of tries remaining
+    DataMapper.define(:av_code) do |m|
+      m.rpc "XUS AV CODE"
+      m.line_field 0, :duz, :integer
+      m.line_field 3, :greeting
+      m.line_field 5, :tries, :integer
+    end
+
+    # XUS CVC — CVC verification
+    DataMapper.define(:cvc_verify) do |m|
+      m.rpc "XUS CVC"
+      m.scalar :verified, :boolean
+    end
+
+    # ORWU USERKEYS — user security keys (multi-line, one key per line)
+    DataMapper.define(:user_keys) do |m|
+      m.rpc "ORWU USERKEYS"
+      m.field 0, :key_name
+    end
+
+    # ========================================================================
+    # TEXT BLOB RESPONSES (free text reports)
+    # ========================================================================
+
+    # ORWRP REPORT TEXT — health summary report text
+    DataMapper.define(:report_text) do |m|
+      m.rpc "ORWRP REPORT TEXT"
+      m.text_blob :report_text
+    end
+
+    # ORWRP TYPE COMPONENTS — report type component list
+    DataMapper.define(:report_type_components) do |m|
+      m.rpc "ORWRP TYPE COMPONENTS"
+      m.field 0, :ien, :integer
+      m.field 1, :name
+    end
+
+    # GMTS PWH REPORT — patient health summary report text
+    DataMapper.define(:health_summary_report) do |m|
+      m.rpc "GMTS PWH REPORT"
+      m.text_blob :report_text
+    end
+
+    # GMTS FLOWSHEET LIST — flowsheet items (multi-line)
+    DataMapper.define(:flowsheet_list) do |m|
+      m.rpc "GMTS FLOWSHEET LIST"
+      m.field 0, :ien
+      m.field 1, :name
+      m.field 2, :date, :fileman_date
+    end
+
+    # GMTS MAINT ITEMS — maintenance items (multi-line)
+    DataMapper.define(:maint_items) do |m|
+      m.rpc "GMTS MAINT ITEMS"
+      m.field 0, :ien
+      m.field 1, :name
+    end
+
+    # ORWLRR REPORT — full lab report text
+    DataMapper.define(:lab_report) do |m|
+      m.rpc "ORWLRR REPORT"
+      m.text_blob :report_text
+    end
+
+    # ORWLRR REPORT LIST — lab report list (multi-line)
+    DataMapper.define(:lab_report_list) do |m|
+      m.rpc "ORWLRR REPORT LIST"
+      m.field 0, :ien
+      m.field 1, :name
+      m.field 2, :date, :fileman_date
+    end
+
+    # ORWRA REPORT — full radiology report text
+    DataMapper.define(:radiology_report) do |m|
+      m.rpc "ORWRA REPORT"
+      m.text_blob :report_text
+    end
+
+    # ========================================================================
+    # CLINICAL DETAIL (single-record GET RPCs)
+    # ========================================================================
+
+    # ORQQPS DETAIL — medication detail (text blob)
+    DataMapper.define(:medication_detail) do |m|
+      m.rpc "ORQQPS DETAIL"
+      m.text_blob :detail_text
+    end
+
+    # ORQQCP GET — single care plan
+    DataMapper.define(:care_plan_detail) do |m|
+      m.rpc "ORQQCP GET"
+      m.field 0, :ien
+      m.field 1, :title
+      m.field 2, :status
+      m.field 3, :start_date, :fileman_date
+      m.field 4, :author
+      m.field 5, :description
+    end
+
+    # ORQQCT GET — single care team member
+    DataMapper.define(:care_team_detail) do |m|
+      m.rpc "ORQQCT GET"
+      m.field 0, :ien
+      m.field 1, :name
+      m.field 2, :role
+      m.field 3, :start_date, :fileman_date
+      m.field 4, :phone
+    end
+
+    # ORQQGO GET — single goal
+    DataMapper.define(:goal_detail) do |m|
+      m.rpc "ORQQGO GET"
+      m.field 0, :ien
+      m.field 1, :description
+      m.field 2, :status
+      m.field 3, :target_date, :fileman_date
+      m.field 4, :author
+    end
+
+    # ORWPCE PROCEDURE GET — single procedure
+    DataMapper.define(:procedure_detail) do |m|
+      m.rpc "ORWPCE PROCEDURE GET"
+      m.field 0, :ien
+      m.field 1, :name
+      m.field 2, :date,     :fileman_date
+      m.field 3, :provider
+      m.field 4, :status
+      m.field 5, :cpt_code
+    end
+
+    # ORWPCE IMPLANT GET — single implanted device
+    DataMapper.define(:device_detail) do |m|
+      m.rpc "ORWPCE IMPLANT GET"
+      m.field 0, :ien
+      m.field 1, :device_name
+      m.field 2, :implant_date, :fileman_date
+      m.field 3, :status
+      m.field 4, :udi
+      m.field 5, :manufacturer
+    end
+
+    # ========================================================================
+    # REFERRAL DETAIL & WRITE RPCs (BMCRPC*)
+    # ========================================================================
+
+    # BMCRPC GTRFBYID — single referral detail
+    DataMapper.define(:referral_detail) do |m|
+      m.rpc "BMCRPC GTRFBYID"
+      m.field 0, :ien
+      m.field 1, :patient_dfn, :integer
+      m.field 2, :status
+      m.field 3, :type
+      m.field 4, :date,     :fileman_date
+      m.field 5, :provider
+      m.field 6, :facility
+      m.field 7, :notes
+    end
+
+    # BMCRPC DELREFRL — referral deletion result
+    DataMapper.define(:referral_delete) do |m|
+      m.rpc "BMCRPC DELREFRL"
+      m.field 0, :success, :boolean
+      m.field 1, :message
+    end
+
+    # ========================================================================
+    # PATIENT RECENT LIST & AGG EDITING (ORWPT*, BEHOENCX*)
+    # ========================================================================
+
+    # ORWPT LIST RECENT — recent patients (multi-line)
+    # Format: DFN^NAME^LAST_ACCESSED
+    DataMapper.define(:patient_recent) do |m|
+      m.rpc "ORWPT LIST RECENT"
+      m.field 0, :dfn, :integer
+      m.field 1, :name
+      m.field 2, :last_accessed
+    end
+
+    # ORWPT SAVE RECENT — write-only (success/failure)
+    DataMapper.define(:patient_save_recent) do |m|
+      m.rpc "ORWPT SAVE RECENT"
+      m.scalar :success, :boolean
+    end
+
+    # BEHOENCX GET SECTION — section data (text blob, parsed by caller)
+    DataMapper.define(:section_data) do |m|
+      m.rpc "BEHOENCX GET SECTION"
+      m.text_blob :section_text
+    end
+
+    # BEHOENCX SAVE SECTION — write result
+    DataMapper.define(:section_save) do |m|
+      m.rpc "BEHOENCX SAVE SECTION"
+      m.scalar :success, :boolean
+    end
+
+    # BEHOENCX GET SECDEF — section definition (text blob, parsed by caller)
+    DataMapper.define(:section_definition) do |m|
+      m.rpc "BEHOENCX GET SECDEF"
+      m.text_blob :definition_text
+    end
+
+    # BEHOENCX LOCK — patient lock result
+    DataMapper.define(:patient_lock) do |m|
+      m.rpc "BEHOENCX LOCK"
+      m.field 0, :success, :boolean
+      m.field 1, :lock_id
+      m.field 2, :message
+    end
+
+    # BEHOENCX UNLOCK — patient unlock (boolean)
+    DataMapper.define(:patient_unlock) do |m|
+      m.rpc "BEHOENCX UNLOCK"
+      m.scalar :success, :boolean
+    end
+
+    # ========================================================================
+    # SECURITY KEY MANAGEMENT (XU KEY*)
+    # ========================================================================
+
+    # XU KEY LIST — key list (multi-line)
+    DataMapper.define(:key_list) do |m|
+      m.rpc "XU KEY LIST"
+      m.field 0, :key_name
+      m.field 1, :key_ien, :integer
+    end
+
+    # XU KEY GRANT — grant result
+    DataMapper.define(:key_grant) do |m|
+      m.rpc "XU KEY GRANT"
+      m.field 0, :success, :boolean
+      m.field 1, :message
+    end
+
+    # XU KEY REVOKE — revoke result
+    DataMapper.define(:key_revoke) do |m|
+      m.rpc "XU KEY REVOKE"
+      m.field 0, :success, :boolean
+      m.field 1, :message
+    end
+
+    # ========================================================================
+    # PHARMACY / E-PRESCRIBING (PSO*)
+    # ========================================================================
+
+    # PSO NEW RX — new prescription result
+    DataMapper.define(:prescription_new) do |m|
+      m.rpc "PSO NEW RX"
+      m.field 0, :success, :boolean
+      m.field 1, :rx_ien_or_error
+    end
+
+    # PSO ERX STATUS — e-prescribe status
+    DataMapper.define(:erx_status) do |m|
+      m.rpc "PSO ERX STATUS"
+      m.field 0, :status
+      m.field 1, :message
+    end
+
+    # PSO CANCEL RX — cancellation result
+    DataMapper.define(:prescription_cancel) do |m|
+      m.rpc "PSO CANCEL RX"
+      m.field 0, :success, :boolean
+      m.field 1, :message
+    end
+
+    # ========================================================================
+    # PHR / CCD (BEHOCCD*, BPHR*, BEHOCIR*)
+    # ========================================================================
+
+    # BEHOCCD PHR — CCD document (text blob)
+    DataMapper.define(:ccd_document) do |m|
+      m.rpc "BEHOCCD PHR"
+      m.text_blob :ccd_xml
+    end
+
+    # BEHOCCD GETREF — referral CCD (text blob)
+    DataMapper.define(:ccd_referral) do |m|
+      m.rpc "BEHOCCD GETREF"
+      m.text_blob :ccd_xml
+    end
+
+    # BEHOCIR GETTXT — immunization text
+    DataMapper.define(:immunization_text) do |m|
+      m.rpc "BEHOCIR GETTXT"
+      m.text_blob :immunization_text
+    end
+
+    # BEHOCIR GETNUM — immunization count
+    DataMapper.define(:immunization_count) do |m|
+      m.rpc "BEHOCIR GETNUM"
+      m.scalar :count, :integer
+    end
+
+    # BPHR RECORD ACCESS — PHR access check
+    DataMapper.define(:phr_access) do |m|
+      m.rpc "BPHR RECORD ACCESS"
+      m.scalar :has_access, :boolean
+    end
+
+    # BPHR PATIENT DIRECT — patient direct messaging
+    DataMapper.define(:phr_patient_direct) do |m|
+      m.rpc "BPHR PATIENT DIRECT"
+      m.field 0, :direct_address
+      m.field 1, :status
+    end
+
+    # BPHR PROVIDER DIRECT — provider direct messaging
+    DataMapper.define(:phr_provider_direct) do |m|
+      m.rpc "BPHR PROVIDER DIRECT"
+      m.field 0, :direct_address
+      m.field 1, :status
+    end
+
+    # BPHR FACILITY DIRECT — facility direct messaging
+    DataMapper.define(:phr_facility_direct) do |m|
+      m.rpc "BPHR FACILITY DIRECT"
+      m.field 0, :direct_address
+      m.field 1, :status
+    end
   end
 end

--- a/test/rpms_rpc/data_mapper_extensions_test.rb
+++ b/test/rpms_rpc/data_mapper_extensions_test.rb
@@ -14,7 +14,7 @@ class RpmsRpc::DataMapperExtensionsTest < Minitest::Test
       m.line_field 5, :tries, :integer
     end
 
-    lines = ["101", "0", "0", "Welcome", "", "3"]
+    lines = [ "101", "0", "0", "Welcome", "", "3" ]
     result = mapping.parse_lines(lines)
 
     assert_equal 101, result[:duz]
@@ -28,7 +28,7 @@ class RpmsRpc::DataMapperExtensionsTest < Minitest::Test
       m.line_field 5, :missing
     end
 
-    result = mapping.parse_lines(["hello"])
+    result = mapping.parse_lines([ "hello" ])
     assert_equal "hello", result[:value]
     assert_nil result[:missing]
   end
@@ -39,7 +39,7 @@ class RpmsRpc::DataMapperExtensionsTest < Minitest::Test
       m.line_field 0, :name
     end
 
-    result = mapping.parse_lines(["DOE,JOHN"], extras: { source: "rpc" })
+    result = mapping.parse_lines([ "DOE,JOHN" ], extras: { source: "rpc" })
     assert_equal "DOE,JOHN", result[:name]
     assert_equal "rpc", result[:source]
   end
@@ -90,7 +90,7 @@ class RpmsRpc::DataMapperExtensionsTest < Minitest::Test
       m.scalar :active, :boolean
     end
 
-    assert_equal true, mapping.parse_scalar(["1", "extra"])
+    assert_equal true, mapping.parse_scalar([ "1", "extra" ])
   end
 
   def test_parse_scalar_returns_nil_for_empty
@@ -112,7 +112,7 @@ class RpmsRpc::DataMapperExtensionsTest < Minitest::Test
       m.text_blob :report_text
     end
 
-    lines = ["Patient: DOE,JOHN", "Date: 2025-03-15", "", "Report content here."]
+    lines = [ "Patient: DOE,JOHN", "Date: 2025-03-15", "", "Report content here." ]
     result = mapping.parse_text(lines)
 
     assert_equal "Patient: DOE,JOHN\nDate: 2025-03-15\n\nReport content here.", result

--- a/test/rpms_rpc/data_mapper_extensions_test.rb
+++ b/test/rpms_rpc/data_mapper_extensions_test.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "date"
+require "rpms_rpc/data_mapper"
+
+class RpmsRpc::DataMapperExtensionsTest < Minitest::Test
+  # -- Line-based responses (one field per line, not per caret) ---------------
+
+  def test_line_field_maps_by_line_number
+    mapping = RpmsRpc::DataMapper.define(:line_test) do |m|
+      m.rpc "XUS AV CODE"
+      m.line_field 0, :duz, :integer
+      m.line_field 5, :tries, :integer
+    end
+
+    lines = ["101", "0", "0", "Welcome", "", "3"]
+    result = mapping.parse_lines(lines)
+
+    assert_equal 101, result[:duz]
+    assert_equal 3, result[:tries]
+  end
+
+  def test_line_field_returns_nil_for_missing_lines
+    mapping = RpmsRpc::DataMapper.define(:line_short_test) do |m|
+      m.rpc "TEST"
+      m.line_field 0, :value
+      m.line_field 5, :missing
+    end
+
+    result = mapping.parse_lines(["hello"])
+    assert_equal "hello", result[:value]
+    assert_nil result[:missing]
+  end
+
+  def test_line_field_with_extras
+    mapping = RpmsRpc::DataMapper.define(:line_extras_test) do |m|
+      m.rpc "TEST"
+      m.line_field 0, :name
+    end
+
+    result = mapping.parse_lines(["DOE,JOHN"], extras: { source: "rpc" })
+    assert_equal "DOE,JOHN", result[:name]
+    assert_equal "rpc", result[:source]
+  end
+
+  def test_parse_lines_returns_nil_for_empty
+    mapping = RpmsRpc::DataMapper.define(:line_empty_test) do |m|
+      m.rpc "TEST"
+      m.line_field 0, :value
+    end
+
+    assert_nil mapping.parse_lines(nil)
+    assert_nil mapping.parse_lines([])
+  end
+
+  # -- Scalar responses (single value, no caret) -----------------------------
+
+  def test_parse_scalar_returns_typed_value
+    mapping = RpmsRpc::DataMapper.define(:scalar_bool_test) do |m|
+      m.rpc "ORWPT SELCHK"
+      m.scalar :sensitive, :boolean
+    end
+
+    assert_equal true, mapping.parse_scalar("1")
+    assert_equal false, mapping.parse_scalar("0")
+  end
+
+  def test_parse_scalar_fileman_date
+    mapping = RpmsRpc::DataMapper.define(:scalar_date_test) do |m|
+      m.rpc "ORWPT DIEDON"
+      m.scalar :deceased_date, :fileman_date
+    end
+
+    assert_equal Date.new(2025, 3, 15), mapping.parse_scalar("3250315")
+  end
+
+  def test_parse_scalar_string
+    mapping = RpmsRpc::DataMapper.define(:scalar_str_test) do |m|
+      m.rpc "TEST"
+      m.scalar :status, :string
+    end
+
+    assert_equal "OK", mapping.parse_scalar("OK")
+  end
+
+  def test_parse_scalar_handles_array_response
+    mapping = RpmsRpc::DataMapper.define(:scalar_array_test) do |m|
+      m.rpc "TEST"
+      m.scalar :active, :boolean
+    end
+
+    assert_equal true, mapping.parse_scalar(["1", "extra"])
+  end
+
+  def test_parse_scalar_returns_nil_for_empty
+    mapping = RpmsRpc::DataMapper.define(:scalar_nil_test) do |m|
+      m.rpc "TEST"
+      m.scalar :value, :string
+    end
+
+    assert_nil mapping.parse_scalar("")
+    assert_nil mapping.parse_scalar(nil)
+    assert_nil mapping.parse_scalar([])
+  end
+
+  # -- Text blob responses (array of lines joined) ---------------------------
+
+  def test_parse_text_joins_lines
+    mapping = RpmsRpc::DataMapper.define(:text_test) do |m|
+      m.rpc "ORWRP REPORT TEXT"
+      m.text_blob :report_text
+    end
+
+    lines = ["Patient: DOE,JOHN", "Date: 2025-03-15", "", "Report content here."]
+    result = mapping.parse_text(lines)
+
+    assert_equal "Patient: DOE,JOHN\nDate: 2025-03-15\n\nReport content here.", result
+  end
+
+  def test_parse_text_returns_nil_for_empty
+    mapping = RpmsRpc::DataMapper.define(:text_empty_test) do |m|
+      m.rpc "TEST"
+      m.text_blob :content
+    end
+
+    assert_nil mapping.parse_text(nil)
+    assert_nil mapping.parse_text([])
+  end
+
+  def test_parse_text_handles_string_response
+    mapping = RpmsRpc::DataMapper.define(:text_string_test) do |m|
+      m.rpc "TEST"
+      m.text_blob :content
+    end
+
+    assert_equal "single line", mapping.parse_text("single line")
+  end
+end

--- a/test/rpms_rpc/data_mapper_test.rb
+++ b/test/rpms_rpc/data_mapper_test.rb
@@ -105,7 +105,7 @@ class RpmsRpc::DataMapperTest < Minitest::Test
       field 0, :name
     end
 
-    result = mapping.parse_one(["DOE,JOHN^M"])
+    result = mapping.parse_one([ "DOE,JOHN^M" ])
     assert_equal "DOE,JOHN", result[:name]
   end
 
@@ -129,7 +129,7 @@ class RpmsRpc::DataMapperTest < Minitest::Test
       field 1, :name
     end
 
-    lines = ["1^DOE,JOHN", "2^SMITH,JANE"]
+    lines = [ "1^DOE,JOHN", "2^SMITH,JANE" ]
     results = mapping.parse_many(lines)
 
     assert_equal 2, results.size
@@ -145,7 +145,7 @@ class RpmsRpc::DataMapperTest < Minitest::Test
       field 0, :name
     end
 
-    results = mapping.parse_many(["DOE,JOHN", "", "SMITH,JANE"])
+    results = mapping.parse_many([ "DOE,JOHN", "", "SMITH,JANE" ])
     assert_equal 2, results.size
   end
 

--- a/test/rpms_rpc/data_mapper_test.rb
+++ b/test/rpms_rpc/data_mapper_test.rb
@@ -1,0 +1,213 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "date"
+require "rpms_rpc/data_mapper"
+
+class RpmsRpc::DataMapperTest < Minitest::Test
+  # -- DSL declaration -------------------------------------------------------
+
+  def test_define_creates_a_named_mapping
+    mapping = RpmsRpc::DataMapper.define(:patient_select) do
+      rpc "ORWPT SELECT"
+      field 0, :name
+      field 1, :sex
+      field 2, :dob, :fileman_date
+      field 3, :ssn
+      field 14, :age, :integer
+    end
+
+    assert_equal :patient_select, mapping.name
+    assert_equal "ORWPT SELECT", mapping.rpc_name
+    assert_equal 5, mapping.fields.size
+  end
+
+  def test_field_stores_position_attribute_and_type
+    mapping = RpmsRpc::DataMapper.define(:test) do
+      rpc "TEST RPC"
+      field 0, :name
+      field 2, :dob, :fileman_date
+      field 3, :count, :integer
+      field 4, :active, :boolean
+    end
+
+    f = mapping.fields.first
+    assert_equal 0, f.position
+    assert_equal :name, f.attribute
+    assert_equal :string, f.type
+
+    date_field = mapping.fields.find { |ff| ff.attribute == :dob }
+    assert_equal :fileman_date, date_field.type
+  end
+
+  # -- Single-line parsing ---------------------------------------------------
+
+  def test_parse_one_extracts_fields_from_caret_delimited_line
+    mapping = RpmsRpc::DataMapper.define(:patient_select) do
+      rpc "ORWPT SELECT"
+      field 0, :name
+      field 1, :sex
+      field 3, :ssn
+    end
+
+    line = "DOE,JOHN^M^2800115^111223333^^^^^^^^^^^^^45"
+    result = mapping.parse_one(line)
+
+    assert_equal "DOE,JOHN", result[:name]
+    assert_equal "M", result[:sex]
+    assert_equal "111223333", result[:ssn]
+  end
+
+  def test_parse_one_coerces_integer_fields
+    mapping = RpmsRpc::DataMapper.define(:test) do
+      rpc "TEST"
+      field 0, :count, :integer
+    end
+
+    assert_equal 42, mapping.parse_one("42")[:count]
+  end
+
+  def test_parse_one_coerces_fileman_date_fields
+    mapping = RpmsRpc::DataMapper.define(:test) do
+      rpc "TEST"
+      field 0, :dob, :fileman_date
+    end
+
+    result = mapping.parse_one("2800115")
+    assert_equal Date.new(1980, 1, 15), result[:dob]
+  end
+
+  def test_parse_one_coerces_boolean_fields
+    mapping = RpmsRpc::DataMapper.define(:test) do
+      rpc "TEST"
+      field 0, :active, :boolean
+    end
+
+    assert_equal true, mapping.parse_one("1")[:active]
+    assert_equal false, mapping.parse_one("0")[:active]
+  end
+
+  def test_parse_one_returns_nil_for_empty_fields
+    mapping = RpmsRpc::DataMapper.define(:test) do
+      rpc "TEST"
+      field 0, :name
+      field 1, :ssn
+    end
+
+    result = mapping.parse_one("DOE,JOHN^")
+    assert_equal "DOE,JOHN", result[:name]
+    assert_nil result[:ssn]
+  end
+
+  def test_parse_one_handles_array_response
+    mapping = RpmsRpc::DataMapper.define(:test) do
+      rpc "TEST"
+      field 0, :name
+    end
+
+    result = mapping.parse_one(["DOE,JOHN^M"])
+    assert_equal "DOE,JOHN", result[:name]
+  end
+
+  def test_parse_one_returns_nil_for_empty_response
+    mapping = RpmsRpc::DataMapper.define(:test) do
+      rpc "TEST"
+      field 0, :name
+    end
+
+    assert_nil mapping.parse_one("")
+    assert_nil mapping.parse_one(nil)
+    assert_nil mapping.parse_one([])
+  end
+
+  # -- Multi-line parsing (search results) -----------------------------------
+
+  def test_parse_many_extracts_array_of_hashes
+    mapping = RpmsRpc::DataMapper.define(:patient_list) do
+      rpc "ORWPT LIST ALL"
+      field 0, :dfn, :integer
+      field 1, :name
+    end
+
+    lines = ["1^DOE,JOHN", "2^SMITH,JANE"]
+    results = mapping.parse_many(lines)
+
+    assert_equal 2, results.size
+    assert_equal 1, results[0][:dfn]
+    assert_equal "DOE,JOHN", results[0][:name]
+    assert_equal 2, results[1][:dfn]
+    assert_equal "SMITH,JANE", results[1][:name]
+  end
+
+  def test_parse_many_skips_empty_lines
+    mapping = RpmsRpc::DataMapper.define(:test) do
+      rpc "TEST"
+      field 0, :name
+    end
+
+    results = mapping.parse_many(["DOE,JOHN", "", "SMITH,JANE"])
+    assert_equal 2, results.size
+  end
+
+  def test_parse_many_returns_empty_array_for_nil
+    mapping = RpmsRpc::DataMapper.define(:test) do
+      rpc "TEST"
+      field 0, :name
+    end
+
+    assert_equal [], mapping.parse_many(nil)
+    assert_equal [], mapping.parse_many([])
+  end
+
+  # -- Merge (multi-RPC) ----------------------------------------------------
+
+  def test_merge_combines_two_parsed_hashes
+    select_mapping = RpmsRpc::DataMapper.define(:patient_select) do
+      rpc "ORWPT SELECT"
+      field 0, :name
+      field 1, :sex
+    end
+
+    id_info_mapping = RpmsRpc::DataMapper.define(:patient_id_info) do
+      rpc "ORWPT ID INFO"
+      field 4, :race
+      field 5, :address_line1
+      field 9, :phone
+    end
+
+    base = select_mapping.parse_one("DOE,JOHN^M^2800115^111223333")
+    extended = id_info_mapping.parse_one("DOE,JOHN^M^2800115^111223333^AMERICAN INDIAN^123 Main St^Anchorage^AK^99501^907-555-1234")
+
+    merged = base.merge(extended)
+    assert_equal "DOE,JOHN", merged[:name]
+    assert_equal "M", merged[:sex]
+    assert_equal "AMERICAN INDIAN", merged[:race]
+    assert_equal "123 Main St", merged[:address_line1]
+    assert_equal "907-555-1234", merged[:phone]
+  end
+
+  # -- Inject extra attributes (e.g. DFN from caller) -----------------------
+
+  def test_parse_one_with_extras_merges_caller_provided_attributes
+    mapping = RpmsRpc::DataMapper.define(:test) do
+      rpc "TEST"
+      field 0, :name
+    end
+
+    result = mapping.parse_one("DOE,JOHN", extras: { dfn: 42 })
+    assert_equal "DOE,JOHN", result[:name]
+    assert_equal 42, result[:dfn]
+  end
+
+  # -- Registry lookup -------------------------------------------------------
+
+  def test_registry_stores_and_retrieves_mappings
+    RpmsRpc::DataMapper.define(:registry_test) do
+      rpc "TEST"
+      field 0, :name
+    end
+
+    mapping = RpmsRpc::DataMapper[:registry_test]
+    assert_equal "TEST", mapping.rpc_name
+  end
+end

--- a/test/rpms_rpc/data_mapper_test.rb
+++ b/test/rpms_rpc/data_mapper_test.rb
@@ -162,13 +162,13 @@ class RpmsRpc::DataMapperTest < Minitest::Test
   # -- Merge (multi-RPC) ----------------------------------------------------
 
   def test_merge_combines_two_parsed_hashes
-    select_mapping = RpmsRpc::DataMapper.define(:patient_select) do
+    select_mapping = RpmsRpc::DataMapper.define(:merge_test_select) do
       rpc "ORWPT SELECT"
       field 0, :name
       field 1, :sex
     end
 
-    id_info_mapping = RpmsRpc::DataMapper.define(:patient_id_info) do
+    id_info_mapping = RpmsRpc::DataMapper.define(:merge_test_id_info) do
       rpc "ORWPT ID INFO"
       field 4, :race
       field 5, :address_line1

--- a/test/rpms_rpc/mappings_test.rb
+++ b/test/rpms_rpc/mappings_test.rb
@@ -221,6 +221,85 @@ class RpmsRpc::MappingsTest < Minitest::Test
     assert_equal true, result[:is_provider]
   end
 
+  # -- Scalar RPCs -----------------------------------------------------------
+
+  def test_patient_deceased_scalar
+    m = RpmsRpc::DataMapper[:patient_deceased]
+    assert_equal Date.new(2025, 3, 15), m.parse_scalar("3250315")
+    assert_nil m.parse_scalar("0")
+  end
+
+  def test_patient_sensitive_scalar
+    m = RpmsRpc::DataMapper[:patient_sensitive]
+    assert_equal true, m.parse_scalar("1")
+    assert_equal false, m.parse_scalar("0")
+  end
+
+  def test_user_has_key_scalar
+    m = RpmsRpc::DataMapper[:user_has_key]
+    assert_equal true, m.parse_scalar("1")
+  end
+
+  # -- Line-based RPCs -------------------------------------------------------
+
+  def test_av_code_line_based
+    m = RpmsRpc::DataMapper[:av_code]
+    result = m.parse_lines(["101", "0", "0", "Welcome to RPMS", "", "3"])
+    assert_equal 101, result[:duz]
+    assert_equal "Welcome to RPMS", result[:greeting]
+    assert_equal 3, result[:tries]
+  end
+
+  def test_av_code_failure
+    m = RpmsRpc::DataMapper[:av_code]
+    result = m.parse_lines(["0", "0", "0", "Not a valid ACCESS CODE/VERIFY CODE pair.", "", "2"])
+    assert_equal 0, result[:duz]
+    assert_equal 2, result[:tries]
+  end
+
+  # -- Text blob RPCs --------------------------------------------------------
+
+  def test_report_text_blob
+    m = RpmsRpc::DataMapper[:report_text]
+    text = m.parse_text(["Patient: DOE,JOHN", "Date: 2025-03-15", "Vitals normal."])
+    assert_equal "Patient: DOE,JOHN\nDate: 2025-03-15\nVitals normal.", text
+  end
+
+  def test_lab_report_blob
+    m = RpmsRpc::DataMapper[:lab_report]
+    text = m.parse_text(["CBC Results", "WBC: 7.2"])
+    assert_equal "CBC Results\nWBC: 7.2", text
+  end
+
+  # -- Write result RPCs -----------------------------------------------------
+
+  def test_referral_delete
+    result = RpmsRpc::DataMapper[:referral_delete].parse_one("1^Referral deleted")
+    assert_equal true, result[:success]
+    assert_equal "Referral deleted", result[:message]
+  end
+
+  def test_key_grant
+    result = RpmsRpc::DataMapper[:key_grant].parse_one("1^Key granted")
+    assert_equal true, result[:success]
+  end
+
+  def test_prescription_new
+    result = RpmsRpc::DataMapper[:prescription_new].parse_one("1^12345")
+    assert_equal true, result[:success]
+    assert_equal "12345", result[:rx_ien_or_error]
+  end
+
+  # -- PHR RPCs --------------------------------------------------------------
+
+  def test_immunization_count
+    assert_equal 5, RpmsRpc::DataMapper[:immunization_count].parse_scalar("5")
+  end
+
+  def test_phr_access
+    assert_equal true, RpmsRpc::DataMapper[:phr_access].parse_scalar("1")
+  end
+
   # -- Registry completeness -------------------------------------------------
 
   def test_all_expected_mappings_registered
@@ -234,6 +313,18 @@ class RpmsRpc::MappingsTest < Minitest::Test
       procedure_list device_list lab_result_list radiology_list
       hospital_location institution referral_search site_params
       user_info report_types reminders_list
+      reminder_detail patient_deceased patient_sensitive user_has_key
+      signon_setup av_code cvc_verify user_keys
+      report_text report_type_components health_summary_report
+      flowsheet_list maint_items lab_report lab_report_list radiology_report
+      medication_detail care_plan_detail care_team_detail goal_detail
+      procedure_detail device_detail referral_detail referral_delete
+      patient_recent patient_save_recent
+      section_data section_save section_definition patient_lock patient_unlock
+      key_list key_grant key_revoke
+      prescription_new erx_status prescription_cancel
+      ccd_document ccd_referral immunization_text immunization_count
+      phr_access phr_patient_direct phr_provider_direct phr_facility_direct
     ]
 
     expected.each do |name|

--- a/test/rpms_rpc/mappings_test.rb
+++ b/test/rpms_rpc/mappings_test.rb
@@ -52,7 +52,7 @@ class RpmsRpc::MappingsTest < Minitest::Test
   # -- ORWPT LIST ALL --------------------------------------------------------
 
   def test_patient_list
-    results = RpmsRpc::DataMapper[:patient_list].parse_many(["1^DOE,JOHN", "2^SMITH,JANE"])
+    results = RpmsRpc::DataMapper[:patient_list].parse_many([ "1^DOE,JOHN", "2^SMITH,JANE" ])
     assert_equal 2, results.size
     assert_equal 1, results[0][:dfn]
     assert_equal "SMITH,JANE", results[1][:name]
@@ -69,7 +69,7 @@ class RpmsRpc::MappingsTest < Minitest::Test
   # -- ORWPT APPTLST ---------------------------------------------------------
 
   def test_patient_appointments
-    results = RpmsRpc::DataMapper[:patient_appointments].parse_many(["3260415.1000^1^Primary Care^KEPT"])
+    results = RpmsRpc::DataMapper[:patient_appointments].parse_many([ "3260415.1000^1^Primary Care^KEPT" ])
     assert_equal 1, results.size
     assert_equal "Primary Care", results[0][:location]
     assert_equal "KEPT", results[0][:status]
@@ -78,7 +78,7 @@ class RpmsRpc::MappingsTest < Minitest::Test
   # -- ORQQAL LIST -----------------------------------------------------------
 
   def test_allergy_list
-    results = RpmsRpc::DataMapper[:allergy_list].parse_many(["PENICILLIN^RASH^MODERATE", "ASPIRIN^HIVES^SEVERE"])
+    results = RpmsRpc::DataMapper[:allergy_list].parse_many([ "PENICILLIN^RASH^MODERATE", "ASPIRIN^HIVES^SEVERE" ])
     assert_equal 2, results.size
     assert_equal "PENICILLIN", results[0][:allergen]
     assert_equal "SEVERE", results[1][:severity]
@@ -87,7 +87,7 @@ class RpmsRpc::MappingsTest < Minitest::Test
   # -- ORQQPL LIST -----------------------------------------------------------
 
   def test_problem_list
-    result = RpmsRpc::DataMapper[:problem_list].parse_many(["123^ACTIVE^Diabetes Type 2^E11.9^3200101^3250301^101"]).first
+    result = RpmsRpc::DataMapper[:problem_list].parse_many([ "123^ACTIVE^Diabetes Type 2^E11.9^3200101^3250301^101" ]).first
     assert_equal "123", result[:ien]
     assert_equal "ACTIVE", result[:status]
     assert_equal "E11.9", result[:icd_code]
@@ -97,7 +97,7 @@ class RpmsRpc::MappingsTest < Minitest::Test
   # -- ORQQVI VITALS ---------------------------------------------------------
 
   def test_vitals
-    results = RpmsRpc::DataMapper[:vitals].parse_many(["BLOOD PRESSURE^120/80^mmHg^3260401"])
+    results = RpmsRpc::DataMapper[:vitals].parse_many([ "BLOOD PRESSURE^120/80^mmHg^3260401" ])
     assert_equal "BLOOD PRESSURE", results[0][:type]
     assert_equal "120/80", results[0][:value]
   end
@@ -179,7 +179,7 @@ class RpmsRpc::MappingsTest < Minitest::Test
   # -- ORWU NEWPERS ----------------------------------------------------------
 
   def test_practitioner_list
-    results = RpmsRpc::DataMapper[:practitioner_list].parse_many(["101^MARTINEZ,SARAH^MD", "102^CHEN,JAMES^DO"])
+    results = RpmsRpc::DataMapper[:practitioner_list].parse_many([ "101^MARTINEZ,SARAH^MD", "102^CHEN,JAMES^DO" ])
     assert_equal 2, results.size
     assert_equal 101, results[0][:ien]
     assert_equal "DO", results[1][:title]
@@ -188,7 +188,7 @@ class RpmsRpc::MappingsTest < Minitest::Test
   # -- ORQQPS LIST -----------------------------------------------------------
 
   def test_medication_list
-    result = RpmsRpc::DataMapper[:medication_list].parse_many(["456^METFORMIN 500MG^TAKE ONE TABLET BY MOUTH TWICE DAILY^ACTIVE^3260101^3^MARTINEZ"]).first
+    result = RpmsRpc::DataMapper[:medication_list].parse_many([ "456^METFORMIN 500MG^TAKE ONE TABLET BY MOUTH TWICE DAILY^ACTIVE^3260101^3^MARTINEZ" ]).first
     assert_equal "METFORMIN 500MG", result[:drug_name]
     assert_equal "ACTIVE", result[:status]
     assert_equal 3, result[:refills]
@@ -244,7 +244,7 @@ class RpmsRpc::MappingsTest < Minitest::Test
 
   def test_av_code_line_based
     m = RpmsRpc::DataMapper[:av_code]
-    result = m.parse_lines(["101", "0", "0", "Welcome to RPMS", "", "3"])
+    result = m.parse_lines([ "101", "0", "0", "Welcome to RPMS", "", "3" ])
     assert_equal 101, result[:duz]
     assert_equal "Welcome to RPMS", result[:greeting]
     assert_equal 3, result[:tries]
@@ -252,7 +252,7 @@ class RpmsRpc::MappingsTest < Minitest::Test
 
   def test_av_code_failure
     m = RpmsRpc::DataMapper[:av_code]
-    result = m.parse_lines(["0", "0", "0", "Not a valid ACCESS CODE/VERIFY CODE pair.", "", "2"])
+    result = m.parse_lines([ "0", "0", "0", "Not a valid ACCESS CODE/VERIFY CODE pair.", "", "2" ])
     assert_equal 0, result[:duz]
     assert_equal 2, result[:tries]
   end
@@ -261,13 +261,13 @@ class RpmsRpc::MappingsTest < Minitest::Test
 
   def test_report_text_blob
     m = RpmsRpc::DataMapper[:report_text]
-    text = m.parse_text(["Patient: DOE,JOHN", "Date: 2025-03-15", "Vitals normal."])
+    text = m.parse_text([ "Patient: DOE,JOHN", "Date: 2025-03-15", "Vitals normal." ])
     assert_equal "Patient: DOE,JOHN\nDate: 2025-03-15\nVitals normal.", text
   end
 
   def test_lab_report_blob
     m = RpmsRpc::DataMapper[:lab_report]
-    text = m.parse_text(["CBC Results", "WBC: 7.2"])
+    text = m.parse_text([ "CBC Results", "WBC: 7.2" ])
     assert_equal "CBC Results\nWBC: 7.2", text
   end
 

--- a/test/rpms_rpc/mappings_test.rb
+++ b/test/rpms_rpc/mappings_test.rb
@@ -1,0 +1,243 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "date"
+require "rpms_rpc/mappings"
+
+class RpmsRpc::MappingsTest < Minitest::Test
+  # -- ORWPT SELECT ----------------------------------------------------------
+
+  def test_patient_select_parses_full_response
+    m = RpmsRpc::DataMapper[:patient_select]
+    result = m.parse_one("DOE,JOHN^M^2800115^111223333^^^^^^^^^^^45", extras: { dfn: 1 })
+
+    assert_equal 1, result[:dfn]
+    assert_equal "DOE,JOHN", result[:name]
+    assert_equal "M", result[:sex]
+    assert_equal Date.new(1980, 1, 15), result[:dob]
+    assert_equal "111223333", result[:ssn]
+    assert_equal 45, result[:age]
+  end
+
+  # -- ORWPT ID INFO ---------------------------------------------------------
+
+  def test_patient_id_info_parses_extended_fields
+    m = RpmsRpc::DataMapper[:patient_id_info]
+    result = m.parse_one("DOE,JOHN^M^2800115^111223333^AMERICAN INDIAN^123 Main St^Anchorage^AK^99501^907-555-1234^ANLC-12345^Anchorage^IHS")
+
+    assert_equal "AMERICAN INDIAN", result[:race]
+    assert_equal "123 Main St", result[:address_line1]
+    assert_equal "Anchorage", result[:city]
+    assert_equal "AK", result[:state]
+    assert_equal "99501", result[:zip_code]
+    assert_equal "907-555-1234", result[:phone]
+    assert_equal "ANLC-12345", result[:tribal_enrollment_number]
+    assert_equal "Anchorage", result[:service_area]
+    assert_equal "IHS", result[:coverage_type]
+  end
+
+  # -- SELECT + ID INFO merge ------------------------------------------------
+
+  def test_patient_merge
+    base = RpmsRpc::DataMapper[:patient_select].parse_one("DOE,JOHN^M^2800115^111223333^^^^^^^^^^^45", extras: { dfn: 1 })
+    ext = RpmsRpc::DataMapper[:patient_id_info].parse_one("DOE,JOHN^M^2800115^111223333^AMERICAN INDIAN^123 Main St^Anchorage^AK^99501^907-555-1234")
+    merged = base.merge(ext)
+
+    assert_equal 1, merged[:dfn]
+    assert_equal "DOE,JOHN", merged[:name]
+    assert_equal "AMERICAN INDIAN", merged[:race]
+    assert_equal "907-555-1234", merged[:phone]
+  end
+
+  # -- ORWPT LIST ALL --------------------------------------------------------
+
+  def test_patient_list
+    results = RpmsRpc::DataMapper[:patient_list].parse_many(["1^DOE,JOHN", "2^SMITH,JANE"])
+    assert_equal 2, results.size
+    assert_equal 1, results[0][:dfn]
+    assert_equal "SMITH,JANE", results[1][:name]
+  end
+
+  # -- ORWPT FULLSSN ---------------------------------------------------------
+
+  def test_patient_ssn
+    result = RpmsRpc::DataMapper[:patient_ssn].parse_one("42^DOE,JOHN^^111223333")
+    assert_equal 42, result[:dfn]
+    assert_equal "111223333", result[:ssn]
+  end
+
+  # -- ORWPT APPTLST ---------------------------------------------------------
+
+  def test_patient_appointments
+    results = RpmsRpc::DataMapper[:patient_appointments].parse_many(["3260415.1000^1^Primary Care^KEPT"])
+    assert_equal 1, results.size
+    assert_equal "Primary Care", results[0][:location]
+    assert_equal "KEPT", results[0][:status]
+  end
+
+  # -- ORQQAL LIST -----------------------------------------------------------
+
+  def test_allergy_list
+    results = RpmsRpc::DataMapper[:allergy_list].parse_many(["PENICILLIN^RASH^MODERATE", "ASPIRIN^HIVES^SEVERE"])
+    assert_equal 2, results.size
+    assert_equal "PENICILLIN", results[0][:allergen]
+    assert_equal "SEVERE", results[1][:severity]
+  end
+
+  # -- ORQQPL LIST -----------------------------------------------------------
+
+  def test_problem_list
+    result = RpmsRpc::DataMapper[:problem_list].parse_many(["123^ACTIVE^Diabetes Type 2^E11.9^3200101^3250301^101"]).first
+    assert_equal "123", result[:ien]
+    assert_equal "ACTIVE", result[:status]
+    assert_equal "E11.9", result[:icd_code]
+    assert_equal Date.new(2020, 1, 1), result[:onset_date]
+  end
+
+  # -- ORQQVI VITALS ---------------------------------------------------------
+
+  def test_vitals
+    results = RpmsRpc::DataMapper[:vitals].parse_many(["BLOOD PRESSURE^120/80^mmHg^3260401"])
+    assert_equal "BLOOD PRESSURE", results[0][:type]
+    assert_equal "120/80", results[0][:value]
+  end
+
+  # -- BHDPTRPC TRIBAL -------------------------------------------------------
+
+  def test_tribal_enrollment
+    result = RpmsRpc::DataMapper[:tribal_enrollment].parse_one("ANLC-12345^Alaska Native - Anchorage (ANLC)^3200101^ACTIVE^Anchorage^ANLC")
+    assert_equal "ANLC-12345", result[:enrollment_number]
+    assert_equal "Alaska Native - Anchorage (ANLC)", result[:tribe_name]
+    assert_equal "ACTIVE", result[:status]
+    assert_equal "ANLC", result[:tribe_code]
+  end
+
+  # -- BHDPTRPC TRIBALVAL ----------------------------------------------------
+
+  def test_tribal_validation
+    result = RpmsRpc::DataMapper[:tribal_validation].parse_one("1^ANLC^12345^ACTIVE^Valid enrollment")
+    assert_equal true, result[:valid]
+    assert_equal "ANLC", result[:tribe_code]
+    assert_equal "Valid enrollment", result[:message]
+  end
+
+  # -- BHDPTRPC TRIBELIST ----------------------------------------------------
+
+  def test_tribe_info
+    result = RpmsRpc::DataMapper[:tribe_info].parse_one("100^Alaska Native - Anchorage (ANLC)^ANLC^Anchorage^Alaska^Alaska Area")
+    assert_equal 100, result[:ien]
+    assert_equal "ANLC", result[:code]
+    assert_equal "Alaska Area", result[:area]
+  end
+
+  # -- BHDPTRPC TRIBALELG ----------------------------------------------------
+
+  def test_enrollment_eligibility
+    result = RpmsRpc::DataMapper[:enrollment_eligibility].parse_one("1^1^Anchorage^Eligible for IHS services^BASIC")
+    assert_equal true, result[:active]
+    assert_equal true, result[:eligible_for_ihs]
+    assert_equal "BASIC", result[:benefit_package]
+  end
+
+  # -- BHDPTRPC SU -----------------------------------------------------------
+
+  def test_service_unit
+    result = RpmsRpc::DataMapper[:service_unit].parse_one("1^Anchorage^Alaska")
+    assert_equal 1, result[:ien]
+    assert_equal "Anchorage", result[:name]
+    assert_equal "Alaska", result[:region]
+  end
+
+  # -- BHDPTRPC REGISTER ----------------------------------------------------
+
+  def test_patient_register_success
+    result = RpmsRpc::DataMapper[:patient_register].parse_one("1^42")
+    assert_equal true, result[:success]
+    assert_equal "42", result[:dfn_or_error]
+  end
+
+  def test_patient_register_failure
+    result = RpmsRpc::DataMapper[:patient_register].parse_one("0^Duplicate SSN")
+    assert_equal false, result[:success]
+    assert_equal "Duplicate SSN", result[:dfn_or_error]
+  end
+
+  # -- ORWU USERINFO ---------------------------------------------------------
+
+  def test_practitioner_info
+    result = RpmsRpc::DataMapper[:practitioner_info].parse_one(
+      "MARTINEZ,SARAH^MD^Internal Medicine^Cardiology^1234567890^AB1234567^907-555-9999^Physician",
+      extras: { ien: 101 }
+    )
+    assert_equal 101, result[:ien]
+    assert_equal "MARTINEZ,SARAH", result[:name]
+    assert_equal "Cardiology", result[:specialty]
+    assert_equal "1234567890", result[:npi]
+    assert_equal "Physician", result[:provider_class]
+  end
+
+  # -- ORWU NEWPERS ----------------------------------------------------------
+
+  def test_practitioner_list
+    results = RpmsRpc::DataMapper[:practitioner_list].parse_many(["101^MARTINEZ,SARAH^MD", "102^CHEN,JAMES^DO"])
+    assert_equal 2, results.size
+    assert_equal 101, results[0][:ien]
+    assert_equal "DO", results[1][:title]
+  end
+
+  # -- ORQQPS LIST -----------------------------------------------------------
+
+  def test_medication_list
+    result = RpmsRpc::DataMapper[:medication_list].parse_many(["456^METFORMIN 500MG^TAKE ONE TABLET BY MOUTH TWICE DAILY^ACTIVE^3260101^3^MARTINEZ"]).first
+    assert_equal "METFORMIN 500MG", result[:drug_name]
+    assert_equal "ACTIVE", result[:status]
+    assert_equal 3, result[:refills]
+  end
+
+  # -- BHDO HOSP LOC DATA ---------------------------------------------------
+
+  def test_hospital_location
+    result = RpmsRpc::DataMapper[:hospital_location].parse_one("1^Primary Care Clinic^PCC^C^101")
+    assert_equal 1, result[:ien]
+    assert_equal "Primary Care Clinic", result[:name]
+    assert_equal "PCC", result[:abbreviation]
+  end
+
+  # -- BHDO INST DATA --------------------------------------------------------
+
+  def test_institution
+    result = RpmsRpc::DataMapper[:institution].parse_one("1^Alaska Native Medical Center^463^4315 Diplomacy Dr^Anchorage^AK^99508^907-729-1900")
+    assert_equal 1, result[:ien]
+    assert_equal "463", result[:station_number]
+    assert_equal "AK", result[:state]
+  end
+
+  # -- XUS GET USER INFO -----------------------------------------------------
+
+  def test_user_info
+    result = RpmsRpc::DataMapper[:user_info].parse_one("101^MARTINEZ,SARAH^PROVIDER^1^1^PHYSICIAN")
+    assert_equal 101, result[:duz]
+    assert_equal true, result[:can_sign]
+    assert_equal true, result[:is_provider]
+  end
+
+  # -- Registry completeness -------------------------------------------------
+
+  def test_all_expected_mappings_registered
+    expected = %i[
+      patient_select patient_id_info patient_list patient_ssn
+      patient_appointments allergy_list problem_list vitals
+      tribal_enrollment tribal_validation tribe_info enrollment_eligibility
+      service_unit patient_register patient_update encounter_create
+      practitioner_info practitioner_list
+      medication_list care_plan_list care_team_list goal_list
+      procedure_list device_list lab_result_list radiology_list
+      hospital_location institution referral_search site_params
+      user_info report_types reminders_list
+    ]
+
+    expected.each do |name|
+      assert RpmsRpc::DataMapper[name], "Missing mapping: #{name}"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `RpmsRpc::DataMapper` DSL for declaring caret-delimited field mappings
- Add 30+ built-in RPMS RPC mappings (patient, practitioner, clinical, lab, radiology, location, auth, referrals)
- All TDD — 165 tests, 385 assertions

## API

```ruby
# Define
RpmsRpc::DataMapper.define(:patient_select) do |m|
  m.rpc "ORWPT SELECT"
  m.field 0, :name
  m.field 1, :sex
  m.field 2, :dob, :fileman_date
  m.field 14, :age, :integer
end

# Parse single-line
RpmsRpc::DataMapper[:patient_select].parse_one(response, extras: { dfn: 42 })

# Parse multi-line (search results)
RpmsRpc::DataMapper[:patient_list].parse_many(response)

# Merge multi-RPC (SELECT + ID INFO)
base = DataMapper[:patient_select].parse_one(select_response, extras: { dfn: 42 })
ext = DataMapper[:patient_id_info].parse_one(id_info_response)
full = base.merge(ext)
```

## Test plan
- [x] DSL declaration and field storage
- [x] Single-line parsing with type coercion (string, integer, fileman_date, boolean)
- [x] Multi-line parsing (search results)
- [x] Multi-RPC merge
- [x] Extras injection (caller-provided attributes like DFN)
- [x] Edge cases (nil, empty, array responses)
- [x] All 30+ built-in mappings tested with realistic response data
- [x] Registry completeness assertion

Closes lakeraven/rpms-rpc#2

🤖 Generated with [Claude Code](https://claude.com/claude-code)