### PR TITLE
MockClient should provide high-fidelity RPC mocking via DataMapper

### DIFF
--- a/lib/rpms_rpc/data_mapper.rb
+++ b/lib/rpms_rpc/data_mapper.rb
@@ -132,6 +132,31 @@ module RpmsRpc
         response.join("\n")
       end
 
+      # -- format_* methods: reverse of parse (hash → caret-delimited string) ----
+
+      # Format a hash into a caret-delimited string matching this mapping's field positions.
+      def format_one(attrs)
+        max_pos = @fields.map(&:position).max || 0
+        parts = Array.new(max_pos + 1, "")
+
+        @fields.each do |f|
+          val = attrs[f.attribute]
+          parts[f.position] = format_value(val, f.type)
+        end
+
+        parts.join("^")
+      end
+
+      # Format an array of hashes into an array of caret-delimited strings.
+      def format_many(attrs_list)
+        attrs_list.map { |attrs| format_one(attrs) }
+      end
+
+      # Format a scalar value for this mapping's scalar type.
+      def format_scalar(value)
+        format_value(value, @scalar_type || :string)
+      end
+
       # -- fetch_* methods: call RPC + parse in one shot -------------------------
 
       # Call RPC and parse a single-line response.
@@ -175,6 +200,21 @@ module RpmsRpc
       end
 
       private
+
+      def format_value(val, type)
+        return "" if val.nil?
+
+        case type
+        when :fileman_date
+          val.is_a?(Date) || val.is_a?(Time) ? FilemanDateParser.format_date(val) : val.to_s
+        when :integer
+          val.to_s
+        when :boolean
+          val ? "1" : "0"
+        else
+          val.to_s
+        end
+      end
 
       def normalize_line(response)
         return nil if response.nil?

--- a/lib/rpms_rpc/mock_client.rb
+++ b/lib/rpms_rpc/mock_client.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require_relative "data_mapper"
+require_relative "mappings"
+
+module RpmsRpc
+  # Mock RPC client for testing. Consumers seed data as hashes;
+  # MockClient formats them into caret-delimited RPC responses
+  # using the DataMapper mappings. High fidelity — responses go
+  # through the same parse path as production.
+  #
+  #   mock = RpmsRpc::MockClient.new
+  #   mock.seed(:patient_select, "1", { name: "DOE,JOHN", sex: "M", dob: Date.new(1980,1,15) })
+  #   mock.call_rpc("ORWPT SELECT", "1")  # => "DOE,JOHN^M^2800115^..."
+  #
+  class MockClient
+    def initialize
+      @records = {}     # { rpc_name => { key => formatted_string } }
+      @collections = {} # { rpc_name => [formatted_string, ...] }
+      @scalars = {}     # { rpc_name => { key => formatted_string } }
+    end
+
+    # Seed a single record for a mapping.
+    # Key is typically the first RPC param (DFN, IEN, etc.).
+    def seed(mapping_name, key, attrs)
+      mapping = DataMapper[mapping_name]
+      formatted = mapping.format_one(attrs)
+      @records[mapping.rpc_name] ||= {}
+      @records[mapping.rpc_name][key.to_s] = formatted
+    end
+
+    # Seed a collection (search results) for a mapping.
+    def seed_collection(mapping_name, attrs_list)
+      mapping = DataMapper[mapping_name]
+      formatted = mapping.format_many(attrs_list)
+      @collections[mapping.rpc_name] = formatted
+    end
+
+    # Seed a scalar value for a mapping.
+    def seed_scalar(mapping_name, key, value)
+      mapping = DataMapper[mapping_name]
+      formatted = mapping.format_scalar(value)
+      @scalars[mapping.rpc_name] ||= {}
+      @scalars[mapping.rpc_name][key.to_s] = formatted
+    end
+
+    # Simulate call_rpc — returns formatted response matching the seeded data.
+    def call_rpc(rpc_name, *params)
+      key = params.first.to_s
+
+      # Check single records first
+      if @records.dig(rpc_name, key)
+        return [ @records[rpc_name][key] ]
+      end
+
+      # Check collections
+      if @collections[rpc_name]
+        return @collections[rpc_name]
+      end
+
+      # Check scalars
+      if @scalars.dig(rpc_name, key)
+        return @scalars[rpc_name][key]
+      end
+
+      ""
+    end
+  end
+end

--- a/test/rpms_rpc/mock_client_test.rb
+++ b/test/rpms_rpc/mock_client_test.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "date"
+require "rpms_rpc/mock_client"
+
+class RpmsRpc::MockClientTest < Minitest::Test
+  # -- format_one (reverse of parse_one) ------------------------------------
+
+  def test_format_one_produces_caret_delimited_string
+    mapping = RpmsRpc::DataMapper.patient_select
+    result = mapping.format_one({ name: "DOE,JOHN", sex: "M", dob: Date.new(1980, 1, 15), ssn: "111223333", age: 45 })
+
+    # Should produce a string that round-trips through parse_one
+    parsed = mapping.parse_one(result)
+    assert_equal "DOE,JOHN", parsed[:name]
+    assert_equal "M", parsed[:sex]
+    assert_equal Date.new(1980, 1, 15), parsed[:dob]
+    assert_equal "111223333", parsed[:ssn]
+    assert_equal 45, parsed[:age]
+  end
+
+  def test_format_one_handles_nil_values
+    mapping = RpmsRpc::DataMapper.patient_select
+    result = mapping.format_one({ name: "DOE,JOHN", sex: "M" })
+
+    parsed = mapping.parse_one(result)
+    assert_equal "DOE,JOHN", parsed[:name]
+    assert_nil parsed[:ssn]
+  end
+
+  def test_format_many_produces_array_of_strings
+    mapping = RpmsRpc::DataMapper.patient_list
+    result = mapping.format_many([
+      { dfn: 1, name: "DOE,JOHN" },
+      { dfn: 2, name: "SMITH,JANE" }
+    ])
+
+    assert_equal 2, result.size
+    parsed = mapping.parse_many(result)
+    assert_equal 1, parsed[0][:dfn]
+    assert_equal "SMITH,JANE", parsed[1][:name]
+  end
+
+  # -- MockClient seed + call_rpc ------------------------------------------
+
+  def test_seed_and_call_rpc_for_single_record
+    mock = RpmsRpc::MockClient.new
+    mock.seed(:institution, "1", { ien: 1, name: "ANMC", station_number: "463",
+                                   address: "4315 Diplomacy Dr", city: "Anchorage",
+                                   state: "AK", zip_code: "99508", phone: "907-729-1900" })
+
+    response = mock.call_rpc("BHDO INST DATA", "1")
+    parsed = RpmsRpc::DataMapper.institution.parse_one(response)
+
+    assert_equal 1, parsed[:ien]
+    assert_equal "ANMC", parsed[:name]
+    assert_equal "AK", parsed[:state]
+  end
+
+  def test_call_rpc_returns_empty_for_unknown_key
+    mock = RpmsRpc::MockClient.new
+    response = mock.call_rpc("BHDO INST DATA", "99999")
+    assert_equal "", response
+  end
+
+  def test_seed_and_call_rpc_for_patient_select
+    mock = RpmsRpc::MockClient.new
+    mock.seed(:patient_select, "1", { name: "DOE,JOHN", sex: "M",
+                                      dob: Date.new(1980, 1, 15), ssn: "111223333", age: 45 })
+
+    response = mock.call_rpc("ORWPT SELECT", "1")
+    parsed = RpmsRpc::DataMapper.patient_select.parse_one(response)
+
+    assert_equal "DOE,JOHN", parsed[:name]
+    assert_equal Date.new(1980, 1, 15), parsed[:dob]
+  end
+
+  def test_seed_collection_for_search_rpcs
+    mock = RpmsRpc::MockClient.new
+    mock.seed_collection(:patient_list, [
+      { dfn: 1, name: "DOE,JOHN" },
+      { dfn: 2, name: "SMITH,JANE" }
+    ])
+
+    response = mock.call_rpc("ORWPT LIST ALL", "DOE", "1")
+    # Returns all seeded records (filtering is caller's responsibility)
+    parsed = RpmsRpc::DataMapper.patient_list.parse_many(response)
+    assert_equal 2, parsed.size
+  end
+
+  def test_seed_collection_returns_empty_for_unknown_rpc
+    mock = RpmsRpc::MockClient.new
+    response = mock.call_rpc("ORWPT LIST ALL", "DOE", "1")
+    assert_equal "", response
+  end
+
+  def test_seed_scalar
+    mock = RpmsRpc::MockClient.new
+    mock.seed_scalar(:patient_sensitive, "1", true)
+
+    response = mock.call_rpc("ORWPT SELCHK", "1")
+    parsed = RpmsRpc::DataMapper.patient_sensitive.parse_scalar(response)
+    assert_equal true, parsed
+  end
+
+  def test_multiple_seeds_same_rpc_different_keys
+    mock = RpmsRpc::MockClient.new
+    mock.seed(:patient_select, "1", { name: "DOE,JOHN", sex: "M" })
+    mock.seed(:patient_select, "2", { name: "SMITH,JANE", sex: "F" })
+
+    p1 = RpmsRpc::DataMapper.patient_select.parse_one(mock.call_rpc("ORWPT SELECT", "1"))
+    p2 = RpmsRpc::DataMapper.patient_select.parse_one(mock.call_rpc("ORWPT SELECT", "2"))
+
+    assert_equal "DOE,JOHN", p1[:name]
+    assert_equal "SMITH,JANE", p2[:name]
+  end
+end


### PR DESCRIPTION
## Summary
- `MockClient` — seed data as hashes, get caret-delimited RPC responses back
- `format_one` / `format_many` / `format_scalar` — reverse of parse (hash → caret string)
- Round-trip tested: format → parse produces the original data
- Consumers seed domain hashes; rpms-rpc handles serialization both directions

## API
```ruby
mock = RpmsRpc::MockClient.new
mock.seed(:patient_select, "1", { name: "DOE,JOHN", sex: "M", dob: Date.new(1980,1,15) })
mock.seed(:institution, "1", { ien: 1, name: "ANMC", state: "AK" })
mock.seed_collection(:patient_list, [{ dfn: 1, name: "DOE" }, { dfn: 2, name: "SMITH" }])
mock.seed_scalar(:patient_sensitive, "1", true)

mock.call_rpc("ORWPT SELECT", "1")  # => ["DOE,JOHN^M^2800115^..."]
```

## Test plan
- [x] format_one produces round-trippable caret strings
- [x] format_one handles nil values
- [x] format_many produces array of strings
- [x] seed + call_rpc for single records (institution, patient)
- [x] seed_collection for search RPCs
- [x] seed_scalar for boolean/value RPCs
- [x] Multiple seeds same RPC different keys
- [x] Unknown key returns empty string
- [x] 213 tests, 523 assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)