### PR TITLE
DataMapper++: terminology and pointer metadata on fields (+15 tests)

### DIFF
--- a/lib/rpms_rpc/data_mapper.rb
+++ b/lib/rpms_rpc/data_mapper.rb
@@ -27,7 +27,7 @@ module RpmsRpc
   #   # => [{ dfn: 1, name: "DOE,JOHN" }, { dfn: 2, name: "SMITH,JANE" }]
   #
   module DataMapper
-    Field = Struct.new(:position, :attribute, :type, keyword_init: true)
+    Field = Struct.new(:position, :attribute, :type, :terminology, :pointer, keyword_init: true)
 
     class Mapping
       attr_reader :name, :rpc_name, :fields
@@ -49,8 +49,9 @@ module RpmsRpc
         @rpc_name = name
       end
 
-      def field(position, attribute, type = :string)
-        @fields << Field.new(position: position, attribute: attribute, type: type)
+      def field(position, attribute, type = :string, terminology: nil, pointer: nil)
+        @fields << Field.new(position: position, attribute: attribute, type: type,
+                             terminology: terminology, pointer: pointer)
       end
 
       # Declare a line-based field (one field per response line, not per caret).
@@ -79,6 +80,14 @@ module RpmsRpc
 
       def scalar?
         !@scalar_attribute.nil?
+      end
+
+      def terminology_fields
+        @fields.select { |f| !f.terminology.nil? }
+      end
+
+      def pointer_fields
+        @fields.select { |f| !f.pointer.nil? }
       end
 
       # Parse a single-line RPC response into a hash.

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -91,10 +91,10 @@ module RpmsRpc
       m.field 0, :ien
       m.field 1, :status
       m.field 2, :description
-      m.field 3, :icd_code
+      m.field 3, :icd_code, :string, terminology: :icd10
       m.field 4, :onset_date,    :fileman_date
       m.field 5, :recorded_date, :fileman_date
-      m.field 6, :provider_duz
+      m.field 6, :provider_duz, :string, pointer: { file: 200 }
     end
 
     # ORQQVI VITALS — patient vitals (multi-line)
@@ -222,12 +222,12 @@ module RpmsRpc
     DataMapper.define(:medication_list) do |m|
       m.rpc "ORQQPS LIST"
       m.field 0, :ien
-      m.field 1, :drug_name
+      m.field 1, :drug_name, :string, terminology: :rxnorm, pointer: { file: 50 }
       m.field 2, :sig
       m.field 3, :status
       m.field 4, :last_fill,   :fileman_date
       m.field 5, :refills,     :integer
-      m.field 6, :provider
+      m.field 6, :provider, :string, pointer: { file: 200 }
     end
 
     # ORQQCP LIST — care plan list (multi-line)

--- a/test/rpms_rpc/data_mapper_metadata_test.rb
+++ b/test/rpms_rpc/data_mapper_metadata_test.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/data_mapper"
+require "rpms_rpc/mappings"
+
+# Tests for DataMapper++ terminology and pointer metadata on field definitions.
+class DataMapperMetadataTest < Minitest::Test
+  # =============================================================================
+  # FIELD METADATA DSL
+  # =============================================================================
+
+  def test_field_accepts_terminology_option
+    mapping = build_mapping do
+      rpc "TEST RPC"
+      field 0, :diagnosis, :string, terminology: :icd10
+    end
+
+    f = mapping.fields.first
+    assert_equal :icd10, f.terminology
+  end
+
+  def test_field_accepts_pointer_option
+    mapping = build_mapping do
+      rpc "TEST RPC"
+      field 0, :provider, :string, pointer: { file: 200 }
+    end
+
+    f = mapping.fields.first
+    assert_equal({ file: 200 }, f.pointer)
+  end
+
+  def test_field_accepts_both_terminology_and_pointer
+    mapping = build_mapping do
+      rpc "TEST RPC"
+      field 0, :diagnosis, :string, terminology: :icd10, pointer: { file: 80 }
+    end
+
+    f = mapping.fields.first
+    assert_equal :icd10, f.terminology
+    assert_equal({ file: 80 }, f.pointer)
+  end
+
+  def test_field_defaults_terminology_to_nil
+    mapping = build_mapping do
+      rpc "TEST RPC"
+      field 0, :name, :string
+    end
+
+    f = mapping.fields.first
+    assert_nil f.terminology
+  end
+
+  def test_field_defaults_pointer_to_nil
+    mapping = build_mapping do
+      rpc "TEST RPC"
+      field 0, :name, :string
+    end
+
+    f = mapping.fields.first
+    assert_nil f.pointer
+  end
+
+  # =============================================================================
+  # QUERY METHODS ON MAPPING
+  # =============================================================================
+
+  def test_terminology_fields_returns_only_fields_with_terminology
+    mapping = build_mapping do
+      rpc "TEST RPC"
+      field 0, :name, :string
+      field 1, :diagnosis, :string, terminology: :icd10
+      field 2, :status, :string
+      field 3, :lab_code, :string, terminology: :loinc
+    end
+
+    tf = mapping.terminology_fields
+    assert_equal 2, tf.length
+    assert_equal :diagnosis, tf[0].attribute
+    assert_equal :lab_code, tf[1].attribute
+  end
+
+  def test_pointer_fields_returns_only_fields_with_pointer
+    mapping = build_mapping do
+      rpc "TEST RPC"
+      field 0, :name, :string
+      field 1, :provider, :string, pointer: { file: 200 }
+      field 2, :facility, :string, pointer: { file: 4 }
+    end
+
+    pf = mapping.pointer_fields
+    assert_equal 2, pf.length
+    assert_equal :provider, pf[0].attribute
+    assert_equal 200, pf[0].pointer[:file]
+    assert_equal :facility, pf[1].attribute
+  end
+
+  def test_terminology_fields_returns_empty_when_none
+    mapping = build_mapping do
+      rpc "TEST RPC"
+      field 0, :name, :string
+    end
+
+    assert_empty mapping.terminology_fields
+  end
+
+  def test_pointer_fields_returns_empty_when_none
+    mapping = build_mapping do
+      rpc "TEST RPC"
+      field 0, :name, :string
+    end
+
+    assert_empty mapping.pointer_fields
+  end
+
+  # =============================================================================
+  # EXISTING BEHAVIOR PRESERVED
+  # =============================================================================
+
+  def test_field_with_metadata_still_parses_correctly
+    mapping = build_mapping do
+      rpc "TEST RPC"
+      field 0, :diagnosis, :string, terminology: :icd10, pointer: { file: 80 }
+      field 1, :status, :string
+    end
+
+    result = mapping.parse_one("E11.9^A")
+    assert_equal "E11.9", result[:diagnosis]
+    assert_equal "A", result[:status]
+  end
+
+  def test_field_with_metadata_still_formats_correctly
+    mapping = build_mapping do
+      rpc "TEST RPC"
+      field 0, :diagnosis, :string, terminology: :icd10
+      field 1, :status, :string
+    end
+
+    formatted = mapping.format_one({ diagnosis: "E11.9", status: "A" })
+    assert_equal "E11.9^A", formatted
+  end
+
+  # =============================================================================
+  # REAL MAPPINGS HAVE METADATA
+  # =============================================================================
+
+  def test_problem_list_has_terminology_on_icd_code
+    mapping = RpmsRpc::DataMapper[:problem_list]
+    tf = mapping.terminology_fields
+
+    assert tf.any? { |f| f.attribute == :icd_code && f.terminology == :icd10 },
+      "problem_list should have :icd10 terminology on :icd_code field"
+  end
+
+  def test_problem_list_has_pointer_on_provider_duz
+    mapping = RpmsRpc::DataMapper[:problem_list]
+    pf = mapping.pointer_fields
+
+    assert pf.any? { |f| f.attribute == :provider_duz && f.pointer[:file] == 200 },
+      "problem_list should have pointer to file 200 on :provider_duz field"
+  end
+
+  def test_medication_list_has_terminology
+    mapping = RpmsRpc::DataMapper[:medication_list]
+    tf = mapping.terminology_fields
+
+    assert tf.any? { |f| f.terminology == :rxnorm },
+      "medication_list should have :rxnorm terminology"
+  end
+
+  def test_allergy_list_is_queryable_for_terminology
+    mapping = RpmsRpc::DataMapper[:allergy_list]
+    assert mapping.terminology_fields.is_a?(Array)
+  end
+
+  private
+
+  def build_mapping(&block)
+    m = RpmsRpc::DataMapper::Mapping.new(:test_mapping)
+    m.configure(&block)
+    m
+  end
+end


### PR DESCRIPTION
## Summary

Phase 1 of domain model architecture (layer contract ratified 2026-05-01).

Extends DataMapper Field struct with `terminology:` and `pointer:` metadata. Additive — no behavioral change to parse/format. Enables terminology decorators and pointer resolution in Phase 2-3.

### Changes

- `Field` struct gains `terminology` and `pointer` members (default nil)
- `field` DSL accepts `terminology:` and `pointer:` keyword options
- `Mapping#terminology_fields` — returns fields with terminology metadata
- `Mapping#pointer_fields` — returns fields with pointer metadata
- `problem_list`: `:icd10` on `icd_code`, pointer to file 200 on `provider_duz`
- `medication_list`: `:rxnorm` on `drug_name`, pointer to file 50/200

### Architecture context

Per layer contract: DataMapper is Layer 1 (Data). This metadata enables Layer 2 (Access/Repositories) to build terminology decorators and resolve pointers without hardcoding field knowledge.

## Test plan

- [x] `bundle exec rake test` — 311 runs, 0 failures
- [x] `bundle exec rubocop` — 0 offenses
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)