### PR TITLE
Add FhirClient and MockFhirClient for FHIR R4 reads

### DIFF
--- a/lib/rpms_rpc/fhir_client.rb
+++ b/lib/rpms_rpc/fhir_client.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module RpmsRpc
+  # FHIR client interface for reading RPMS data via FHIR R4 API.
+  # In production, this wraps HTTP calls to an IRIS for Health FHIR endpoint.
+  # In test, MockFhirClient returns FHIR-shaped JSON from seeded data.
+  #
+  #   # Search
+  #   RpmsRpc.fhir_client.search("Patient", name: "Anderson")
+  #   # => { "resourceType" => "Bundle", "type" => "searchset", ... }
+  #
+  #   # Read
+  #   RpmsRpc.fhir_client.read("Patient", "1")
+  #   # => { "resourceType" => "Patient", "id" => "1", ... }
+  #
+  class FhirClient
+    attr_reader :base_url
+
+    def initialize(base_url:)
+      @base_url = base_url
+    end
+
+    def search(resource_type, params = {})
+      query = params.map { |k, v| "#{k}=#{v}" }.join("&")
+      url = "#{@base_url}/#{resource_type}?#{query}"
+      response = Net::HTTP.get(URI(url))
+      JSON.parse(response)
+    end
+
+    def read(resource_type, id)
+      url = "#{@base_url}/#{resource_type}/#{id}"
+      response = Net::HTTP.get(URI(url))
+      JSON.parse(response)
+    end
+  end
+end

--- a/lib/rpms_rpc/mock_fhir_client.rb
+++ b/lib/rpms_rpc/mock_fhir_client.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+module RpmsRpc
+  # Mock FHIR client for testing. Reads from the same seed data as MockClient
+  # and returns FHIR R4-shaped hashes. No HTTP, no external dependencies.
+  #
+  # Consumers seed FHIR resources directly:
+  #
+  #   RpmsRpc.mock_fhir! do |f|
+  #     f.seed_resource("Patient", "1", {
+  #       resourceType: "Patient", id: "1",
+  #       name: [{ family: "Anderson", given: ["Alice"] }],
+  #       gender: "female", birthDate: "1980-05-15"
+  #     })
+  #   end
+  #
+  #   RpmsRpc.fhir_client.read("Patient", "1")
+  #   RpmsRpc.fhir_client.search("Patient", name: "Anderson")
+  #
+  class MockFhirClient
+    def initialize
+      @resources = {} # { "Patient" => { "1" => { resourceType: "Patient", ... } } }
+    end
+
+    # Seed a single FHIR resource.
+    def seed_resource(resource_type, id, resource_hash)
+      @resources[resource_type] ||= {}
+      @resources[resource_type][id.to_s] = resource_hash.is_a?(Hash) ? resource_hash : resource_hash.to_h
+    end
+
+    # Read a single resource by type and ID.
+    def read(resource_type, id)
+      resource = @resources.dig(resource_type, id.to_s)
+      return operation_outcome("not-found", "#{resource_type}/#{id} not found") unless resource
+
+      stringify_keys_deep(resource)
+    end
+
+    # Search resources by type and params.
+    # Supports: name (prefix match on family/given), identifier, patient, _id
+    def search(resource_type, params = {})
+      candidates = @resources[resource_type]&.values || []
+      results = filter(candidates, params)
+      bundle(results)
+    end
+
+    private
+
+    def filter(resources, params)
+      resources.select do |r|
+        params.all? { |key, value| matches?(r, key.to_s, value.to_s) }
+      end
+    end
+
+    def matches?(resource, key, value)
+      case key
+      when "name"
+        match_name(resource, value)
+      when "identifier"
+        match_identifier(resource, value)
+      when "patient"
+        match_patient(resource, value)
+      when "_id"
+        resource[:id].to_s == value || resource["id"].to_s == value
+      when "gender"
+        (resource[:gender] || resource["gender"]).to_s == value
+      when "birthdate"
+        (resource[:birthDate] || resource["birthDate"]).to_s == value
+      else
+        true # unknown params don't filter
+      end
+    end
+
+    def match_name(resource, value)
+      names = resource[:name] || resource["name"] || []
+      names.any? do |n|
+        family = (n[:family] || n["family"]).to_s
+        given = Array(n[:given] || n["given"]).join(" ")
+        full = "#{family} #{given}"
+        full.upcase.include?(value.upcase) || family.upcase.start_with?(value.upcase)
+      end
+    end
+
+    def match_identifier(resource, value)
+      identifiers = resource[:identifier] || resource["identifier"] || []
+      identifiers.any? { |i| (i[:value] || i["value"]).to_s == value }
+    end
+
+    def match_patient(resource, value)
+      subject = resource[:subject] || resource["subject"] || {}
+      ref = (subject[:reference] || subject["reference"]).to_s
+      ref == "Patient/#{value}" || ref == value
+    end
+
+    def bundle(entries)
+      {
+        "resourceType" => "Bundle",
+        "type" => "searchset",
+        "total" => entries.length,
+        "entry" => entries.map { |e| { "resource" => stringify_keys_deep(e) } }
+      }
+    end
+
+    def operation_outcome(code, message)
+      {
+        "resourceType" => "OperationOutcome",
+        "issue" => [{ "severity" => "error", "code" => code, "diagnostics" => message }]
+      }
+    end
+
+    def stringify_keys_deep(obj)
+      case obj
+      when Hash then obj.transform_keys(&:to_s).transform_values { |v| stringify_keys_deep(v) }
+      when Array then obj.map { |v| stringify_keys_deep(v) }
+      else obj
+      end
+    end
+  end
+end

--- a/lib/rpms_rpc/version.rb
+++ b/lib/rpms_rpc/version.rb
@@ -10,7 +10,7 @@ module RpmsRpc
   class NotConfiguredError < StandardError; end
 
   class Configuration
-    attr_accessor :client
+    attr_accessor :client, :fhir_client
   end
 
   class << self
@@ -30,6 +30,14 @@ module RpmsRpc
       )
     end
 
+    def fhir_client
+      configuration.fhir_client || raise(
+        NotConfiguredError,
+        "RpmsRpc.fhir_client is not configured. Call RpmsRpc.configure { |c| c.fhir_client = ... } " \
+        "or RpmsRpc.mock_fhir! for testing."
+      )
+    end
+
     def reset!
       @configuration = Configuration.new
     end
@@ -40,6 +48,16 @@ module RpmsRpc
       require_relative "mock_client"
       mock = MockClient.new
       configure { |c| c.client = mock }
+      yield(mock) if block_given?
+      mock
+    end
+
+    # Convenience: configure a MockFhirClient for testing.
+    # Optionally accepts a block for seeding FHIR resources.
+    def mock_fhir!
+      require_relative "mock_fhir_client"
+      mock = MockFhirClient.new
+      configure { |c| c.fhir_client = mock }
       yield(mock) if block_given?
       mock
     end

--- a/test/rpms_rpc/mock_fhir_client_test.rb
+++ b/test/rpms_rpc/mock_fhir_client_test.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require_relative "../../lib/rpms_rpc/mock_fhir_client"
+
+class RpmsRpc::MockFhirClientTest < Minitest::Test
+  def setup
+    @client = RpmsRpc::MockFhirClient.new
+
+    @client.seed_resource("Patient", "1", {
+      resourceType: "Patient", id: "1",
+      name: [{ family: "Anderson", given: ["Alice"] }],
+      gender: "female", birthDate: "1980-05-15",
+      identifier: [
+        { system: "urn:oid:2.16.840.1.113883.4.349", value: "1" },
+        { system: "http://hl7.org/fhir/sid/us-ssn", value: "111-11-1111" }
+      ]
+    })
+
+    @client.seed_resource("Patient", "2", {
+      resourceType: "Patient", id: "2",
+      name: [{ family: "Mouse", given: ["Mickey", "M"] }],
+      gender: "male", birthDate: "2010-02-14"
+    })
+
+    @client.seed_resource("Patient", "3", {
+      resourceType: "Patient", id: "3",
+      name: [{ family: "Doe", given: ["Jane"] }],
+      gender: "female", birthDate: "1990-12-25"
+    })
+
+    @client.seed_resource("Observation", "101", {
+      resourceType: "Observation", id: "101",
+      subject: { reference: "Patient/1" },
+      code: { text: "Blood Pressure" },
+      valueQuantity: { value: 120, unit: "mmHg" }
+    })
+  end
+
+  # -- read -------------------------------------------------------------------
+
+  def test_read_existing_resource
+    result = @client.read("Patient", "1")
+    assert_equal "Patient", result["resourceType"]
+    assert_equal "1", result["id"]
+    assert_equal "Anderson", result.dig("name", 0, "family")
+  end
+
+  def test_read_nonexistent_resource
+    result = @client.read("Patient", "999")
+    assert_equal "OperationOutcome", result["resourceType"]
+    assert_equal "not-found", result.dig("issue", 0, "code")
+  end
+
+  def test_read_nonexistent_type
+    result = @client.read("Encounter", "1")
+    assert_equal "OperationOutcome", result["resourceType"]
+  end
+
+  # -- search by name ---------------------------------------------------------
+
+  def test_search_by_name_family
+    result = @client.search("Patient", name: "Anderson")
+    assert_equal "Bundle", result["resourceType"]
+    assert_equal 1, result["total"]
+    assert_equal "1", result.dig("entry", 0, "resource", "id")
+  end
+
+  def test_search_by_name_partial
+    result = @client.search("Patient", name: "And")
+    assert_equal 1, result["total"]
+  end
+
+  def test_search_by_name_case_insensitive
+    result = @client.search("Patient", name: "anderson")
+    assert_equal 1, result["total"]
+  end
+
+  def test_search_by_name_no_match
+    result = @client.search("Patient", name: "Nonexistent")
+    assert_equal 0, result["total"]
+    assert_empty result["entry"]
+  end
+
+  # -- search by identifier ---------------------------------------------------
+
+  def test_search_by_identifier
+    result = @client.search("Patient", identifier: "111-11-1111")
+    assert_equal 1, result["total"]
+    assert_equal "1", result.dig("entry", 0, "resource", "id")
+  end
+
+  # -- search by _id ----------------------------------------------------------
+
+  def test_search_by_id
+    result = @client.search("Patient", _id: "2")
+    assert_equal 1, result["total"]
+    assert_equal "2", result.dig("entry", 0, "resource", "id")
+  end
+
+  # -- search by patient (for clinical resources) -----------------------------
+
+  def test_search_by_patient_reference
+    result = @client.search("Observation", patient: "1")
+    assert_equal 1, result["total"]
+    assert_equal "Blood Pressure", result.dig("entry", 0, "resource", "code", "text")
+  end
+
+  def test_search_by_patient_no_match
+    result = @client.search("Observation", patient: "999")
+    assert_equal 0, result["total"]
+  end
+
+  # -- search with no params (return all) -------------------------------------
+
+  def test_search_all
+    result = @client.search("Patient")
+    assert_equal 3, result["total"]
+  end
+
+  # -- search nonexistent type ------------------------------------------------
+
+  def test_search_empty_type
+    result = @client.search("Encounter")
+    assert_equal 0, result["total"]
+  end
+
+  # -- search with multiple params --------------------------------------------
+
+  def test_search_multiple_params
+    result = @client.search("Patient", name: "Anderson", gender: "female")
+    assert_equal 1, result["total"]
+  end
+
+  def test_search_multiple_params_no_match
+    result = @client.search("Patient", name: "Anderson", gender: "male")
+    assert_equal 0, result["total"]
+  end
+
+  # -- bundle format ----------------------------------------------------------
+
+  def test_bundle_format
+    result = @client.search("Patient", name: "Anderson")
+    assert_equal "Bundle", result["resourceType"]
+    assert_equal "searchset", result["type"]
+    assert_equal 1, result["total"]
+    assert_kind_of Array, result["entry"]
+    assert result.dig("entry", 0, "resource")
+  end
+
+  # -- string keys in output --------------------------------------------------
+
+  def test_output_uses_string_keys
+    result = @client.read("Patient", "1")
+    assert result.key?("resourceType"), "Expected string keys in output"
+    refute result.key?(:resourceType), "Expected no symbol keys in output"
+  end
+end


### PR DESCRIPTION
## Summary

- `FhirClient`: production HTTP client for IRIS for Health FHIR endpoint (read + search)
- `MockFhirClient`: test double seeded with FHIR resource hashes — supports `read` and `search` by name, identifier, patient reference, `_id`, gender
- `RpmsRpc.fhir_client` accessor and `RpmsRpc.mock_fhir!` convenience method mirror the existing RPC client/mock pattern
- `Configuration` gains `fhir_client` attribute

## Test plan

- [x] 266 tests pass (17 new MockFhirClient tests)
- [x] Existing RPC mock/client tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)