### PR TITLE
MockClient: text_blob and scalar auto-detection (+7 tests)

### DIFF
--- a/lib/rpms_rpc/data_mapper.rb
+++ b/lib/rpms_rpc/data_mapper.rb
@@ -73,6 +73,14 @@ module RpmsRpc
         @text_attribute = attribute
       end
 
+      def text_blob?
+        !@text_attribute.nil?
+      end
+
+      def scalar?
+        !@scalar_attribute.nil?
+      end
+
       # Parse a single-line RPC response into a hash.
       def parse_one(response, extras: {})
         line = normalize_line(response)

--- a/lib/rpms_rpc/mock_client.rb
+++ b/lib/rpms_rpc/mock_client.rb
@@ -22,11 +22,28 @@ module RpmsRpc
     end
 
     # Seed a single record for a mapping.
+    # Auto-detects mapping type: text_blob stores raw text,
+    # scalar stores formatted scalar, field-based formats to caret-delimited.
     def seed(mapping_name, key, attrs)
       mapping = DataMapper[mapping_name]
-      formatted = mapping.format_one(attrs)
-      @records[mapping.rpc_name] ||= {}
-      @records[mapping.rpc_name][key.to_s] = formatted
+
+      if mapping.text_blob? && attrs.is_a?(String)
+        seed_text(mapping_name, key, attrs)
+      elsif mapping.scalar?
+        seed_scalar(mapping_name, key, attrs.is_a?(Hash) ? attrs.values.first : attrs)
+      else
+        formatted = mapping.format_one(attrs)
+        @records[mapping.rpc_name] ||= {}
+        @records[mapping.rpc_name][key.to_s] = formatted
+      end
+    end
+
+    # Seed raw text for a text_blob mapping.
+    def seed_text(mapping_name, key, text)
+      mapping = DataMapper[mapping_name]
+      @text_blobs ||= {}
+      @text_blobs[mapping.rpc_name] ||= {}
+      @text_blobs[mapping.rpc_name][key.to_s] = text
     end
 
     # Seed a collection (search results) for a mapping.
@@ -110,6 +127,12 @@ module RpmsRpc
       # Line-based responses (keyed by first param)
       if @lines&.dig(rpc_name, key)
         return @lines[rpc_name][key]
+      end
+
+      # Text blob responses (keyed by first param)
+      if @text_blobs&.dig(rpc_name, key)
+        text = @text_blobs[rpc_name][key]
+        return text.include?("\n") ? text.split("\n") : text
       end
 
       # Single records (keyed by first param)

--- a/lib/rpms_rpc/mock_fhir_client.rb
+++ b/lib/rpms_rpc/mock_fhir_client.rb
@@ -104,7 +104,7 @@ module RpmsRpc
     def operation_outcome(code, message)
       {
         "resourceType" => "OperationOutcome",
-        "issue" => [{ "severity" => "error", "code" => code, "diagnostics" => message }]
+        "issue" => [ { "severity" => "error", "code" => code, "diagnostics" => message } ]
       }
     end
 

--- a/test/rpms_rpc/capabilities_test.rb
+++ b/test/rpms_rpc/capabilities_test.rb
@@ -8,12 +8,12 @@ class RpmsRpc::CapabilitiesTest < Minitest::Test
   User = Struct.new(:user_type, :security_keys, keyword_init: true)
 
   def test_can_approve_chs_with_supervisor_key
-    user = User.new(user_type: "case_manager", security_keys: [:prc_supervisor])
+    user = User.new(user_type: "case_manager", security_keys: [ :prc_supervisor ])
     assert RpmsRpc::Capabilities.can_approve_chs?(user)
   end
 
   def test_can_approve_chs_with_manager_key
-    user = User.new(user_type: "case_manager", security_keys: [:prc_manager])
+    user = User.new(user_type: "case_manager", security_keys: [ :prc_manager ])
     assert RpmsRpc::Capabilities.can_approve_chs?(user)
   end
 
@@ -23,12 +23,12 @@ class RpmsRpc::CapabilitiesTest < Minitest::Test
   end
 
   def test_can_process_chs
-    user = User.new(user_type: "clerk", security_keys: [:prc_tech])
+    user = User.new(user_type: "clerk", security_keys: [ :prc_tech ])
     assert RpmsRpc::Capabilities.can_process_chs?(user)
   end
 
   def test_can_manage_consults
-    user = User.new(user_type: "nurse", security_keys: [:consult_manager])
+    user = User.new(user_type: "nurse", security_keys: [ :consult_manager ])
     assert RpmsRpc::Capabilities.can_manage_consults?(user)
   end
 
@@ -38,12 +38,12 @@ class RpmsRpc::CapabilitiesTest < Minitest::Test
   end
 
   def test_can_access_behavioral_health
-    user = User.new(user_type: "provider", security_keys: [:bh_provider])
+    user = User.new(user_type: "provider", security_keys: [ :bh_provider ])
     assert RpmsRpc::Capabilities.can_access_behavioral_health?(user)
   end
 
   def test_can_access_dental
-    user = User.new(user_type: "provider", security_keys: [:dental_supervisor])
+    user = User.new(user_type: "provider", security_keys: [ :dental_supervisor ])
     assert RpmsRpc::Capabilities.can_access_dental?(user)
   end
 
@@ -78,7 +78,7 @@ class RpmsRpc::CapabilitiesTest < Minitest::Test
   end
 
   def test_capabilities_for_merges_role_and_keys
-    user = User.new(user_type: "clerk", security_keys: [:prc_tech])
+    user = User.new(user_type: "clerk", security_keys: [ :prc_tech ])
     caps = RpmsRpc::Capabilities.capabilities_for(user)
     assert_includes caps, :view_patients       # from role
     assert_includes caps, :process_claims      # from key
@@ -86,7 +86,7 @@ class RpmsRpc::CapabilitiesTest < Minitest::Test
   end
 
   def test_capabilities_for_case_manager_with_supervisor
-    user = User.new(user_type: "case_manager", security_keys: [:prc_supervisor])
+    user = User.new(user_type: "case_manager", security_keys: [ :prc_supervisor ])
     caps = RpmsRpc::Capabilities.capabilities_for(user)
     assert_includes caps, :manage_referrals     # from role
     assert_includes caps, :approve_referrals    # from role + key
@@ -96,6 +96,6 @@ class RpmsRpc::CapabilitiesTest < Minitest::Test
   def test_unknown_role_defaults_to_user
     user = User.new(user_type: "unknown", security_keys: [])
     perms = RpmsRpc::Capabilities.permissions_for(user)
-    assert_equal [:view_own_referrals], perms
+    assert_equal [ :view_own_referrals ], perms
   end
 end

--- a/test/rpms_rpc/mock_client_test.rb
+++ b/test/rpms_rpc/mock_client_test.rb
@@ -119,4 +119,74 @@ class RpmsRpc::MockClientTest < Minitest::Test
     assert_equal "DOE,JOHN", p1[:name]
     assert_equal "SMITH,JANE", p2[:name]
   end
+
+  # -- text_blob support -------------------------------------------------------
+
+  def test_seed_text_blob_and_fetch_text
+    RpmsRpc.mock! do |m|
+      m.seed(:section_data, "1", "Header\nName: DOE,JOHN\nDOB: 01/15/1980")
+    end
+
+    text = RpmsRpc::DataMapper.section_data.fetch_text("1")
+    assert_includes text, "DOE,JOHN"
+    assert_includes text, "Header"
+  end
+
+  def test_seed_text_blob_returns_nil_for_unknown_key
+    RpmsRpc.mock! do |m|
+      m.seed(:section_data, "1", "some text")
+    end
+
+    assert_nil RpmsRpc::DataMapper.section_data.fetch_text("999")
+  end
+
+  def test_seed_text_blob_with_multiline_content
+    content = "ALLERGIES:\n  Penicillin - Hives\n  Shellfish - Anaphylaxis\n\nMEDICATIONS:\n  Lisinopril 10mg"
+    RpmsRpc.mock! do |m|
+      m.seed(:health_summary_report, "1", content)
+    end
+
+    text = RpmsRpc::DataMapper.health_summary_report.fetch_text("1")
+    assert_includes text, "Penicillin"
+    assert_includes text, "Lisinopril"
+  end
+
+  def test_seed_section_definition_text_blob
+    RpmsRpc.mock! do |m|
+      m.seed(:section_definition, "Header", "1^name^string\n2^dob^date")
+    end
+
+    text = RpmsRpc::DataMapper.section_definition.fetch_text("Header")
+    assert_includes text, "name"
+    assert_includes text, "dob"
+  end
+
+  # -- smart seed auto-detection -----------------------------------------------
+
+  def test_seed_auto_detects_text_blob_mapping_with_string
+    RpmsRpc.mock! do |m|
+      m.seed(:section_data, "1", "raw text content")
+    end
+
+    text = RpmsRpc::DataMapper.section_data.fetch_text("1")
+    assert_equal "raw text content", text
+  end
+
+  def test_seed_auto_detects_scalar_mapping_with_hash
+    RpmsRpc.mock! do |m|
+      m.seed(:section_save, "1", { success: true })
+    end
+
+    result = RpmsRpc::DataMapper.section_save.fetch_scalar("1")
+    assert_equal true, result
+  end
+
+  def test_seed_field_based_mapping_still_works
+    RpmsRpc.mock! do |m|
+      m.seed(:patient_select, "99", { name: "TEST,AUTO", sex: "F" })
+    end
+
+    p = RpmsRpc::DataMapper.patient_select.fetch_one("99")
+    assert_equal "TEST,AUTO", p[:name]
+  end
 end

--- a/test/rpms_rpc/mock_fhir_client_test.rb
+++ b/test/rpms_rpc/mock_fhir_client_test.rb
@@ -9,7 +9,7 @@ class RpmsRpc::MockFhirClientTest < Minitest::Test
 
     @client.seed_resource("Patient", "1", {
       resourceType: "Patient", id: "1",
-      name: [{ family: "Anderson", given: ["Alice"] }],
+      name: [ { family: "Anderson", given: [ "Alice" ] } ],
       gender: "female", birthDate: "1980-05-15",
       identifier: [
         { system: "urn:oid:2.16.840.1.113883.4.349", value: "1" },
@@ -19,13 +19,13 @@ class RpmsRpc::MockFhirClientTest < Minitest::Test
 
     @client.seed_resource("Patient", "2", {
       resourceType: "Patient", id: "2",
-      name: [{ family: "Mouse", given: ["Mickey", "M"] }],
+      name: [ { family: "Mouse", given: [ "Mickey", "M" ] } ],
       gender: "male", birthDate: "2010-02-14"
     })
 
     @client.seed_resource("Patient", "3", {
       resourceType: "Patient", id: "3",
-      name: [{ family: "Doe", given: ["Jane"] }],
+      name: [ { family: "Doe", given: [ "Jane" ] } ],
       gender: "female", birthDate: "1990-12-25"
     })
 

--- a/test/rpms_rpc/security_keys_test.rb
+++ b/test/rpms_rpc/security_keys_test.rb
@@ -5,13 +5,13 @@ require_relative "../../lib/rpms_rpc/security_keys"
 
 class RpmsRpc::SecurityKeysTest < Minitest::Test
   def test_symbolize_known_keys
-    result = RpmsRpc::SecurityKeys.symbolize(["PRCFA SUPERVISOR", "GMRC MGR"])
-    assert_equal [:prc_supervisor, :consult_manager], result
+    result = RpmsRpc::SecurityKeys.symbolize([ "PRCFA SUPERVISOR", "GMRC MGR" ])
+    assert_equal [ :prc_supervisor, :consult_manager ], result
   end
 
   def test_symbolize_ignores_unknown_keys
-    result = RpmsRpc::SecurityKeys.symbolize(["PRCFA SUPERVISOR", "UNKNOWN KEY", "OR CPRS GUI CHART"])
-    assert_equal [:prc_supervisor, :cprs_gui_chart], result
+    result = RpmsRpc::SecurityKeys.symbolize([ "PRCFA SUPERVISOR", "UNKNOWN KEY", "OR CPRS GUI CHART" ])
+    assert_equal [ :prc_supervisor, :cprs_gui_chart ], result
   end
 
   def test_symbolize_empty

--- a/test/rpms_rpc/user_roles_test.rb
+++ b/test/rpms_rpc/user_roles_test.rb
@@ -30,7 +30,7 @@ class RpmsRpc::UserRolesTest < Minitest::Test
   def test_resolve_case_manager_from_keys
     assert_equal "case_manager", RpmsRpc::UserRoles.resolve(
       user_info: { is_provider: false, user_class: "3" },
-      security_keys: [:prc_supervisor]
+      security_keys: [ :prc_supervisor ]
     )
   end
 


### PR DESCRIPTION
## Summary

`seed()` now auto-detects mapping type and routes to the correct storage:
- text_blob mappings + String data → `seed_text` (raw text storage)
- scalar mappings → `seed_scalar` (formatted scalar)
- field-based mappings → existing `format_one` (caret-delimited)

Adds `text_blob?` and `scalar?` predicates to Mapping. Adds `seed_text` for explicit text blob seeding.

Unblocks lakeraven-ehr#187 (210 gateway tests needing section_data, health_summary, etc.)

Closes #48

## Test plan

- [x] `bundle exec rake test` — 274 runs, 0 failures
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)