### PR TITLE
Patient.brief_header chart-banner projection (closes #60)

### DIFF
--- a/lib/rpms_rpc/api/patient.rb
+++ b/lib/rpms_rpc/api/patient.rb
@@ -27,5 +27,52 @@ module RpmsRpc
 
       DataMapper.patient_ssn.fetch_one(ssn.to_s)
     end
+
+    # Chart-banner projection per issue #60 contract:
+    #
+    #   { name:, dob:, sex:, mrn:, age:, allergy_flag:, ad_flag:, primary_provider: }
+    #
+    # Composed from three RPCs:
+    #   - BEHOPTCX PTINFO         (name, sex, DOB raw, MRN, primary provider name)
+    #   - BEHOPTPC GETBDP         (designated primary provider — overrides if present)
+    #   - BEHOCACV CWAD           (Crises/Warnings/Allergies/Directives flags)
+    #
+    # Returns nil for invalid (nil / zero / negative) DFNs and for unknown DFNs
+    # (no PTINFO and no GETBDP response).
+    def brief_header(dfn)
+      return nil if dfn.nil? || dfn.to_i <= 0
+
+      ptinfo = DataMapper.patient_ptinfo.fetch_one(dfn.to_s)
+      bdp    = DataMapper.patient_designated_provider.fetch_one(dfn.to_s)
+      return nil if ptinfo.nil? && bdp.nil?
+
+      cwad = DataMapper.patient_cwad.fetch_scalar(dfn.to_s) || ""
+      dob  = FilemanDateParser.parse_date(ptinfo && ptinfo[:dob_raw])
+      provider = (bdp && bdp[:provider_name]) || (ptinfo && ptinfo[:primary_provider])
+
+      {
+        name:             ptinfo && ptinfo[:name],
+        dob:              dob,
+        sex:              ptinfo && ptinfo[:sex],
+        mrn:              ptinfo && ptinfo[:mrn],
+        age:              age_from(dob),
+        allergy_flag:     cwad.to_s.include?("A"),
+        ad_flag:          cwad.to_s.include?("D"),
+        primary_provider: provider
+      }
+    end
+
+    # Compute integer years between dob and today. `today:` is a keyword arg
+    # for testability — production callers omit it and get Date.today.
+    # Default is `nil` (not `Date.today`) so the nil-DOB guard runs before
+    # touching the Date constant, keeping the helper safe even if `Date`
+    # hasn't been required by the caller.
+    def age_from(dob, today: nil)
+      return nil if dob.nil?
+      today ||= Date.today
+      years = today.year - dob.year
+      years -= 1 if today.month < dob.month || (today.month == dob.month && today.day < dob.day)
+      years
+    end
   end
 end

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -75,6 +75,38 @@ module RpmsRpc
       m.field 3, :status
     end
 
+    # BEHOPTCX PTINFO — broad patient identity bundle for chart banner
+    # Format: NAME^SEX^DOB^SSN^^^^^^^MRN^^^^^^DESIGNATED_TEAM^PRIMARY_PROVIDER^^
+    DataMapper.define(:patient_ptinfo) do |m|
+      m.rpc "BEHOPTCX PTINFO"
+      m.field 0,  :name
+      m.field 1,  :sex
+      m.field 2,  :dob_raw
+      m.field 3,  :ssn
+      m.field 10, :mrn
+      m.field 16, :designated_team
+      m.field 17, :primary_provider
+    end
+
+    # BEHOPTPC GETBDP — designated primary provider detail
+    # Format: LABEL^PROVIDER_NAME^PROVIDER_IEN^TITLE^DATE
+    DataMapper.define(:patient_designated_provider) do |m|
+      m.rpc "BEHOPTPC GETBDP"
+      m.field 0, :label
+      m.field 1, :provider_name
+      m.field 2, :provider_ien, :integer
+      m.field 3, :title
+      m.field 4, :date_raw
+    end
+
+    # BEHOCACV CWAD — patient CWAD flags (scalar). Each letter present in
+    # the response indicates: C=Crises, W=Warnings, A=Allergies, D=Advance
+    # Directives. Empty string means none.
+    DataMapper.define(:patient_cwad) do |m|
+      m.rpc "BEHOCACV CWAD"
+      m.scalar :cwad
+    end
+
     # ORQQAL LIST — patient allergies (multi-line)
     # Format: ALLERGEN^REACTION^SEVERITY
     DataMapper.define(:allergy_list) do |m|

--- a/test/rpms_rpc/api/patient_brief_header_test.rb
+++ b/test/rpms_rpc/api/patient_brief_header_test.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "date"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/patient"
+
+class PatientBriefHeaderTest < Minitest::Test
+  def setup
+    RpmsRpc.mock! do |m|
+      # BEHOPTCX PTINFO — broad patient identity bundle (test patient #8791)
+      m.seed(:patient_ptinfo, "8791", {
+        name: "TESTPATIENT,FIRST",
+        sex: "F",
+        dob_raw: "2860701",          # FileMan: 286 + 1700 = 1986-07-01
+        ssn: "XXX-XX-XXXX",
+        mrn: "120305",
+        designated_team: "Primary Care Team",
+        primary_provider: "PROVIDER,DEFAULT"
+      })
+      m.seed_scalar(:patient_cwad, "8791", "A")  # has allergies, no AD
+
+      # Both sources for the same DFN (composition test)
+      m.seed(:patient_ptinfo, "26664", {
+        name: "TESTPATIENT,SECOND",
+        sex: "M",
+        dob_raw: "2700101",          # 1970-01-01
+        mrn: "260664",
+        designated_team: "Internal Med Team",
+        primary_provider: "PROVIDER,OVERRIDDEN"
+      })
+      m.seed(:patient_designated_provider, "26664", {
+        label: "DESIGNATED PRIMARY PROVIDER",
+        provider_name: "PROVIDER,FROM_GETBDP",
+        provider_ien: 2843,
+        title: "PHYSICIAN",
+        date_raw: "3260507"
+      })
+      m.seed_scalar(:patient_cwad, "26664", "AD")  # both flags
+    end
+  end
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  # === Contract shape (issue #60) ===
+
+  def test_brief_header_returns_documented_keys_and_nothing_else
+    header = RpmsRpc::Patient.brief_header(8791)
+    refute_nil header
+    expected = %i[name dob sex mrn age allergy_flag ad_flag primary_provider].sort
+    assert_equal expected, header.keys.sort, "Return shape must match issue #60 contract"
+  end
+
+  def test_brief_header_parses_dob_to_date_object
+    header = RpmsRpc::Patient.brief_header(8791)
+    assert_kind_of Date, header[:dob]
+    assert_equal Date.new(1986, 7, 1), header[:dob]
+  end
+
+  def test_brief_header_computes_age_from_dob
+    header = RpmsRpc::Patient.brief_header(8791)
+    # Assert brief_header's age equals what the helper computes against
+    # today — avoids a hard upper bound that ages into the future.
+    expected = RpmsRpc::Patient.age_from(header[:dob], today: Date.today)
+    assert_kind_of Integer, header[:age]
+    assert_equal expected, header[:age]
+  end
+
+  # Pin the age computation against a fixed reference date so future
+  # regressions in the FileMan-to-age path (off-by-one around birthday,
+  # leap year, etc.) are caught precisely without depending on wall-clock.
+  def test_age_from_with_fixed_today_returns_exact_year_count
+    dob = Date.new(1986, 7, 1)
+    assert_equal 39, RpmsRpc::Patient.age_from(dob, today: Date.new(2026, 5, 22)),
+                 "Before birthday: should be 39"
+    assert_equal 40, RpmsRpc::Patient.age_from(dob, today: Date.new(2026, 7, 1)),
+                 "On birthday: should be 40"
+    assert_equal 40, RpmsRpc::Patient.age_from(dob, today: Date.new(2026, 7, 2)),
+                 "Day after birthday: should be 40"
+    assert_equal 39, RpmsRpc::Patient.age_from(dob, today: Date.new(2026, 6, 30)),
+                 "Day before birthday: should be 39"
+    assert_nil RpmsRpc::Patient.age_from(nil), "nil DOB returns nil"
+  end
+
+  def test_brief_header_carries_name_sex_mrn_from_ptinfo
+    header = RpmsRpc::Patient.brief_header(8791)
+    assert_equal "TESTPATIENT,FIRST", header[:name]
+    assert_equal "F",                 header[:sex]
+    assert_equal "120305",            header[:mrn]
+  end
+
+  # === Flags from CWAD ===
+
+  def test_allergy_flag_true_when_cwad_includes_A
+    assert_equal true, RpmsRpc::Patient.brief_header(8791)[:allergy_flag]
+  end
+
+  def test_ad_flag_false_when_cwad_does_not_include_D
+    assert_equal false, RpmsRpc::Patient.brief_header(8791)[:ad_flag]
+  end
+
+  def test_both_flags_true_when_cwad_is_AD
+    header = RpmsRpc::Patient.brief_header(26664)
+    assert_equal true, header[:allergy_flag]
+    assert_equal true, header[:ad_flag]
+  end
+
+  # === Primary provider precedence ===
+
+  def test_primary_provider_prefers_GETBDP_over_PTINFO
+    # PTINFO says "PROVIDER,OVERRIDDEN"; GETBDP says "PROVIDER,FROM_GETBDP".
+    # The designated-provider RPC should win.
+    header = RpmsRpc::Patient.brief_header(26664)
+    assert_equal "PROVIDER,FROM_GETBDP", header[:primary_provider]
+  end
+
+  def test_primary_provider_falls_back_to_PTINFO_when_no_GETBDP
+    header = RpmsRpc::Patient.brief_header(8791)
+    assert_equal "PROVIDER,DEFAULT", header[:primary_provider]
+  end
+
+  # === Invalid / unknown DFN handling ===
+
+  def test_brief_header_returns_nil_for_invalid_dfn
+    assert_nil RpmsRpc::Patient.brief_header(nil)
+    assert_nil RpmsRpc::Patient.brief_header(0)
+    assert_nil RpmsRpc::Patient.brief_header(-5)
+  end
+
+  def test_brief_header_returns_nil_for_unknown_dfn
+    assert_nil RpmsRpc::Patient.brief_header(999999)
+  end
+
+  # === Regression ===
+
+  def test_existing_patient_find_still_works
+    RpmsRpc.reset!
+    RpmsRpc.mock! do |m|
+      m.seed(:patient_select, "1", { name: "TEST,ONE", sex: "F", age: 30 })
+    end
+    refute_nil RpmsRpc::Patient.find(1)
+  end
+end


### PR DESCRIPTION
## Summary

- Adds three DataMapper mappings: `:patient_ptinfo` (BEHOPTCX PTINFO), `:patient_designated_provider` (BEHOPTPC GETBDP), and `:patient_cwad` (BEHOCACV CWAD)
- Adds `RpmsRpc::Patient.brief_header(dfn)` returning the issue-#60 contract shape: `{ name:, dob:, sex:, mrn:, age:, allergy_flag:, ad_flag:, primary_provider: }`
- DOB parsed to `Date` via FilemanDateParser; age computed via `age_from(dob, today:)` which is exposed as a public testable utility with fixed-date pinning
- CWAD flags derived from the BEHOCACV scalar response
- primary_provider follows precedence: GETBDP detail wins, PTINFO falls back
- Returns nil for nil/zero/negative DFNs and for unknown patients
- Existing `find`, `search`, `find_by_ssn` unchanged

## Test plan

- [x] `bundle exec ruby -Ilib -Itest test/rpms_rpc/api/patient_brief_header_test.rb` — 13 runs, 26 assertions, green
- [x] Age computation pinned by fixed-date tests (birthday boundary, day-before, day-after, nil DOB)
- [x] `bundle exec rake test` (full suite) — green

Closes #60. (Per the updated issue body, the implementation composes three RPCs — PTINFO + GETBDP + CWAD — rather than the single GETBDP originally documented, because no one RPC carries the full banner contract.)