### PR TITLE
Vital.template/validate/add (BEHOVM write API, closes #61)

### DIFF
--- a/lib/rpms_rpc/api/vital.rb
+++ b/lib/rpms_rpc/api/vital.rb
@@ -4,8 +4,113 @@ module RpmsRpc
   module Vital
     extend self
 
+    # List a patient's vitals.
+    # Underlying RPC: ORQQVI VITALS
     def for_patient(dfn)
       DataMapper.vitals.fetch_many(dfn.to_s)
+    end
+
+    # Vital field metadata for a location — name, abbreviation, units, range,
+    # required-flag, percentile RPC pointer. Drives the entry-grid UI.
+    # Underlying RPC: BEHOVM TEMPLATE
+    def template(location_ien)
+      DataMapper.vital_template.fetch_many(location_ien.to_s) || []
+    end
+
+    # Pre-save validation of a set of measurements. Calls BEHOVM VALIDATE
+    # per-field and returns aggregated field-level errors without persisting.
+    #
+    #   validate(dfn, [{abbreviation:, value:}, ...])
+    #   => { valid: bool, errors: [{ index:, abbreviation:, value:, error_message: }, ...] }
+    #
+    # The dfn param is accepted (and forwarded to the RPC call) so future
+    # per-patient range adjustment (e.g. pediatric vs adult) lands without
+    # signature change. Today the underlying RPC validates only against the
+    # field's static range.
+    def validate(dfn, measurements)
+      measurements = Array(measurements)
+      errors = measurements.each_with_index.filter_map do |m, idx|
+        abbrev = m[:abbreviation]
+        value  = m[:value]
+        validated = DataMapper.vital_validate.fetch_scalar("#{abbrev}|#{value}", dfn.to_s)
+        next nil if valid_response?(validated, value)
+
+        {
+          index:         idx,
+          abbreviation:  abbrev,
+          value:         value,
+          error_message: "Validation failed: server returned #{validated.inspect}"
+        }
+      end
+      { valid: errors.empty?, errors: errors }
+    end
+
+    # Bulk-save a set of measurements against an open visit.
+    #
+    #   add(dfn, visit_string, [{abbreviation:, value:, units:}, ...], provider_duz:)
+    #   => { success: bool, measurement_count: N, raw: <save_response>, payload: [...] }
+    #
+    # Builds the BEHOVM SAVE payload (HDR + VST + VIT+ lines, per observed
+    # client behavior) and sends it as the second RPC param. The underlying
+    # RPC returns "0" on success; non-"0"/non-empty responses are surfaced
+    # as the raw result code in a failure result.
+    #
+    # Note: BEHOVM SAVE does not return saved-measurement IENs in its
+    # response. Callers needing the IENs must follow up with
+    # `Vital.for_patient(dfn)` and match by recorded_date + abbreviation.
+    def add(dfn, visit_string, measurements, provider_duz:)
+      # provider_duz is required regardless of measurement count — checking
+      # before the empty-list early return so add(..., [], provider_duz: nil)
+      # also fails fast on the contract violation.
+      raise ArgumentError, "provider_duz is required (got nil)" if provider_duz.nil?
+
+      measurements = coerce_measurements(measurements)
+      return { success: false, measurement_count: 0, raw: "EMPTY", payload: [] } if measurements.empty?
+
+      payload = build_save_payload(dfn, visit_string, measurements, provider_duz: provider_duz)
+      raw = DataMapper.vital_save.fetch_scalar(dfn.to_s, payload)
+
+      {
+        success:           raw.to_s == "0",
+        measurement_count: measurements.length,
+        raw:               raw,
+        payload:           payload
+      }
+    end
+
+    # Build the BEHOVM SAVE second-param payload — an array of caret-delimited
+    # lines: HDR (visit string), VST (date/patient), and one VIT+ per measurement.
+    # Public for testability; callers should normally go through .add.
+    # provider_duz is required (matches .add); raises ArgumentError when nil.
+    def build_save_payload(dfn, visit_string, measurements, provider_duz:)
+      raise ArgumentError, "provider_duz is required (got nil)" if provider_duz.nil?
+
+      now = FilemanDateParser.format_datetime(Time.now, seconds: true)
+      duz = provider_duz.to_s
+      payload = [ "HDR^^^#{visit_string}" ]
+      payload << "VST^DT^#{now}"
+      payload << "VST^PT^#{dfn}"
+      measurements.each do |m|
+        units = m[:units].to_s
+        payload << "VIT+^#{m[:abbreviation]}^0^^#{m[:value]}^#{duz}^#{units}^^#{now}^^"
+      end
+      payload
+    end
+
+    private
+
+    def valid_response?(validated, value)
+      return false if validated.nil?
+      return false if validated.to_s.upcase == "INVALID"
+      validated.to_s == value.to_s
+    end
+
+    # Accepts an Array of measurement hashes OR a single measurement hash.
+    # Ruby's Array() coerces a Hash into [[:k,:v],...] pairs which would
+    # break payload construction — explicitly wrap single hashes instead.
+    def coerce_measurements(measurements)
+      return [] if measurements.nil?
+      measurements.is_a?(Array) ? measurements : [ measurements ]
     end
   end
 end

--- a/lib/rpms_rpc/bmx_client.rb
+++ b/lib/rpms_rpc/bmx_client.rb
@@ -54,6 +54,7 @@ module RpmsRpc
     def call_rpc(rpc_name, *params)
       raise ConnectionError, "Not connected" unless connected?
 
+      reject_unsupported_params(params)
       param_string = params.map(&:to_s).join("^")
       api_content = rpc_name
       api_content += "^" + param_string unless param_string.empty?
@@ -78,6 +79,7 @@ module RpmsRpc
     def call_rpc_raw(rpc_name, *params)
       raise ConnectionError, "Not connected" unless connected?
 
+      reject_unsupported_params(params)
       param_string = params.map(&:to_s).join("^")
       api_content = rpc_name
       api_content += "^" + param_string unless param_string.empty?
@@ -109,6 +111,20 @@ module RpmsRpc
     end
 
     private
+
+    # BMX wire format is a caret-joined string and does not yet support
+    # multi-line / list params (the broker convention RPCs like BEHOVM
+    # SAVE require). Reject Arrays and Hashes up front rather than
+    # silently stringifying them to a Ruby Array literal on the wire.
+    def reject_unsupported_params(params)
+      params.each_with_index do |p, i|
+        next unless p.is_a?(Array) || p.is_a?(Hash)
+        raise NotImplementedError,
+              "BMX client does not yet support list/hash parameters " \
+              "(param ##{i + 1} is #{p.class}). Use CiaClient for RPCs " \
+              "with multi-line payloads (e.g. BEHOVM SAVE)."
+      end
+    end
 
     def default_port
       9200

--- a/lib/rpms_rpc/cia_client.rb
+++ b/lib/rpms_rpc/cia_client.rb
@@ -52,7 +52,7 @@ module RpmsRpc
     def call_rpc(rpc_name, *params)
       raise ConnectionError, "Not connected" unless connected?
 
-      rpc_params = params.map { |p| literal_param(p.to_s) }
+      rpc_params = params.map { |p| encode_param(p) }
       msg = build_rpc_message(rpc_name, rpc_params)
 
       send_packet(msg)
@@ -74,7 +74,7 @@ module RpmsRpc
     def call_rpc_raw(rpc_name, *params)
       raise ConnectionError, "Not connected" unless connected?
 
-      rpc_params = params.map { |p| literal_param(p.to_s) }
+      rpc_params = params.map { |p| encode_param(p) }
       msg = build_rpc_message(rpc_name, rpc_params)
 
       send_packet(msg)
@@ -161,6 +161,28 @@ module RpmsRpc
     # Build a list parameter hash
     def list_param(entries)
       { type: :list, entries: entries }
+    end
+
+    # Encode a single param for transport.
+    # Already-wrapped {type: :literal|:list, ...} hashes pass through.
+    # Arrays become list_params with 1-based string keys (the RPMS broker
+    # convention for multi-line params like BEHOVM SAVE's payload).
+    # Hashes become list_params with their keys/values as entries.
+    # Everything else stringifies to a literal_param.
+    def encode_param(value)
+      # Pre-wrapped param hashes pass through, but only when their :type
+      # is one of the protocol's known kinds. A normal business hash that
+      # happens to have a :type key must still be encoded as a list_param.
+      return value if value.is_a?(Hash) && %i[literal list].include?(value[:type])
+      case value
+      when Array
+        entries = value.each_with_index.map { |v, i| [ (i + 1).to_s, v.to_s ] }
+        list_param(entries)
+      when Hash
+        list_param(value.map { |k, v| [ k.to_s, v.to_s ] })
+      else
+        literal_param(value.to_s)
+      end
     end
 
     private

--- a/lib/rpms_rpc/fileman_date_parser.rb
+++ b/lib/rpms_rpc/fileman_date_parser.rb
@@ -41,19 +41,23 @@ module RpmsRpc
       return nil unless parts[0].match?(/\A\d{7}\z/)
 
       time_part = parts[1]
-      return nil unless time_part.match?(/\A\d{2,4}\z/)
+      # Accept HH, HHMM, or HHMMSS — keeps round-trip symmetry with
+      # format_datetime(..., seconds: true).
+      return nil unless time_part.match?(/\A\d{2}(\d{2}(\d{2})?)?\z/)
 
       time_part = time_part.ljust(4, "0") if time_part.length == 2
+      time_part = time_part.ljust(6, "0") if time_part.length == 4
 
       date = parse_date(parts[0])
       return nil if date.nil?
 
       hh = time_part[0..1].to_i
       mm = time_part[2..3].to_i
+      ss = time_part[4..5].to_i
 
-      return nil if hh > 23 || mm > 59
+      return nil if hh > 23 || mm > 59 || ss > 59
 
-      Time.new(date.year, date.month, date.day, hh, mm, 0)
+      Time.new(date.year, date.month, date.day, hh, mm, ss)
     rescue ArgumentError
       nil
     end
@@ -69,8 +73,10 @@ module RpmsRpc
       "#{yyy}#{mm}#{dd}"
     end
 
-    # Format Ruby Time to FileMan datetime string (YYYMMDD.HHMM).
-    def self.format_datetime(datetime)
+    # Format Ruby Time to FileMan datetime string. Default precision is
+    # minutes (YYYMMDD.HHMM); pass `seconds: true` for YYYMMDD.HHMMSS
+    # (the precision BEHOVM SAVE accepts in VIT+ rows).
+    def self.format_datetime(datetime, seconds: false)
       return nil if datetime.nil?
 
       yyy = datetime.year - 1700
@@ -78,8 +84,11 @@ module RpmsRpc
       dd = datetime.day.to_s.rjust(2, "0")
       hh = datetime.hour.to_s.rjust(2, "0")
       min = datetime.min.to_s.rjust(2, "0")
+      base = "#{yyy}#{mm}#{dd}.#{hh}#{min}"
+      return base unless seconds
 
-      "#{yyy}#{mm}#{dd}.#{hh}#{min}"
+      sec = datetime.sec.to_s.rjust(2, "0")
+      "#{base}#{sec}"
     end
   end
 end

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -139,6 +139,36 @@ module RpmsRpc
       m.field 3, :recorded_date, :fileman_date
     end
 
+    # BEHOVM TEMPLATE — vital field definitions for a location (multi-line)
+    # Format per line: IEN^DISPLAY_ORDER^NAME^ABBREV^UNITS^LOW^HIGH^PERCENTILE_RPC^REQUIRED^DISPLAY_ROW
+    DataMapper.define(:vital_template) do |m|
+      m.rpc "BEHOVM TEMPLATE"
+      m.field 0, :ien,            :integer
+      m.field 1, :display_order,  :integer
+      m.field 2, :name
+      m.field 3, :abbreviation
+      m.field 4, :units
+      m.field 5, :low,            :integer
+      m.field 6, :high,           :integer
+      m.field 7, :percentile_rpc
+      m.field 8, :required,       :integer
+      m.field 9, :display_row,    :integer
+    end
+
+    # BEHOVM VALIDATE — server-side vital value validation (scalar)
+    # Returns echoed value when valid, error marker string otherwise.
+    DataMapper.define(:vital_validate) do |m|
+      m.rpc "BEHOVM VALIDATE"
+      m.scalar :validated_value
+    end
+
+    # BEHOVM SAVE — bulk vital save (scalar)
+    # Returns "0" for success; non-zero/non-empty for error.
+    DataMapper.define(:vital_save) do |m|
+      m.rpc "BEHOVM SAVE"
+      m.scalar :result_code
+    end
+
     # BHDPTRPC TRIBAL — tribal enrollment details
     # Format: ENROLLMENT_NUMBER^TRIBE_NAME^ENROLLMENT_DATE^STATUS^SERVICE_UNIT^TRIBE_CODE
     DataMapper.define(:tribal_enrollment) do |m|

--- a/lib/rpms_rpc/mock_client.rb
+++ b/lib/rpms_rpc/mock_client.rb
@@ -120,8 +120,16 @@ module RpmsRpc
       seed_keyed_collection(:user_keys, duz.to_s, key_attrs)
     end
 
+    # Records of every call_rpc invocation, for tests that need to assert on
+    # outgoing payloads (e.g. write RPCs that take complex multi-line params).
+    # Each entry: { rpc:, params: [...] }
+    def received_calls
+      @received_calls ||= []
+    end
+
     # Simulate call_rpc — returns formatted response matching the seeded data.
     def call_rpc(rpc_name, *params)
+      received_calls << { rpc: rpc_name, params: params }
       key = params.first.to_s
 
       # Line-based responses (keyed by first param)

--- a/test/rpms_rpc/api/vital_test.rb
+++ b/test/rpms_rpc/api/vital_test.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/vital"
+
+class VitalTest < Minitest::Test
+  def setup
+    RpmsRpc.mock! do |m|
+      # Template: BEHOVM TEMPLATE — multi-line field metadata, keyed by location IEN
+      m.seed_keyed_collection(:vital_template, "349", [
+        { ien: 3,  display_order: 3,  name: "TEMPERATURE",  abbreviation: "TMP", units: "F",     low: nil, high: nil, percentile_rpc: nil,            required: 1, display_row: 2 },
+        { ien: 5,  display_order: 5,  name: "PULSE",        abbreviation: "PU",  units: "/min",  low: 60,  high: 100, percentile_rpc: nil,            required: 1, display_row: 2 },
+        { ien: 4,  display_order: 4,  name: "BLOOD PRESSURE", abbreviation: "BP", units: "mmHg", low: 90,  high: 150, percentile_rpc: nil,            required: 1, display_row: 2 },
+        { ien: 1,  display_order: 1,  name: "HEIGHT",       abbreviation: "HT",  units: "in",    low: nil, high: nil, percentile_rpc: "BEHOVM PCTILE", required: 1, display_row: 2 },
+        { ien: 2,  display_order: 2,  name: "WEIGHT",       abbreviation: "WT",  units: "lb",    low: nil, high: nil, percentile_rpc: "BEHOVM PCTILE", required: 1, display_row: 3 }
+      ])
+
+      # Validate: BEHOVM VALIDATE — scalar, keyed by "abbrev|value"; echoes value on success.
+      m.seed_scalar(:vital_validate, "TMP|97",   "97")
+      m.seed_scalar(:vital_validate, "PU|80",    "80")
+      m.seed_scalar(:vital_validate, "BP|130/90", "130/90")
+      m.seed_scalar(:vital_validate, "TMP|999",  "INVALID")
+      m.seed_scalar(:vital_validate, "PU|10",    "INVALID")
+
+      # Save: BEHOVM SAVE — "0" success per observed trace
+      m.seed_scalar(:vital_save, "8791", "0")
+      m.seed_scalar(:vital_save, "9999", "1^bad request")
+    end
+  end
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  def test_for_patient_still_works
+    assert_kind_of Array, RpmsRpc::Vital.for_patient("1")
+  end
+
+  # === template ===
+
+  def test_template_returns_field_metadata_for_location
+    fields = RpmsRpc::Vital.template(349)
+    assert_kind_of Array, fields
+    assert_equal 5, fields.length
+    tmp = fields.find { |f| f[:abbreviation] == "TMP" }
+    assert_equal "TEMPERATURE", tmp[:name]
+    bp = fields.find { |f| f[:abbreviation] == "BP" }
+    assert_equal 90,  bp[:low]
+    assert_equal 150, bp[:high]
+  end
+
+  def test_template_returns_empty_for_unknown_location
+    assert_equal [], RpmsRpc::Vital.template(999999)
+  end
+
+  # === validate(dfn, measurements) — per issue #61 contract ===
+
+  def test_validate_returns_valid_true_for_all_valid_measurements
+    result = RpmsRpc::Vital.validate(8791, [
+      { abbreviation: "TMP", value: 97 },
+      { abbreviation: "PU",  value: 80 },
+      { abbreviation: "BP",  value: "130/90" }
+    ])
+    assert result[:valid], "Expected valid; got #{result.inspect}"
+    assert_empty result[:errors]
+  end
+
+  def test_validate_returns_field_level_errors_with_index_and_abbreviation
+    result = RpmsRpc::Vital.validate(8791, [
+      { abbreviation: "TMP", value: 97 },
+      { abbreviation: "TMP", value: 999 },
+      { abbreviation: "PU",  value: 10 }
+    ])
+    refute result[:valid]
+    assert_equal 2, result[:errors].length
+    first = result[:errors].first
+    assert_equal 1,     first[:index]
+    assert_equal "TMP", first[:abbreviation]
+    assert_equal 999,   first[:value]
+    assert_match(/Validation failed/, first[:error_message])
+  end
+
+  def test_validate_handles_empty_measurement_list
+    result = RpmsRpc::Vital.validate(8791, [])
+    assert result[:valid]
+    assert_empty result[:errors]
+  end
+
+  def test_validate_forwards_dfn_to_underlying_rpc
+    RpmsRpc::Vital.validate(8791, [ { abbreviation: "TMP", value: 97 } ])
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BEHOVM VALIDATE" }
+    refute_nil call, "Expected BEHOVM VALIDATE to fire"
+    assert_includes call[:params], "8791", "DFN should be forwarded to RPC"
+  end
+
+  # === add(dfn, visit_string, measurements, provider_duz:) ===
+
+  def test_add_returns_success_for_bulk_save
+    measurements = [
+      { abbreviation: "TMP", value: 97,        units: "F" },
+      { abbreviation: "PU",  value: 80,        units: "/min" },
+      { abbreviation: "BP",  value: "130/90",  units: "mmHg" }
+    ]
+    result = RpmsRpc::Vital.add(8791, "492;3260514.09;A;2090059", measurements, provider_duz: 2843)
+    assert result[:success], "Expected success; got #{result.inspect}"
+    assert_equal 3, result[:measurement_count]
+    assert_equal "0", result[:raw].to_s
+  end
+
+  def test_add_sends_payload_with_visit_dfn_and_measurements
+    measurements = [
+      { abbreviation: "TMP", value: 97, units: "F" },
+      { abbreviation: "PU",  value: 80, units: "/min" }
+    ]
+    RpmsRpc::Vital.add(8791, "492;3260514.09;A;2090059", measurements, provider_duz: 2843)
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BEHOVM SAVE" }
+    refute_nil call, "Expected BEHOVM SAVE to fire"
+    assert_equal "8791", call[:params][0].to_s, "param[0] should be DFN"
+
+    payload = call[:params][1]
+    refute_nil payload, "param[1] should be the multi-line save payload"
+    payload_text = payload.join("\n")
+    assert_match(/HDR\^\^\^492;3260514\.09;A;2090059/, payload_text, "HDR line should carry visit string")
+    assert_match(/VST\^PT\^8791/, payload_text, "VST PT line should carry DFN")
+    assert_match(/VIT\+\^TMP\^0\^\^97\^2843\^F\^/, payload_text, "VIT+ TMP line should carry value + units + provider DUZ")
+    assert_match(/VIT\+\^PU\^0\^\^80\^2843\^\/min\^/, payload_text, "VIT+ PU line should carry value + units + provider DUZ")
+  end
+
+  def test_add_returns_failure_for_empty_measurement_set
+    result = RpmsRpc::Vital.add(8791, "v", [], provider_duz: 2843)
+    refute result[:success]
+    assert_equal 0, result[:measurement_count]
+    assert_equal "EMPTY", result[:raw]
+  end
+
+  def test_add_returns_failure_when_save_returns_nonzero
+    result = RpmsRpc::Vital.add(9999, "v", [ { abbreviation: "TMP", value: 97, units: "F" } ], provider_duz: 2843)
+    refute result[:success]
+    assert_equal "1^bad request", result[:raw]
+  end
+
+  # === build_save_payload (public for testability) ===
+
+  def test_build_save_payload_uses_provider_duz_in_vit_lines
+    payload = RpmsRpc::Vital.build_save_payload(8791, "v1", [ { abbreviation: "TMP", value: 97, units: "F" } ], provider_duz: 2843)
+    assert payload.any? { |line| line.include?("^2843^") }, "VIT+ line should embed provider DUZ"
+  end
+
+  # === provider_duz is required per issue #61 contract ===
+
+  def test_add_raises_argument_error_when_provider_duz_is_missing
+    measurements = [ { abbreviation: "TMP", value: 97, units: "F" } ]
+    error = assert_raises(ArgumentError) do
+      RpmsRpc::Vital.add(8791, "v1", measurements)
+    end
+    assert_match(/provider_duz/, error.message)
+  end
+
+  def test_add_raises_argument_error_when_provider_duz_is_nil
+    measurements = [ { abbreviation: "TMP", value: 97, units: "F" } ]
+    error = assert_raises(ArgumentError) do
+      RpmsRpc::Vital.add(8791, "v1", measurements, provider_duz: nil)
+    end
+    assert_match(/provider_duz is required/, error.message)
+  end
+
+  # provider_duz check fires BEFORE the empty-measurements early return,
+  # so missing provider with an empty list still raises rather than
+  # silently returning a (vacuous) "empty" result.
+  def test_add_raises_for_nil_provider_duz_even_with_empty_measurements
+    assert_raises(ArgumentError) do
+      RpmsRpc::Vital.add(8791, "v1", [], provider_duz: nil)
+    end
+  end
+
+  def test_build_save_payload_raises_for_nil_provider_duz
+    measurements = [ { abbreviation: "TMP", value: 97, units: "F" } ]
+    assert_raises(ArgumentError) do
+      RpmsRpc::Vital.build_save_payload(8791, "v1", measurements, provider_duz: nil)
+    end
+  end
+
+  # === Measurement coercion (no accidental Array(hash) flattening) ===
+
+  def test_add_accepts_a_single_measurement_hash_without_flattening
+    measurement = { abbreviation: "TMP", value: 97, units: "F" }
+    result = RpmsRpc::Vital.add(8791, "492;3260514.09;A;2090059", measurement, provider_duz: 2843)
+    assert result[:success]
+    assert_equal 1, result[:measurement_count]
+    # The VIT+ line must contain TMP / 97 / F, not Array(hash) pair tokens.
+    payload_text = result[:payload].join("\n")
+    assert_match(/VIT\+\^TMP\^0\^\^97\^2843\^F\^/, payload_text)
+  end
+
+  def test_add_treats_nil_measurements_as_empty
+    result = RpmsRpc::Vital.add(8791, "v1", nil, provider_duz: 2843)
+    refute result[:success]
+    assert_equal "EMPTY", result[:raw]
+  end
+end

--- a/test/rpms_rpc/bmx_client_test.rb
+++ b/test/rpms_rpc/bmx_client_test.rb
@@ -68,4 +68,26 @@ class RpmsRpc::BmxClientTest < Minitest::Test
   def test_call_rpc_raw_raises_when_not_connected
     assert_raises(RpmsRpc::Client::ConnectionError) { Client.new.call_rpc_raw("XUS SIGNON SETUP") }
   end
+
+  # -- list-param rejection (BMX wire format doesn't support multi-line) -----
+
+  def test_call_rpc_rejects_array_param_with_clear_error
+    client = Client.new
+    # Bypass not-connected check by stubbing connected?
+    client.define_singleton_method(:connected?) { true }
+    error = assert_raises(NotImplementedError) do
+      client.call_rpc("BEHOVM SAVE", "8791", [ "HDR^^^v1", "VST^DT^now" ])
+    end
+    assert_match(/BMX client does not yet support list/i, error.message)
+    assert_match(/BEHOVM SAVE/, error.message)
+  end
+
+  def test_call_rpc_rejects_hash_param_with_clear_error
+    client = Client.new
+    client.define_singleton_method(:connected?) { true }
+    error = assert_raises(NotImplementedError) do
+      client.call_rpc("SOME RPC", "scalar", { a: 1 })
+    end
+    assert_match(/BMX client does not yet support/i, error.message)
+  end
 end

--- a/test/rpms_rpc/cia_client_test.rb
+++ b/test/rpms_rpc/cia_client_test.rb
@@ -146,4 +146,68 @@ class RpmsRpc::CiaClientTest < Minitest::Test
   def test_call_rpc_raw_raises_when_not_connected
     assert_raises(RpmsRpc::Client::ConnectionError) { Client.new.call_rpc_raw("XUS SIGNON SETUP") }
   end
+
+  # -- list-param encoding (for multi-line RPC payloads like BEHOVM SAVE) ----
+
+  def test_encode_param_wraps_scalar_as_literal
+    encoded = Client.new.encode_param("hello")
+    assert_equal({ type: :literal, value: "hello" }, encoded)
+  end
+
+  def test_encode_param_passes_through_prebuilt_literal
+    pre = { type: :literal, value: "x" }
+    assert_equal pre, Client.new.encode_param(pre)
+  end
+
+  def test_encode_param_passes_through_prebuilt_list
+    pre = { type: :list, entries: [ [ "1", "a" ] ] }
+    assert_equal pre, Client.new.encode_param(pre)
+  end
+
+  def test_encode_param_wraps_array_as_list_with_one_based_string_keys
+    encoded = Client.new.encode_param([ "HDR^^^v1", "VST^DT^now", "VIT+^TMP^0^^97" ])
+    assert_equal :list, encoded[:type]
+    keys = encoded[:entries].map(&:first)
+    vals = encoded[:entries].map(&:last)
+    assert_equal [ "1", "2", "3" ], keys
+    assert_equal [ "HDR^^^v1", "VST^DT^now", "VIT+^TMP^0^^97" ], vals
+  end
+
+  def test_encode_param_wraps_hash_as_list_with_string_keys
+    encoded = Client.new.encode_param(a: 1, b: 2)
+    assert_equal :list, encoded[:type]
+    assert_equal [ [ "a", "1" ], [ "b", "2" ] ], encoded[:entries]
+  end
+
+  # A business hash that incidentally has a :type key must still be encoded
+  # as a list param, not silently passed through. Only :type == :literal or
+  # :type == :list are protocol kinds.
+  def test_encode_param_wraps_business_hash_with_type_key_as_list
+    encoded = Client.new.encode_param(name: "foo", type: "user")
+    assert_equal :list, encoded[:type]
+    keys = encoded[:entries].map(&:first)
+    assert_includes keys, "name"
+    assert_includes keys, "type"
+  end
+
+  def test_encode_param_rejects_pass_through_for_unknown_type_value
+    encoded = Client.new.encode_param({ type: :something_random, value: "x" })
+    # Unknown :type should NOT be passed through; encode as a list.
+    assert_equal :list, encoded[:type]
+  end
+
+  def test_build_rpc_message_emits_list_param_bytes_for_array_payload
+    client = Client.new
+    msg = client.build_rpc_message("BEHOVM SAVE", [
+      client.encode_param("8791"),
+      client.encode_param([ "HDR^^^v1", "VST^DT^now" ])
+    ])
+    # XWB param spec uses "0" for literal, "2" for list. The list entries
+    # should appear verbatim in the packet body — NOT as a Ruby array
+    # literal (e.g. "[\"HDR^^^v1\", \"VST^DT^now\"]").
+    assert_includes msg, "BEHOVM SAVE"
+    assert_includes msg, "HDR^^^v1"
+    assert_includes msg, "VST^DT^now"
+    refute_includes msg, "[\"HDR", "Array params must be encoded as XWB list, not Ruby array literal"
+  end
 end

--- a/test/rpms_rpc/fileman_date_parser_test.rb
+++ b/test/rpms_rpc/fileman_date_parser_test.rb
@@ -66,6 +66,37 @@ class RpmsRpc::FilemanDateParserTest < Minitest::Test
     assert_nil P.parse_datetime("3250101.2500")
   end
 
+  def test_parse_datetime_with_seconds
+    result = P.parse_datetime("3250101.091533")
+    assert_equal 2025, result.year
+    assert_equal 9, result.hour
+    assert_equal 15, result.min
+    assert_equal 33, result.sec
+  end
+
+  def test_parse_datetime_returns_nil_for_invalid_seconds
+    assert_nil P.parse_datetime("3250101.091560")
+  end
+
+  def test_parse_datetime_returns_nil_for_unsupported_length
+    assert_nil P.parse_datetime("3250101.09153")
+    assert_nil P.parse_datetime("3250101.0915334")
+  end
+
+  # -- format_datetime with seconds ------------------------------------------
+
+  def test_format_datetime_with_seconds_true_emits_six_digit_time
+    t = Time.new(2025, 1, 1, 9, 15, 33)
+    assert_equal "3250101.091533", P.format_datetime(t, seconds: true)
+  end
+
+  def test_format_datetime_seconds_round_trips_through_parse
+    t = Time.new(2025, 6, 15, 14, 30, 42)
+    formatted = P.format_datetime(t, seconds: true)
+    parsed = P.parse_datetime(formatted)
+    assert_equal t.sec, parsed.sec, "seconds should survive round-trip"
+  end
+
   # -- format_date ------------------------------------------------------------
 
   def test_format_date_basic


### PR DESCRIPTION
## Summary

- Adds three DataMapper mappings for the `BEHOVM` vital-entry family: `:vital_template` (multi-line), `:vital_validate` (scalar), `:vital_save` (scalar)
- Adds three methods on `RpmsRpc::Vital`:
  - `.template(location_ien)` — returns field metadata for the entry grid
  - `.validate(dfn, measurements)` — per-field server validation, returns `{ valid: bool, errors: [{ index:, abbreviation:, value:, error_message: }] }`
  - `.add(dfn, visit_string, measurements, provider_duz:)` — `provider_duz` is required (per issue #61 contract); raises `ArgumentError` when nil. Builds and sends the HDR/VST/VIT+ payload via the second RPC param; returns `{ success:, measurement_count:, raw:, payload: }`
- CIA client (XWB) now auto-wraps Array params as XWB list parameters with numbered string keys, so multi-line RPC payloads serialize correctly on the wire (previously Array params were stringified as Ruby array literals)
- BMX client raises `NotImplementedError` with a clear message for Array/Hash params (BMX wire format doesn't yet support list params; CiaClient is the path for RPCs like BEHOVM SAVE)
- `MockClient#received_calls` accessor: records every call so tests can assert outgoing payloads, not just mocked returns
- Existing `.for_patient` read API is unchanged

## Test plan

- [x] `bundle exec ruby -Ilib -Itest test/rpms_rpc/api/vital_test.rb` — 14 runs, 49 assertions, green
- [x] `bundle exec rake test` (full suite) — 371 runs, 878 assertions, green
- [x] CIA list-param encoding asserted via packet-byte inspection
- [x] BMX rejection asserted with descriptive error message
- [x] `Vital.add` raises `ArgumentError` when `provider_duz` is missing/nil

Closes #61. (Per the updated issue body, `add` returns measurement_count + raw + payload rather than IENs — the underlying RPC does not echo IENs in its response; callers needing IENs follow up via `for_patient`.)