### PR TITLE
Encounter.open hydrates visit context (slice 1 of #55)

### DIFF
--- a/lib/rpms_rpc/api/encounter.rb
+++ b/lib/rpms_rpc/api/encounter.rb
@@ -4,8 +4,51 @@ module RpmsRpc
   module Encounter
     extend self
 
+    # List recent appointments for a patient.
+    # Underlying RPC: ORWPT APPTLST
     def for_patient(dfn)
       DataMapper.patient_appointments.fetch_many(dfn.to_s)
+    end
+
+    # Open an active encounter — hydrates the visit context the chart needs:
+    # location, provider, datetime, status, ward, and a missing-components report.
+    #
+    # Returns nil when the visit doesn't exist, when the BEHOENCX FETCH companion
+    # response is missing (incomplete hydration is treated as a miss rather than
+    # silently returning partial data), or when the visit belongs to a different
+    # DFN than the caller passed (prevents cross-patient visit access).
+    #
+    # Underlying RPCs (composed): BEHOENCX GETVISIT, BEHOENCX FETCH, BEHOENCX CHKVISIT
+    def open(dfn, visit_ien)
+      return nil if dfn.nil? || visit_ien.nil?
+
+      key = visit_ien.to_s
+      visit = DataMapper.encounter_visit.fetch_one(key)
+      return nil if visit.nil?
+
+      # Cross-patient guard: BEHOENCX GETVISIT returns the visit's owning DFN
+      # in field 3. If the caller passed a different DFN, reject.
+      if visit[:patient_dfn] && visit[:patient_dfn].to_i != dfn.to_i
+        return nil
+      end
+
+      fetch = DataMapper.encounter_fetch.fetch_one(key)
+      return nil if fetch.nil?
+
+      missing = DataMapper.encounter_chkvisit.fetch_many(key)
+
+      {
+        visit_ien:          visit_ien.to_i,
+        patient_dfn:        (visit[:patient_dfn] || dfn).to_i,
+        location_ien:       fetch[:location_ien] || visit[:location_ien],
+        location:           fetch[:clinic_name],
+        clinic_abbrev:      fetch[:clinic_abbrev],
+        provider:           fetch[:provider],
+        datetime_raw:       visit[:datetime_raw],
+        status:             visit[:status],
+        ward:               fetch[:ward] || visit[:ward],
+        missing_components: missing
+      }
     end
   end
 end

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -649,6 +649,37 @@ module RpmsRpc
       m.text_blob :definition_text
     end
 
+    # BEHOENCX GETVISIT — core visit detail by visit_ien
+    # Format: LOCATION_IEN^DATETIME_RAW^STATUS^PATIENT_DFN^WARD^?
+    DataMapper.define(:encounter_visit) do |m|
+      m.rpc "BEHOENCX GETVISIT"
+      m.field 0, :location_ien, :integer
+      m.field 1, :datetime_raw
+      m.field 2, :status
+      m.field 3, :patient_dfn, :integer
+      m.field 4, :ward
+    end
+
+    # BEHOENCX FETCH — hydrated visit context (location + provider names + ward)
+    # Format: CLINIC_NAME^CLINIC_ABBREV^^LOCATION_IEN^PROVIDER^VISIT_IEN^WARD^?
+    DataMapper.define(:encounter_fetch) do |m|
+      m.rpc "BEHOENCX FETCH"
+      m.field 0, :clinic_name
+      m.field 1, :clinic_abbrev
+      m.field 3, :location_ien, :integer
+      m.field 4, :provider
+      m.field 5, :visit_ien, :integer
+      m.field 6, :ward
+    end
+
+    # BEHOENCX CHKVISIT — missing-component report (multi-line)
+    # Format per line: COMPONENT^MESSAGE
+    DataMapper.define(:encounter_chkvisit) do |m|
+      m.rpc "BEHOENCX CHKVISIT"
+      m.field 0, :component
+      m.field 1, :message
+    end
+
     # BEHOENCX LOCK — patient lock result
     DataMapper.define(:patient_lock) do |m|
       m.rpc "BEHOENCX LOCK"

--- a/test/rpms_rpc/api/encounter_test.rb
+++ b/test/rpms_rpc/api/encounter_test.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/encounter"
+
+class EncounterTest < Minitest::Test
+  def setup
+    RpmsRpc.mock! do |m|
+      # Existing read API
+      m.seed_keyed_collection(:patient_appointments, "26664", [
+        { datetime: nil, location_ien: 1608, location: "PS CLINICS", status: "scheduled" }
+      ])
+
+      # Open: BEHOENCX GETVISIT — visit_ien -> visit detail
+      m.seed(:encounter_visit, "2090061", {
+        location_ien: 1608,
+        datetime_raw: "3260514.1907",
+        status: "A",
+        patient_dfn: 26664,
+        ward: "2D309-PAH"
+      })
+
+      # Open: BEHOENCX FETCH — hydrated visit context
+      m.seed(:encounter_fetch, "2090061", {
+        clinic_name:    "PS CLINICS",
+        clinic_abbrev:  "PSCL",
+        location_ien:   1608,
+        provider:       "SAND,ASH",
+        visit_ien:      2090061,
+        ward:           "2D309-PAH"
+      })
+
+      # Open: BEHOENCX CHKVISIT — missing-component report (multi-line)
+      m.seed_keyed_collection(:encounter_chkvisit, "2090061", [
+        { component: "POV", message: "Visit has no note" },
+        { component: "E&M", message: "Visit has no note" }
+      ])
+    end
+  end
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  def test_open_returns_hydrated_encounter_context
+    result = RpmsRpc::Encounter.open(26664, 2090061)
+
+    refute_nil result, "Encounter.open should return a hash"
+    assert_equal 2090061, result[:visit_ien]
+    assert_equal 26664,   result[:patient_dfn]
+    assert_equal 1608,    result[:location_ien]
+    assert_equal "PS CLINICS", result[:location]
+    assert_equal "SAND,ASH",   result[:provider]
+    assert_equal "A", result[:status]
+    assert_equal "3260514.1907", result[:datetime_raw]
+    assert_equal "2D309-PAH",  result[:ward]
+  end
+
+  def test_open_reports_missing_components
+    result = RpmsRpc::Encounter.open(26664, 2090061)
+
+    refute_nil result[:missing_components]
+    assert_equal 2, result[:missing_components].length
+    assert_includes result[:missing_components].map { |c| c[:component] }, "POV"
+    assert_includes result[:missing_components].map { |c| c[:component] }, "E&M"
+  end
+
+  def test_open_returns_nil_for_unknown_visit
+    assert_nil RpmsRpc::Encounter.open(26664, 99999999)
+  end
+
+  def test_open_returns_nil_for_nil_dfn_or_visit_ien
+    assert_nil RpmsRpc::Encounter.open(nil, 2090061)
+    assert_nil RpmsRpc::Encounter.open(26664, nil)
+  end
+
+  # Cross-patient guard: visit 2090061 belongs to dfn 26664. A caller passing
+  # any other dfn must not get the hydrated context — opening another
+  # patient's chart by visit IEN would be a data-access leak.
+  def test_open_returns_nil_when_visit_belongs_to_different_dfn
+    assert_nil RpmsRpc::Encounter.open(99999, 2090061)
+    assert_nil RpmsRpc::Encounter.open(0,     2090061)
+  end
+
+  # If BEHOENCX FETCH is missing, we have only partial context (no clinic
+  # name, no provider). Treat as miss rather than returning a half-filled hash.
+  def test_open_returns_nil_when_fetch_response_is_missing
+    RpmsRpc.reset!
+    RpmsRpc.mock! do |m|
+      m.seed(:encounter_visit, "2090061", {
+        location_ien: 1608, datetime_raw: "3260514.1907", status: "A",
+        patient_dfn: 26664, ward: "2D309-PAH"
+      })
+      # Intentionally no :encounter_fetch seed
+      m.seed_keyed_collection(:encounter_chkvisit, "2090061", [])
+    end
+    assert_nil RpmsRpc::Encounter.open(26664, 2090061)
+  end
+
+  def test_for_patient_still_works
+    # Regression: the existing read API is unchanged.
+    appointments = RpmsRpc::Encounter.for_patient("26664")
+    assert_kind_of Array, appointments
+    refute appointments.empty?
+    assert_equal "PS CLINICS", appointments.first[:location]
+  end
+end


### PR DESCRIPTION
## Summary

- Adds three DataMapper mappings for the `BEHOENCX` visit-detail family: `:encounter_visit` (`BEHOENCX GETVISIT`), `:encounter_fetch` (`BEHOENCX FETCH`), `:encounter_chkvisit` (`BEHOENCX CHKVISIT`)
- Adds new public method `RpmsRpc::Encounter.open(dfn, visit_ien)` that composes the three RPCs into a single hydrated payload (location, provider, datetime, status, ward, missing-component report)
- Cross-patient guard: rejects when the visit's owning DFN doesn't match the caller's DFN
- Rejects nil DFN/visit_ien and missing FETCH response (no silent partial hydration)
- Existing `Encounter.for_patient(dfn)` is unchanged

This is slice 1 of #55. Follow-up slices will add `Encounter.create` and `Encounter.last_for_user`.

## Test plan

- [x] `bundle exec ruby -Ilib -Itest test/rpms_rpc/api/encounter_test.rb` — 7 runs, 24 assertions, green
- [x] `bundle exec rake test` (full suite) — green

Part of #55.