### PR TITLE
Symbolic API: Patient, Practitioner, Organization, Location, Referral, Tribal, VFC (+25 tests)

### DIFF
--- a/lib/rpms_rpc/api/location.rb
+++ b/lib/rpms_rpc/api/location.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module RpmsRpc
+  module Location
+    extend self
+
+    def find(ien)
+      return nil if ien.nil?
+
+      DataMapper.hospital_location.fetch_one(ien.to_s)
+    end
+  end
+end

--- a/lib/rpms_rpc/api/organization.rb
+++ b/lib/rpms_rpc/api/organization.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module RpmsRpc
+  module Organization
+    extend self
+
+    def find(ien)
+      return nil if ien.nil?
+
+      DataMapper.institution.fetch_one(ien.to_s)
+    end
+  end
+end

--- a/lib/rpms_rpc/api/patient.rb
+++ b/lib/rpms_rpc/api/patient.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module RpmsRpc
+  # Symbolic API for patient data. Engine code calls these methods
+  # instead of referencing DataMapper mappings directly.
+  module Patient
+    extend self
+
+    def find(dfn)
+      return nil if dfn.nil? || dfn.to_i <= 0
+
+      attrs = DataMapper.patient_select.fetch_one(dfn.to_s, extras: { dfn: dfn.to_i })
+      return nil unless attrs
+
+      extended = DataMapper.patient_id_info.fetch_one(dfn.to_s)
+      attrs.merge!(extended) if extended
+
+      attrs
+    end
+
+    def search(name_pattern)
+      DataMapper.patient_list.fetch_many(name_pattern.to_s, "1")
+    end
+
+    def find_by_ssn(ssn)
+      return nil if ssn.nil? || ssn.to_s.empty?
+
+      DataMapper.patient_ssn.fetch_one(ssn.to_s)
+    end
+  end
+end

--- a/lib/rpms_rpc/api/practitioner.rb
+++ b/lib/rpms_rpc/api/practitioner.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module RpmsRpc
+  module Practitioner
+    extend self
+
+    def find(ien)
+      return nil if ien.nil? || ien.to_i <= 0
+
+      DataMapper.practitioner_info.fetch_one(ien.to_s, extras: { ien: ien.to_i })
+    end
+
+    def search(name_pattern)
+      DataMapper.practitioner_list.fetch_many(name_pattern.to_s, "1")
+    end
+  end
+end

--- a/lib/rpms_rpc/api/referral.rb
+++ b/lib/rpms_rpc/api/referral.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module RpmsRpc
+  module Referral
+    extend self
+
+    def for_patient(dfn)
+      DataMapper.referral_search.fetch_many(dfn.to_s)
+    end
+
+    def find(ien)
+      return nil if ien.nil?
+
+      DataMapper.referral_detail.fetch_one(ien.to_s)
+    end
+
+    def delete(ien, reason: nil)
+      DataMapper.referral_delete.fetch_one(ien.to_s, reason)
+    end
+  end
+end

--- a/lib/rpms_rpc/api/tribal.rb
+++ b/lib/rpms_rpc/api/tribal.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module RpmsRpc
+  module Tribal
+    extend self
+
+    def enrollment(dfn)
+      DataMapper.tribal_enrollment.fetch_one(dfn.to_s)
+    end
+
+    def validate(enrollment_number)
+      DataMapper.tribal_validation.fetch_one(enrollment_number.to_s)
+    end
+
+    def eligibility(dfn)
+      DataMapper.enrollment_eligibility.fetch_one(dfn.to_s) || { active: false, eligible_for_ihs: false }
+    end
+
+    def service_unit(dfn)
+      DataMapper.service_unit.fetch_one(dfn.to_s)
+    end
+
+    def tribe_info(code)
+      DataMapper.tribe_info.fetch_one(code.to_s)
+    end
+  end
+end

--- a/lib/rpms_rpc/api/vfc.rb
+++ b/lib/rpms_rpc/api/vfc.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module RpmsRpc
+  module VFC
+    extend self
+
+    def eligibility(dfn)
+      DataMapper.vfc_eligibility.fetch_one(dfn.to_s) || { code: nil, label: nil }
+    end
+
+    def eligibility_codes
+      DataMapper.vfc_eligibility_list.fetch_many
+    end
+  end
+end

--- a/test/rpms_rpc/api/clinical_test.rb
+++ b/test/rpms_rpc/api/clinical_test.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/practitioner"
+require "rpms_rpc/api/organization"
+require "rpms_rpc/api/location"
+require "rpms_rpc/api/referral"
+
+# Tests for clinical data symbolic APIs.
+class ClinicalTest < Minitest::Test
+  def setup
+    RpmsRpc.mock! do |m|
+      m.seed(:practitioner_info, "101", { name: "MARTINEZ,SARAH", title: "MD", specialty: "Cardiology", npi: "1234567890" })
+      m.seed_collection(:practitioner_list,
+        [ { ien: 101, name: "MARTINEZ,SARAH", title: "MD" } ],
+        filter_field: :name)
+      m.seed(:institution, "1", { ien: 1, name: "Alaska Native Medical Center", station_number: "463" })
+      m.seed(:hospital_location, "1", { ien: 1, name: "Primary Care Clinic", abbreviation: "PCC" })
+      m.seed(:referral_detail, "SR-001", { ien: "SR-001", status: "draft", patient_dfn: 1, type: "Cardiology" })
+      m.seed(:referral_delete, "SR-001", { success: true, message: "Referral deleted" })
+    end
+  end
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  # =============================================================================
+  # PRACTITIONER
+  # =============================================================================
+
+  def test_practitioner_find
+    result = RpmsRpc::Practitioner.find(101)
+
+    refute_nil result
+    assert_equal "MARTINEZ,SARAH", result[:name]
+    assert_equal "1234567890", result[:npi]
+  end
+
+  def test_practitioner_find_nil_for_unknown
+    assert_nil RpmsRpc::Practitioner.find(99999)
+  end
+
+  def test_practitioner_search
+    results = RpmsRpc::Practitioner.search("MARTINEZ")
+
+    assert results.any?
+    assert_equal "MARTINEZ,SARAH", results.first[:name]
+  end
+
+  # =============================================================================
+  # ORGANIZATION
+  # =============================================================================
+
+  def test_organization_find
+    result = RpmsRpc::Organization.find(1)
+
+    refute_nil result
+    assert_equal "Alaska Native Medical Center", result[:name]
+  end
+
+  def test_organization_find_nil_for_unknown
+    assert_nil RpmsRpc::Organization.find(99999)
+  end
+
+  # =============================================================================
+  # LOCATION
+  # =============================================================================
+
+  def test_location_find
+    result = RpmsRpc::Location.find(1)
+
+    refute_nil result
+    assert_equal "Primary Care Clinic", result[:name]
+  end
+
+  def test_location_find_nil_for_unknown
+    assert_nil RpmsRpc::Location.find(99999)
+  end
+
+  # =============================================================================
+  # REFERRAL
+  # =============================================================================
+
+  def test_referral_find
+    result = RpmsRpc::Referral.find("SR-001")
+
+    refute_nil result
+    assert_equal "draft", result[:status]
+  end
+
+  def test_referral_find_nil_for_unknown
+    assert_nil RpmsRpc::Referral.find("NONEXISTENT")
+  end
+
+  def test_referral_delete
+    result = RpmsRpc::Referral.delete("SR-001")
+
+    refute_nil result
+    assert result[:success]
+  end
+end

--- a/test/rpms_rpc/api/patient_test.rb
+++ b/test/rpms_rpc/api/patient_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/patient"
+
+# Tests for RpmsRpc::Patient symbolic API.
+# Engine code calls these methods instead of DataMapper directly.
+class PatientTest < Minitest::Test
+  def setup
+    RpmsRpc.mock! do |m|
+      m.seed(:patient_select, "1", { name: "DOE,JOHN", sex: "M", dob: Date.new(1980, 1, 15), ssn: "111223333", age: 45 })
+      m.seed(:patient_id_info, "1", { race: "AMERICAN INDIAN", address_line1: "123 Main St", city: "Anchorage", state: "AK" })
+      m.seed(:patient_ssn, "111-22-3333", { dfn: 1, name: "DOE,JOHN", ssn: "111-22-3333" })
+      m.seed_collection(:patient_list,
+        [ { dfn: 1, name: "DOE,JOHN", sex: "M" }, { dfn: 2, name: "SMITH,JANE", sex: "F" } ],
+        filter_field: :name)
+    end
+  end
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  # =============================================================================
+  # FIND
+  # =============================================================================
+
+  def test_find_returns_hash_with_demographics
+    result = RpmsRpc::Patient.find(1)
+
+    refute_nil result
+    assert_equal "DOE,JOHN", result[:name]
+    assert_equal "M", result[:sex]
+  end
+
+  def test_find_merges_extended_demographics
+    result = RpmsRpc::Patient.find(1)
+
+    assert_equal "AMERICAN INDIAN", result[:race]
+    assert_equal "123 Main St", result[:address_line1]
+    assert_equal "Anchorage", result[:city]
+  end
+
+  def test_find_returns_nil_for_unknown
+    assert_nil RpmsRpc::Patient.find(99999)
+  end
+
+  def test_find_returns_nil_for_nil
+    assert_nil RpmsRpc::Patient.find(nil)
+  end
+
+  # =============================================================================
+  # SEARCH
+  # =============================================================================
+
+  def test_search_returns_array
+    results = RpmsRpc::Patient.search("DOE")
+
+    assert results.is_a?(Array)
+    assert_equal 1, results.length
+    assert_equal "DOE,JOHN", results.first[:name]
+  end
+
+  def test_search_returns_empty_for_no_match
+    results = RpmsRpc::Patient.search("ZZZZZ")
+
+    assert_equal [], results
+  end
+
+  # =============================================================================
+  # FIND BY SSN
+  # =============================================================================
+
+  def test_find_by_ssn_returns_hash
+    result = RpmsRpc::Patient.find_by_ssn("111-22-3333")
+
+    refute_nil result
+    assert_equal 1, result[:dfn]
+  end
+
+  def test_find_by_ssn_returns_nil_for_unknown
+    assert_nil RpmsRpc::Patient.find_by_ssn("000-00-0000")
+  end
+end

--- a/test/rpms_rpc/api/tribal_test.rb
+++ b/test/rpms_rpc/api/tribal_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/tribal"
+require "rpms_rpc/api/vfc"
+
+# Tests for tribal/IHS symbolic APIs.
+class TribalTest < Minitest::Test
+  def setup
+    RpmsRpc.mock! do |m|
+      m.seed(:tribal_enrollment, "1", { enrollment_number: "ANLC-12345", tribe_name: "Alaska Native", status: "ACTIVE" })
+      m.seed(:tribal_validation, "ANLC-12345", { valid: true, tribe_code: "ANLC", status: "ACTIVE" })
+      m.seed(:enrollment_eligibility, "1", { active: true, eligible_for_ihs: true, service_unit: "Anchorage" })
+      m.seed(:service_unit, "1", { ien: 1, name: "Anchorage", region: "Alaska" })
+      m.seed(:tribe_info, "ANLC", { ien: 100, name: "Alaska Native - Anchorage (ANLC)", code: "ANLC" })
+      m.seed(:vfc_eligibility, "1", { code: "V04", label: "AI/AN" })
+      m.seed_collection(:vfc_eligibility_list, [
+        { code: "V01", label: "Not VFC eligible" },
+        { code: "V04", label: "AI/AN" }
+      ])
+    end
+  end
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  def test_tribal_enrollment
+    result = RpmsRpc::Tribal.enrollment(1)
+
+    refute_nil result
+    assert_equal "ANLC-12345", result[:enrollment_number]
+  end
+
+  def test_tribal_validate
+    result = RpmsRpc::Tribal.validate("ANLC-12345")
+
+    assert result[:valid]
+    assert_equal "ANLC", result[:tribe_code]
+  end
+
+  def test_tribal_eligibility
+    result = RpmsRpc::Tribal.eligibility(1)
+
+    assert result[:active]
+    assert result[:eligible_for_ihs]
+  end
+
+  def test_tribal_service_unit
+    result = RpmsRpc::Tribal.service_unit(1)
+
+    refute_nil result
+    assert_equal "Anchorage", result[:name]
+  end
+
+  def test_tribal_tribe_info
+    result = RpmsRpc::Tribal.tribe_info("ANLC")
+
+    refute_nil result
+    assert_equal "ANLC", result[:code]
+  end
+
+  def test_vfc_eligibility
+    result = RpmsRpc::VFC.eligibility(1)
+
+    refute_nil result
+    assert_equal "V04", result[:code]
+  end
+
+  def test_vfc_eligibility_codes
+    codes = RpmsRpc::VFC.eligibility_codes
+
+    assert codes.is_a?(Array)
+    assert codes.any? { |c| c[:code] == "V04" }
+  end
+end


### PR DESCRIPTION
## Summary

Adds 7 symbolic API modules that engine code calls instead of referencing DataMapper mappings directly. This is the public interface that lakeraven-ehr repositories should use.

### API surface

| Module | Methods | DataMapper mappings wrapped |
|---|---|---|
| `RpmsRpc::Patient` | find, search, find_by_ssn | patient_select + patient_id_info, patient_list, patient_ssn |
| `RpmsRpc::Practitioner` | find, search | practitioner_info, practitioner_list |
| `RpmsRpc::Organization` | find | institution |
| `RpmsRpc::Location` | find | hospital_location |
| `RpmsRpc::Referral` | for_patient, find, delete | referral_search, referral_detail, referral_delete |
| `RpmsRpc::Tribal` | enrollment, validate, eligibility, service_unit, tribe_info | tribal_enrollment, tribal_validation, enrollment_eligibility, service_unit, tribe_info |
| `RpmsRpc::VFC` | eligibility, eligibility_codes | vfc_eligibility, vfc_eligibility_list |

Unblocks lakeraven-ehr#197 (gateway boundary migration).

## Test plan

- [x] `bundle exec rake test` — 336 runs, 0 failures
- [x] `bundle exec rubocop` — 0 offenses
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)