### PR TITLE
Add SecurityKeys, UserRoles, Capabilities and seed_user

### DIFF
--- a/lib/rpms_rpc/capabilities.rb
+++ b/lib/rpms_rpc/capabilities.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module RpmsRpc
+  # Framework-agnostic capability checks derived from RPMS security keys.
+  # Used by authorization policies in any engine (Pundit, Action Policy, etc.).
+  #
+  # All methods accept a user-like object that responds to:
+  #   - security_keys: Array of symbols (e.g., [:prc_supervisor, :consult_manager])
+  #   - user_type: String (e.g., "provider", "nurse")
+  #
+  module Capabilities
+    # PRC / CHS
+    def self.can_approve_chs?(user)
+      has_any_key?(user, :prc_supervisor, :prc_manager)
+    end
+
+    def self.can_process_chs?(user)
+      has_any_key?(user, :prc_tech, :prc_supervisor)
+    end
+
+    def self.can_manage_chs?(user)
+      has_any_key?(user, :prc_supervisor, :prc_tech, :prc_manager, :chs_approve, :chs_clerk)
+    end
+
+    # Clinical
+    def self.can_manage_consults?(user)
+      has_key?(user, :consult_manager)
+    end
+
+    def self.can_verify_eligibility?(user)
+      has_key?(user, :eligibility_verify)
+    end
+
+    def self.can_manage_scheduling?(user)
+      has_key?(user, :scheduling_admin)
+    end
+
+    # Service line access (42 CFR Part 2 separation)
+    def self.can_access_behavioral_health?(user)
+      has_any_key?(user, :bh_provider, :bh_supervisor)
+    end
+
+    def self.can_access_dental?(user)
+      has_any_key?(user, :dental_provider, :dental_supervisor)
+    end
+
+    # Role-based permissions
+    ROLE_PERMISSIONS = {
+      "provider" => %i[view_patients view_referrals create_referrals edit_own_referrals],
+      "nurse" => %i[view_patients view_referrals update_referral_status],
+      "clerk" => %i[view_patients view_referrals],
+      "case_manager" => %i[view_patients view_referrals approve_referrals deny_referrals manage_referrals],
+      "admin" => %i[view_patients view_referrals create_referrals approve_referrals deny_referrals manage_referrals],
+      "user" => %i[view_own_referrals]
+    }.freeze
+
+    def self.permissions_for(user)
+      ROLE_PERMISSIONS[user.user_type] || ROLE_PERMISSIONS["user"]
+    end
+
+    def self.can?(user, permission)
+      permissions_for(user).include?(permission.to_sym)
+    end
+
+    # Aggregate all capabilities (role-based + key-derived) into a Set.
+    def self.capabilities_for(user)
+      caps = Set.new(permissions_for(user))
+
+      caps << :approve_referrals if can_approve_chs?(user)
+      caps << :deny_referrals if can_approve_chs?(user)
+      caps << :process_claims if can_process_chs?(user)
+      caps << :verify_eligibility if can_verify_eligibility?(user)
+      caps << :manage_consults if can_manage_consults?(user)
+      caps << :manage_scheduling if can_manage_scheduling?(user)
+      caps << :access_behavioral_health if can_access_behavioral_health?(user)
+      caps << :access_dental if can_access_dental?(user)
+
+      caps
+    end
+
+    def self.has_key?(user, key_symbol)
+      Array(user.security_keys).include?(key_symbol)
+    end
+
+    def self.has_any_key?(user, *key_symbols)
+      keys = Array(user.security_keys)
+      key_symbols.any? { |k| keys.include?(k) }
+    end
+  end
+end

--- a/lib/rpms_rpc/mock_client.rb
+++ b/lib/rpms_rpc/mock_client.rb
@@ -52,13 +52,74 @@ module RpmsRpc
       @scalars[mapping.rpc_name][key.to_s] = formatted
     end
 
+    # Seed a line-based response for a mapping (e.g., XUS AV CODE).
+    # attrs is a hash matching the mapping's line_fields; stored as an array of lines.
+    def seed_lines(mapping_name, key, attrs)
+      mapping = DataMapper[mapping_name]
+      line_fields = mapping.instance_variable_get(:@line_fields) || []
+      max_line = line_fields.map(&:position).max || 0
+      lines = Array.new(max_line + 1, "")
+      line_fields.each do |f|
+        val = attrs[f.attribute]
+        lines[f.position] = val.nil? ? "" : val.to_s
+      end
+      @lines ||= {}
+      @lines[mapping.rpc_name] ||= {}
+      @lines[mapping.rpc_name][key.to_s] = lines
+    end
+
+    # Seed a keyed collection — different keys return different result sets.
+    # Unlike seed_collection (one set for all keys), this stores per-key arrays.
+    def seed_keyed_collection(mapping_name, key, attrs_list)
+      mapping = DataMapper[mapping_name]
+      formatted = mapping.format_many(attrs_list)
+      @keyed_collections ||= {}
+      @keyed_collections[mapping.rpc_name] ||= {}
+      @keyed_collections[mapping.rpc_name][key.to_s] = formatted
+    end
+
+    # Seed a complete user for authentication testing.
+    # Handles all the RPMS-specific mapping internally — callers use domain terms only.
+    #
+    #   m.seed_user("301",
+    #     credentials: "testprovider;test123",
+    #     name: "PROVIDER,TEST",
+    #     role: :provider,
+    #     security_keys: [:prc_supervisor, :cprs_gui_chart])
+    #
+    def seed_user(duz, credentials:, name:, role:, security_keys: [])
+      require_relative "security_keys"
+      require_relative "user_roles"
+
+      # Credential response
+      seed_lines(:av_code, credentials, { duz: duz.to_i, greeting: "Welcome #{name}", tries: 3 })
+
+      # User info
+      seed(:user_info, duz.to_s, UserRoles.mock_user_info(duz: duz, name: name, role: role))
+
+      # Security keys (symbolic → RPMS strings)
+      rpms_keys = security_keys.filter_map { |sym| SecurityKeys.rpms_name(sym) }
+      key_attrs = rpms_keys.map { |k| { key_name: k } }
+      seed_keyed_collection(:user_keys, duz.to_s, key_attrs)
+    end
+
     # Simulate call_rpc — returns formatted response matching the seeded data.
     def call_rpc(rpc_name, *params)
       key = params.first.to_s
 
+      # Line-based responses (keyed by first param)
+      if @lines&.dig(rpc_name, key)
+        return @lines[rpc_name][key]
+      end
+
       # Single records (keyed by first param)
       if @records.dig(rpc_name, key)
         return [ @records[rpc_name][key] ]
+      end
+
+      # Keyed collections (keyed by first param)
+      if @keyed_collections&.dig(rpc_name, key)
+        return @keyed_collections[rpc_name][key]
       end
 
       # Collections (optionally filtered by first param)

--- a/lib/rpms_rpc/security_keys.rb
+++ b/lib/rpms_rpc/security_keys.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module RpmsRpc
+  module SecurityKeys
+    REGISTRY = {
+      # PRC/CHS
+      prc_supervisor: "PRCFA SUPERVISOR",
+      prc_tech: "PRCFA TECH",
+      prc_manager: "BPRC MANAGER",
+      chs_approve: "BGOZ CHS APPROVE",
+      chs_clerk: "BGOZ CHS CLERK",
+
+      # Clinical
+      consult_manager: "GMRC MGR",
+      eligibility_verify: "APCL VERIFY",
+      scheduling_admin: "SD SUPERVISOR",
+
+      # Behavioral Health (42 CFR Part 2)
+      bh_provider: "BGMH PROVIDER",
+      bh_supervisor: "BGMH SUPERVISOR",
+
+      # Dental
+      dental_provider: "DENTP PROVIDER",
+      dental_supervisor: "DENTP SUPERVISOR",
+
+      # CPRS
+      cprs_gui_chart: "OR CPRS GUI CHART"
+    }.freeze
+
+    REVERSE = REGISTRY.invert.freeze
+
+    # Resolve raw RPMS key strings to symbols, ignoring unknown keys.
+    def self.symbolize(key_strings)
+      Array(key_strings).filter_map { |s| REVERSE[s] }
+    end
+
+    # Resolve a symbol to its RPMS key string.
+    def self.rpms_name(symbol)
+      REGISTRY[symbol]
+    end
+  end
+end

--- a/lib/rpms_rpc/user_roles.rb
+++ b/lib/rpms_rpc/user_roles.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module RpmsRpc
+  module UserRoles
+    USER_CLASS_MAP = {
+      "1" => "admin",
+      "3" => "provider",
+      "4" => "nurse",
+      "5" => "clerk"
+    }.freeze
+
+    REVERSE_CLASS_MAP = USER_CLASS_MAP.invert.freeze
+
+    # Resolve a VistA user class number to a role string.
+    def self.for_class(user_class)
+      USER_CLASS_MAP[user_class.to_s] || "user"
+    end
+
+    # Return the user_class string for a role (e.g., "provider" → "3").
+    def self.class_for(role)
+      REVERSE_CLASS_MAP[role.to_s]
+    end
+
+    # Return mock-friendly user_info attrs for a role.
+    def self.mock_user_info(duz:, name:, role:)
+      is_provider = (role.to_s == "provider")
+      user_class = class_for(role) || "0"
+      { duz: duz.to_i, name: name, user_class: user_class,
+        can_sign: is_provider, is_provider: is_provider, order_role: is_provider ? "1" : "" }
+    end
+
+    # Determine role from user info and security keys.
+    # Security keys can elevate a role (e.g., PRCFA SUPERVISOR → case_manager).
+    def self.resolve(user_info:, security_keys:)
+      return "provider" if user_info&.dig(:is_provider)
+
+      if security_keys.include?(:prc_supervisor) || security_keys.include?(:prc_manager)
+        return "case_manager"
+      end
+
+      for_class(user_info&.dig(:user_class))
+    end
+  end
+end

--- a/lib/rpms_rpc/version.rb
+++ b/lib/rpms_rpc/version.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require_relative "security_keys"
+require_relative "user_roles"
+require_relative "capabilities"
+
 module RpmsRpc
   VERSION = "0.1.0"
 

--- a/test/rpms_rpc/capabilities_test.rb
+++ b/test/rpms_rpc/capabilities_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "set"
+require_relative "../../lib/rpms_rpc/capabilities"
+
+class RpmsRpc::CapabilitiesTest < Minitest::Test
+  User = Struct.new(:user_type, :security_keys, keyword_init: true)
+
+  def test_can_approve_chs_with_supervisor_key
+    user = User.new(user_type: "case_manager", security_keys: [:prc_supervisor])
+    assert RpmsRpc::Capabilities.can_approve_chs?(user)
+  end
+
+  def test_can_approve_chs_with_manager_key
+    user = User.new(user_type: "case_manager", security_keys: [:prc_manager])
+    assert RpmsRpc::Capabilities.can_approve_chs?(user)
+  end
+
+  def test_cannot_approve_chs_without_keys
+    user = User.new(user_type: "clerk", security_keys: [])
+    refute RpmsRpc::Capabilities.can_approve_chs?(user)
+  end
+
+  def test_can_process_chs
+    user = User.new(user_type: "clerk", security_keys: [:prc_tech])
+    assert RpmsRpc::Capabilities.can_process_chs?(user)
+  end
+
+  def test_can_manage_consults
+    user = User.new(user_type: "nurse", security_keys: [:consult_manager])
+    assert RpmsRpc::Capabilities.can_manage_consults?(user)
+  end
+
+  def test_cannot_manage_consults_without_key
+    user = User.new(user_type: "nurse", security_keys: [])
+    refute RpmsRpc::Capabilities.can_manage_consults?(user)
+  end
+
+  def test_can_access_behavioral_health
+    user = User.new(user_type: "provider", security_keys: [:bh_provider])
+    assert RpmsRpc::Capabilities.can_access_behavioral_health?(user)
+  end
+
+  def test_can_access_dental
+    user = User.new(user_type: "provider", security_keys: [:dental_supervisor])
+    assert RpmsRpc::Capabilities.can_access_dental?(user)
+  end
+
+  def test_role_permissions_for_provider
+    user = User.new(user_type: "provider", security_keys: [])
+    perms = RpmsRpc::Capabilities.permissions_for(user)
+    assert_includes perms, :view_patients
+    assert_includes perms, :create_referrals
+    refute_includes perms, :approve_referrals
+  end
+
+  def test_role_permissions_for_nurse
+    user = User.new(user_type: "nurse", security_keys: [])
+    perms = RpmsRpc::Capabilities.permissions_for(user)
+    assert_includes perms, :view_patients
+    assert_includes perms, :update_referral_status
+    refute_includes perms, :create_referrals
+  end
+
+  def test_role_permissions_for_clerk
+    user = User.new(user_type: "clerk", security_keys: [])
+    perms = RpmsRpc::Capabilities.permissions_for(user)
+    assert_includes perms, :view_patients
+    refute_includes perms, :create_referrals
+    refute_includes perms, :approve_referrals
+  end
+
+  def test_can_check
+    user = User.new(user_type: "provider", security_keys: [])
+    assert RpmsRpc::Capabilities.can?(user, :view_patients)
+    refute RpmsRpc::Capabilities.can?(user, :approve_referrals)
+  end
+
+  def test_capabilities_for_merges_role_and_keys
+    user = User.new(user_type: "clerk", security_keys: [:prc_tech])
+    caps = RpmsRpc::Capabilities.capabilities_for(user)
+    assert_includes caps, :view_patients       # from role
+    assert_includes caps, :process_claims      # from key
+    refute_includes caps, :create_referrals    # not in clerk role
+  end
+
+  def test_capabilities_for_case_manager_with_supervisor
+    user = User.new(user_type: "case_manager", security_keys: [:prc_supervisor])
+    caps = RpmsRpc::Capabilities.capabilities_for(user)
+    assert_includes caps, :manage_referrals     # from role
+    assert_includes caps, :approve_referrals    # from role + key
+    assert_includes caps, :process_claims       # from key
+  end
+
+  def test_unknown_role_defaults_to_user
+    user = User.new(user_type: "unknown", security_keys: [])
+    perms = RpmsRpc::Capabilities.permissions_for(user)
+    assert_equal [:view_own_referrals], perms
+  end
+end

--- a/test/rpms_rpc/security_keys_test.rb
+++ b/test/rpms_rpc/security_keys_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require_relative "../../lib/rpms_rpc/security_keys"
+
+class RpmsRpc::SecurityKeysTest < Minitest::Test
+  def test_symbolize_known_keys
+    result = RpmsRpc::SecurityKeys.symbolize(["PRCFA SUPERVISOR", "GMRC MGR"])
+    assert_equal [:prc_supervisor, :consult_manager], result
+  end
+
+  def test_symbolize_ignores_unknown_keys
+    result = RpmsRpc::SecurityKeys.symbolize(["PRCFA SUPERVISOR", "UNKNOWN KEY", "OR CPRS GUI CHART"])
+    assert_equal [:prc_supervisor, :cprs_gui_chart], result
+  end
+
+  def test_symbolize_empty
+    assert_equal [], RpmsRpc::SecurityKeys.symbolize([])
+  end
+
+  def test_symbolize_nil
+    assert_equal [], RpmsRpc::SecurityKeys.symbolize(nil)
+  end
+
+  def test_rpms_name
+    assert_equal "PRCFA SUPERVISOR", RpmsRpc::SecurityKeys.rpms_name(:prc_supervisor)
+    assert_equal "GMRC MGR", RpmsRpc::SecurityKeys.rpms_name(:consult_manager)
+    assert_nil RpmsRpc::SecurityKeys.rpms_name(:nonexistent)
+  end
+
+  def test_registry_is_frozen
+    assert RpmsRpc::SecurityKeys::REGISTRY.frozen?
+  end
+end

--- a/test/rpms_rpc/user_roles_test.rb
+++ b/test/rpms_rpc/user_roles_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require_relative "../../lib/rpms_rpc/user_roles"
+
+class RpmsRpc::UserRolesTest < Minitest::Test
+  def test_for_class_maps_known_classes
+    assert_equal "provider", RpmsRpc::UserRoles.for_class("3")
+    assert_equal "nurse", RpmsRpc::UserRoles.for_class("4")
+    assert_equal "clerk", RpmsRpc::UserRoles.for_class("5")
+    assert_equal "admin", RpmsRpc::UserRoles.for_class("1")
+  end
+
+  def test_for_class_defaults_to_user
+    assert_equal "user", RpmsRpc::UserRoles.for_class("99")
+    assert_equal "user", RpmsRpc::UserRoles.for_class("")
+  end
+
+  def test_for_class_accepts_integer
+    assert_equal "nurse", RpmsRpc::UserRoles.for_class(4)
+  end
+
+  def test_resolve_provider
+    assert_equal "provider", RpmsRpc::UserRoles.resolve(
+      user_info: { is_provider: true, user_class: "3" },
+      security_keys: []
+    )
+  end
+
+  def test_resolve_case_manager_from_keys
+    assert_equal "case_manager", RpmsRpc::UserRoles.resolve(
+      user_info: { is_provider: false, user_class: "3" },
+      security_keys: [:prc_supervisor]
+    )
+  end
+
+  def test_resolve_nurse_from_class
+    assert_equal "nurse", RpmsRpc::UserRoles.resolve(
+      user_info: { is_provider: false, user_class: "4" },
+      security_keys: []
+    )
+  end
+
+  def test_resolve_defaults_to_user
+    assert_equal "user", RpmsRpc::UserRoles.resolve(
+      user_info: nil,
+      security_keys: []
+    )
+  end
+end


### PR DESCRIPTION
## Summary

- `SecurityKeys`: RPMS key name registry with symbolize/resolve — maps symbolic names (`:prc_supervisor`) to RPMS strings (`"PRCFA SUPERVISOR"`)
- `UserRoles`: VistA user class mapping and role resolution — maps class numbers to role strings, resolves role from user info + security keys
- `Capabilities`: Framework-agnostic capability checks derived from RPMS security keys and roles — consumed by authorization policies in any engine (Pundit, Action Policy, etc.)
- `MockClient#seed_user`: Domain-level auth seeding that hides all RPMS wire format details from consumers
- `MockClient#seed_lines` and `seed_keyed_collection`: Support for line-based RPCs and per-key collections

## Test plan

- [x] 249 tests pass (30 new across SecurityKeys, UserRoles, Capabilities)
- [x] Existing mock client tests unaffected
- [x] Verified downstream in lakeraven-ehr: 531 minitest + 129 cucumber scenarios pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)