### PR TITLE
Lab module: port from rpms_redux (Part of #80)

### DIFF
--- a/lib/rpms_rpc/api/lab.rb
+++ b/lib/rpms_rpc/api/lab.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+module RpmsRpc
+  # Symbolic API for laboratory data.
+  # Underlying RPCs (ORWLRR family): RESULT LIST, REPORT LIST, REPORT.
+  module Lab
+    extend self
+
+    # Recent labs for a patient. Defaults to the last 90 days.
+    # Returns an Array of result hashes (empty for invalid/unknown DFN).
+    #
+    # Each hash: { ien:, test_name:, result:, units:, reference_range:,
+    #              abnormal:, abnormal_flag:, collection_date:, status: }
+    def for_patient(dfn, days: 90)
+      return [] if dfn.nil? || dfn.to_s.empty? || dfn.to_i <= 0
+
+      raw = DataMapper.lab_result_list.fetch_many(dfn.to_s, *date_range_params(days))
+      Array(raw).map { |row| decorate_result(row) }
+    end
+
+    # Only the abnormal results within the window.
+    def abnormal(dfn, days: 90)
+      for_patient(dfn, days: days).select { |r| r[:abnormal] }
+    end
+
+    # DiagnosticReport-style panel aggregation for a patient.
+    # Each hash: { ien:, panel_name:, performed_at_raw:, status:, performing_lab: }
+    def reports(dfn)
+      return [] if dfn.nil? || dfn.to_s.empty? || dfn.to_i <= 0
+
+      Array(DataMapper.lab_report_list.fetch_many(dfn.to_s))
+    end
+
+    # Single lab / panel detail. Returns a hash or nil if not found.
+    # Parses the text-blob response (LABEL: VALUE lines) into a structured hash.
+    def find(dfn, lab_ien)
+      return nil if dfn.nil? || lab_ien.nil?
+      return nil if dfn.to_s.empty? || lab_ien.to_s.empty?
+
+      key = "#{dfn}|#{lab_ien}"
+      text = DataMapper.lab_report.fetch_text(key)
+      return nil if text.nil? || (text.respond_to?(:empty?) && text.empty?)
+
+      parse_detail(text, lab_ien)
+    end
+
+    private
+
+    # ORWLRR RESULT LIST takes (dfn, from_mm_dd_yyyy, to_mm_dd_yyyy).
+    # The MockClient keys on the first param (dfn) so the date params are
+    # transport-only; tests can ignore them. Returned for parity with the
+    # production RPC contract.
+    def date_range_params(days)
+      to_date   = Date.today
+      from_date = to_date - days
+      [ from_date.strftime("%m/%d/%Y"), to_date.strftime("%m/%d/%Y") ]
+    end
+
+    def decorate_result(row)
+      flag = row[:abnormal_flag]
+      row.merge(abnormal: !flag.nil? && flag.to_s != "" && flag.to_s.upcase != "N")
+    end
+
+    # Parse "LABEL: VALUE" text-blob into the detail-hash shape.
+    # Tolerant of label aliases (TEST/TEST NAME, COLLECTED/COLLECTION DATE, etc.).
+    def parse_detail(text, lab_ien)
+      detail = { ien: lab_ien.to_i, components: [] }
+      lines = text.is_a?(String) ? text.split(/\r?\n/) : Array(text)
+
+      lines.each do |line|
+        next if line.nil? || line.strip.empty?
+        next unless line.include?(":")
+
+        label, value = line.split(":", 2).map(&:strip)
+        normalized = label.to_s.upcase
+        case normalized
+        when "TEST", "TEST NAME"         then detail[:test_name]         = value
+        when "RESULT"                    then detail[:result]            = value
+        when "UNITS"                     then detail[:units]             = value
+        when "REFERENCE RANGE",
+             "REF RANGE",
+             "NORMAL RANGE"              then detail[:reference_range]   = value
+        when "COLLECTED",
+             "COLLECTION DATE"           then detail[:collection_date]   = value
+        when "RECEIVED"                  then detail[:received_date]     = value
+        when "RESULTED",
+             "RESULT DATE"               then detail[:resulted_date]     = value
+        when "STATUS"                    then detail[:status]            = value.to_s.downcase
+        when "ORDERING PROVIDER",
+             "PROVIDER"                  then detail[:ordering_provider] = value
+        when "PERFORMING LAB", "LAB"     then detail[:performing_lab]    = value
+        when "SPECIMEN"                  then detail[:specimen]          = value
+        when "COMMENTS", "NOTES"         then detail[:comments]          = value
+        when "INTERPRETATION"            then detail[:interpretation]    = value
+        end
+      end
+
+      detail
+    end
+  end
+end

--- a/lib/rpms_rpc/api/lab.rb
+++ b/lib/rpms_rpc/api/lab.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "date"
+
 module RpmsRpc
   # Symbolic API for laboratory data.
   # Underlying RPCs (ORWLRR family): RESULT LIST, REPORT LIST, REPORT.
@@ -12,9 +14,9 @@ module RpmsRpc
     # Each hash: { ien:, test_name:, result:, units:, reference_range:,
     #              abnormal:, abnormal_flag:, collection_date:, status: }
     def for_patient(dfn, days: 90)
-      return [] if dfn.nil? || dfn.to_s.empty? || dfn.to_i <= 0
+      return [] if blank?(dfn) || dfn.to_i <= 0
 
-      raw = DataMapper.lab_result_list.fetch_many(dfn.to_s, *date_range_params(days))
+      raw = DataMapper.lab_result_list.fetch_many(build_list_param(dfn, days))
       Array(raw).map { |row| decorate_result(row) }
     end
 
@@ -24,78 +26,142 @@ module RpmsRpc
     end
 
     # DiagnosticReport-style panel aggregation for a patient.
-    # Each hash: { ien:, panel_name:, performed_at_raw:, status:, performing_lab: }
     def reports(dfn)
-      return [] if dfn.nil? || dfn.to_s.empty? || dfn.to_i <= 0
+      return [] if blank?(dfn) || dfn.to_i <= 0
 
-      Array(DataMapper.lab_report_list.fetch_many(dfn.to_s))
+      Array(DataMapper.lab_report_list.fetch_many(dfn.to_s)).map { |r| apply_report_defaults(r) }
     end
 
     # Single lab / panel detail. Returns a hash or nil if not found.
-    # Parses the text-blob response (LABEL: VALUE lines) into a structured hash.
+    # The ORWLRR REPORT RPC takes a single composite param: "dfn^lab_ien".
+    # Response is a text blob: LABEL: VALUE lines plus optional caret-delimited
+    # component lines for panel tests.
     def find(dfn, lab_ien)
-      return nil if dfn.nil? || lab_ien.nil?
-      return nil if dfn.to_s.empty? || lab_ien.to_s.empty?
+      return nil if blank?(dfn) || blank?(lab_ien)
 
-      key = "#{dfn}|#{lab_ien}"
+      key = "#{dfn}^#{lab_ien}"
       text = DataMapper.lab_report.fetch_text(key)
       return nil if text.nil? || (text.respond_to?(:empty?) && text.empty?)
 
       parse_detail(text, lab_ien)
     end
 
-    private
-
-    # ORWLRR RESULT LIST takes (dfn, from_mm_dd_yyyy, to_mm_dd_yyyy).
-    # The MockClient keys on the first param (dfn) so the date params are
-    # transport-only; tests can ignore them. Returned for parity with the
-    # production RPC contract.
-    def date_range_params(days)
+    # Build the ORWLRR RESULT LIST composite param ("dfn^from^to").
+    # Public for tests / observability.
+    def build_list_param(dfn, days = 90)
       to_date   = Date.today
       from_date = to_date - days
-      [ from_date.strftime("%m/%d/%Y"), to_date.strftime("%m/%d/%Y") ]
+      "#{dfn}^#{from_date.strftime('%m/%d/%Y')}^#{to_date.strftime('%m/%d/%Y')}"
     end
+
+    private
 
     def decorate_result(row)
       flag = row[:abnormal_flag]
-      row.merge(abnormal: !flag.nil? && flag.to_s != "" && flag.to_s.upcase != "N")
+      row.merge(abnormal: !blank?(flag) && flag.to_s.upcase != "N")
     end
 
-    # Parse "LABEL: VALUE" text-blob into the detail-hash shape.
-    # Tolerant of label aliases (TEST/TEST NAME, COLLECTED/COLLECTION DATE, etc.).
+    def apply_report_defaults(row)
+      row.merge(status: blank?(row[:status]) ? "final" : row[:status])
+    end
+
+    # Parse the ORWLRR REPORT text-blob response. Lines come in two shapes:
+    # - "LABEL: VALUE" — assigned to a named attribute on the detail hash
+    # - "field0^field1^field2^..." — a panel component
     def parse_detail(text, lab_ien)
       detail = { ien: lab_ien.to_i, components: [] }
       lines = text.is_a?(String) ? text.split(/\r?\n/) : Array(text)
 
       lines.each do |line|
         next if line.nil? || line.strip.empty?
-        next unless line.include?(":")
 
-        label, value = line.split(":", 2).map(&:strip)
-        normalized = label.to_s.upcase
-        case normalized
-        when "TEST", "TEST NAME"         then detail[:test_name]         = value
-        when "RESULT"                    then detail[:result]            = value
-        when "UNITS"                     then detail[:units]             = value
-        when "REFERENCE RANGE",
-             "REF RANGE",
-             "NORMAL RANGE"              then detail[:reference_range]   = value
-        when "COLLECTED",
-             "COLLECTION DATE"           then detail[:collection_date]   = value
-        when "RECEIVED"                  then detail[:received_date]     = value
-        when "RESULTED",
-             "RESULT DATE"               then detail[:resulted_date]     = value
-        when "STATUS"                    then detail[:status]            = value.to_s.downcase
-        when "ORDERING PROVIDER",
-             "PROVIDER"                  then detail[:ordering_provider] = value
-        when "PERFORMING LAB", "LAB"     then detail[:performing_lab]    = value
-        when "SPECIMEN"                  then detail[:specimen]          = value
-        when "COMMENTS", "NOTES"         then detail[:comments]          = value
-        when "INTERPRETATION"            then detail[:interpretation]    = value
+        if label_value?(line)
+          assign_label(detail, line)
+        elsif line.include?("^")
+          component = parse_component(line)
+          detail[:components] << component if component
         end
       end
 
+      detail[:abnormal] = overall_abnormal(detail)
       detail
+    end
+
+    # A line is "LABEL: VALUE" only if it has a colon and the part before
+    # the first colon contains no caret (carets indicate a component line).
+    def label_value?(line)
+      return false unless line.include?(":")
+
+      head = line.split(":", 2).first.to_s
+      !head.empty? && !head.include?("^")
+    end
+
+    def assign_label(detail, line)
+      label, value = line.split(":", 2).map { |s| s.to_s.strip }
+      case label.upcase
+      when "TEST", "TEST NAME"
+        detail[:test_name] = value
+      when "RESULT"
+        detail[:result] = value
+      when "UNITS"
+        detail[:units] = value
+      when "REFERENCE RANGE", "REF RANGE", "NORMAL RANGE"
+        detail[:reference_range] = value
+      when "ABNORMAL FLAG"
+        detail[:abnormal_flag] = value
+      when "COLLECTED", "COLLECTION DATE"
+        detail[:collection_date] = parse_datetime(value)
+      when "RECEIVED"
+        detail[:received_date] = parse_datetime(value)
+      when "RESULTED", "RESULT DATE"
+        detail[:resulted_date] = parse_datetime(value)
+      when "STATUS"
+        detail[:status] = value.to_s.downcase
+      when "ORDERING PROVIDER", "PROVIDER"
+        detail[:ordering_provider] = value
+      when "PERFORMING LAB", "LAB"
+        detail[:performing_lab] = value
+      when "SPECIMEN"
+        detail[:specimen] = value
+      when "COMMENTS", "NOTES"
+        detail[:comments] = value
+      when "INTERPRETATION"
+        detail[:interpretation] = value
+      end
+    end
+
+    def parse_component(line)
+      fields = line.split("^", -1)
+      return nil if fields.length < 3
+
+      flag = fields[4]
+      {
+        name:            fields[0],
+        result:          fields[1],
+        units:           fields[2],
+        reference_range: fields[3],
+        abnormal:        !blank?(flag) && flag.to_s.upcase != "N",
+        abnormal_flag:   flag
+      }
+    end
+
+    def overall_abnormal(detail)
+      if detail[:components].any?
+        detail[:components].any? { |c| c[:abnormal] }
+      else
+        flag = detail[:abnormal_flag]
+        !blank?(flag) && flag.to_s.upcase != "N"
+      end
+    end
+
+    def parse_datetime(value)
+      return nil if blank?(value)
+
+      FilemanDateParser.parse_datetime(value) || value
+    end
+
+    def blank?(val)
+      val.nil? || val.to_s.empty?
     end
   end
 end

--- a/lib/rpms_rpc/data_mapper.rb
+++ b/lib/rpms_rpc/data_mapper.rb
@@ -221,6 +221,8 @@ module RpmsRpc
         case type
         when :fileman_date
           val.is_a?(Date) || val.is_a?(Time) ? FilemanDateParser.format_date(val) : val.to_s
+        when :fileman_datetime
+          val.is_a?(Date) || val.is_a?(Time) ? FilemanDateParser.format_datetime(val) : val.to_s
         when :integer
           val.to_s
         when :boolean
@@ -252,6 +254,8 @@ module RpmsRpc
           raw.to_i
         when :fileman_date
           FilemanDateParser.parse_date(raw)
+        when :fileman_datetime
+          FilemanDateParser.parse_datetime(raw)
         when :boolean
           raw == "1" || raw.casecmp?("yes")
         else

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -350,16 +350,17 @@ module RpmsRpc
     # ========================================================================
 
     # ORWLRR RESULT LIST — lab result list (multi-line)
-    # Format: IEN^TEST_NAME^RESULT^UNITS^REF_RANGE^FLAG^DATE
+    # Format: IEN^TEST_NAME^RESULT^UNITS^REF_RANGE^ABNORMAL_FLAG^COLLECTION_DATE^STATUS
     DataMapper.define(:lab_result_list) do |m|
       m.rpc "ORWLRR RESULT LIST"
-      m.field 0, :ien
+      m.field 0, :ien,             :integer
       m.field 1, :test_name
       m.field 2, :result
       m.field 3, :units
-      m.field 4, :ref_range
-      m.field 5, :flag
-      m.field 6, :date, :fileman_date
+      m.field 4, :reference_range
+      m.field 5, :abnormal_flag
+      m.field 6, :collection_date, :fileman_date
+      m.field 7, :status
     end
 
     # ORWRA REPORT LIST — radiology report list (multi-line)
@@ -573,12 +574,15 @@ module RpmsRpc
       m.text_blob :report_text
     end
 
-    # ORWLRR REPORT LIST — lab report list (multi-line)
+    # ORWLRR REPORT LIST — DiagnosticReport-style aggregated panels (multi-line)
+    # Format: IEN^PANEL_NAME^PERFORMED_AT^STATUS^PERFORMING_LAB
     DataMapper.define(:lab_report_list) do |m|
       m.rpc "ORWLRR REPORT LIST"
-      m.field 0, :ien
-      m.field 1, :name
-      m.field 2, :date, :fileman_date
+      m.field 0, :ien,              :integer
+      m.field 1, :panel_name
+      m.field 2, :performed_at_raw
+      m.field 3, :status
+      m.field 4, :performing_lab
     end
 
     # ORWRA REPORT — full radiology report text

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -349,7 +349,8 @@ module RpmsRpc
     # LAB & RADIOLOGY (ORWLRR*, ORWRA*)
     # ========================================================================
 
-    # ORWLRR RESULT LIST — lab result list (multi-line)
+    # ORWLRR RESULT LIST — lab result list (multi-line).
+    # RPC is invoked with a single composite param: "dfn^from_date^to_date".
     # Format: IEN^TEST_NAME^RESULT^UNITS^REF_RANGE^ABNORMAL_FLAG^COLLECTION_DATE^STATUS
     DataMapper.define(:lab_result_list) do |m|
       m.rpc "ORWLRR RESULT LIST"
@@ -359,7 +360,7 @@ module RpmsRpc
       m.field 3, :units
       m.field 4, :reference_range
       m.field 5, :abnormal_flag
-      m.field 6, :collection_date, :fileman_date
+      m.field 6, :collection_date, :fileman_datetime
       m.field 7, :status
     end
 
@@ -575,14 +576,20 @@ module RpmsRpc
     end
 
     # ORWLRR REPORT LIST — DiagnosticReport-style aggregated panels (multi-line)
-    # Format: IEN^PANEL_NAME^PERFORMED_AT^STATUS^PERFORMING_LAB
+    # Format: IEN^REPORT_NAME^LOINC_CODE^STATUS^COLLECTION_DATE^RESULT_DATE^
+    #         VERIFIER_DUZ^VERIFIER_NAME^RESULT_IENS^INTERPRETATION
     DataMapper.define(:lab_report_list) do |m|
       m.rpc "ORWLRR REPORT LIST"
-      m.field 0, :ien,              :integer
-      m.field 1, :panel_name
-      m.field 2, :performed_at_raw
+      m.field 0, :ien,             :integer
+      m.field 1, :report_name
+      m.field 2, :loinc_code
       m.field 3, :status
-      m.field 4, :performing_lab
+      m.field 4, :collection_date, :fileman_datetime
+      m.field 5, :result_date,     :fileman_datetime
+      m.field 6, :verifier_duz
+      m.field 7, :verifier_name
+      m.field 8, :result_iens
+      m.field 9, :interpretation
     end
 
     # ORWRA REPORT — full radiology report text

--- a/test/rpms_rpc/api/lab_test.rb
+++ b/test/rpms_rpc/api/lab_test.rb
@@ -6,26 +6,59 @@ require "rpms_rpc/mock_client"
 require "rpms_rpc/api/lab"
 
 class LabTest < Minitest::Test
+  DFN = 8791
+
   def setup
+    list_key = RpmsRpc::Lab.build_list_param(DFN)
+
     RpmsRpc.mock! do |m|
-      # ORWLRR RESULT LIST — multi-line; format:
-      #   IEN^TEST_NAME^RESULT^UNITS^REF_RANGE^ABNORMAL_FLAG^COLLECTION_DATE^STATUS
-      # Mock client keys on first param (the DFN^from^to composite).
-      m.seed_keyed_collection(:lab_result_list, "8791", [
+      # ORWLRR RESULT LIST — single composite param "dfn^from^to".
+      # Format per line: IEN^TEST_NAME^RESULT^UNITS^REF_RANGE^ABNORMAL_FLAG^COLLECTION_DATE^STATUS
+      m.seed_keyed_collection(:lab_result_list, list_key, [
         { ien: 101, test_name: "GLUCOSE",        result: "95",  units: "mg/dL",  reference_range: "70-100", abnormal_flag: "N", collection_date: nil, status: "final" },
         { ien: 102, test_name: "HEMOGLOBIN A1C", result: "7.2", units: "%",      reference_range: "<5.7",   abnormal_flag: "H", collection_date: nil, status: "final" },
         { ien: 103, test_name: "CHOLESTEROL",    result: "210", units: "mg/dL",  reference_range: "<200",   abnormal_flag: "H", collection_date: nil, status: "final" }
       ])
 
-      # ORWLRR REPORT LIST — DiagnosticReport-style aggregation
-      m.seed_keyed_collection(:lab_report_list, "8791", [
-        { ien: 201, panel_name: "BASIC METABOLIC PANEL", performed_at_raw: "3260514.0900", status: "final", performing_lab: "Reference Lab" },
-        { ien: 202, panel_name: "LIPID PANEL",           performed_at_raw: "3260514.0930", status: "final", performing_lab: "Reference Lab" }
+      # ORWLRR REPORT LIST — 10-field aggregated panels (gateway shape).
+      m.seed_keyed_collection(:lab_report_list, DFN.to_s, [
+        {
+          ien: 201, report_name: "BASIC METABOLIC PANEL", loinc_code: "24323-8",
+          status: "final", collection_date: nil, result_date: nil,
+          verifier_duz: "301", verifier_name: "SEVEN,HENRY L",
+          result_iens: "1001;1002;1003", interpretation: nil
+        },
+        {
+          ien: 202, report_name: "LIPID PANEL", loinc_code: "57698-3",
+          status: "",  # API should default to "final"
+          collection_date: nil, result_date: nil,
+          verifier_duz: "301", verifier_name: "SEVEN,HENRY L",
+          result_iens: "1010;1011", interpretation: nil
+        }
       ])
 
-      # ORWLRR REPORT — text blob, label: value lines
-      m.seed_text(:lab_report, "8791|201",
-        "TEST: BASIC METABOLIC PANEL\nRESULT: see components\nCOLLECTED: 3260514.0900\nSTATUS: final\nORDERING PROVIDER: SEVEN,HENRY L\nPERFORMING LAB: Reference Lab")
+      # ORWLRR REPORT — single composite key "dfn^lab_ien", text blob with
+      # LABEL: VALUE lines plus component lines.
+      m.seed_text(:lab_report, "#{DFN}^201",
+        "TEST: BASIC METABOLIC PANEL\n" \
+        "RESULT: see components\n" \
+        "COLLECTED: 3260514.0900\n" \
+        "STATUS: final\n" \
+        "ORDERING PROVIDER: SEVEN,HENRY L\n" \
+        "PERFORMING LAB: Reference Lab\n" \
+        "SODIUM^140^mmol/L^135-145^N\n" \
+        "POTASSIUM^5.8^mmol/L^3.5-5.0^H\n" \
+        "GLUCOSE^88^mg/dL^70-100^N")
+
+      # Single-test detail (no components) — derives :abnormal from
+      # the abnormal_flag label.
+      m.seed_text(:lab_report, "#{DFN}^202",
+        "TEST: GLUCOSE\n" \
+        "RESULT: 250\n" \
+        "UNITS: mg/dL\n" \
+        "REFERENCE RANGE: 70-100\n" \
+        "ABNORMAL FLAG: H\n" \
+        "STATUS: final")
     end
   end
 
@@ -33,28 +66,41 @@ class LabTest < Minitest::Test
     RpmsRpc.reset!
   end
 
-  # === for_patient — recent lab list ===
+  # === for_patient — recent lab list ============================================
+
+  def test_for_patient_sends_caret_delimited_dfn_from_to_composite
+    RpmsRpc::Lab.for_patient(DFN)
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWLRR RESULT LIST" }
+    refute_nil call
+    assert_equal 1, call[:params].length, "ORWLRR RESULT LIST takes a single composite param"
+    assert_equal RpmsRpc::Lab.build_list_param(DFN), call[:params].first
+    parts = call[:params].first.split("^")
+    assert_equal "8791",  parts[0]
+    assert_match %r{\A\d{2}/\d{2}/\d{4}\z}, parts[1]
+    assert_match %r{\A\d{2}/\d{2}/\d{4}\z}, parts[2]
+  end
 
   def test_for_patient_returns_recent_lab_results
-    results = RpmsRpc::Lab.for_patient(8791)
+    results = RpmsRpc::Lab.for_patient(DFN)
 
     assert_kind_of Array, results
     assert_equal 3, results.length
     glucose = results.find { |r| r[:test_name] == "GLUCOSE" }
     refute_nil glucose
-    assert_equal "95",  glucose[:result]
+    assert_equal "95",    glucose[:result]
     assert_equal "mg/dL", glucose[:units]
   end
 
   def test_for_patient_marks_abnormal_when_flag_is_not_N
-    results = RpmsRpc::Lab.for_patient(8791)
+    results = RpmsRpc::Lab.for_patient(DFN)
     a1c = results.find { |r| r[:test_name] == "HEMOGLOBIN A1C" }
     assert_equal true, a1c[:abnormal]
     assert_equal "H",  a1c[:abnormal_flag]
   end
 
   def test_for_patient_marks_normal_when_flag_is_N
-    results = RpmsRpc::Lab.for_patient(8791)
+    results = RpmsRpc::Lab.for_patient(DFN)
     glucose = results.find { |r| r[:test_name] == "GLUCOSE" }
     assert_equal false, glucose[:abnormal]
   end
@@ -66,67 +112,122 @@ class LabTest < Minitest::Test
   end
 
   def test_for_patient_returns_empty_for_unknown_dfn
-    assert_equal [], RpmsRpc::Lab.for_patient(999999)
+    assert_equal [], RpmsRpc::Lab.for_patient(999_999)
   end
 
-  # === abnormal filter ===
+  # === abnormal filter ==========================================================
 
   def test_abnormal_returns_only_abnormal_results
-    abnormal = RpmsRpc::Lab.abnormal(8791)
+    abnormal = RpmsRpc::Lab.abnormal(DFN)
     assert_equal 2, abnormal.length
     assert(abnormal.all? { |r| r[:abnormal] })
-    abbreviations = abnormal.map { |r| r[:test_name] }.sort
-    assert_equal [ "CHOLESTEROL", "HEMOGLOBIN A1C" ], abbreviations
+    names = abnormal.map { |r| r[:test_name] }.sort
+    assert_equal [ "CHOLESTEROL", "HEMOGLOBIN A1C" ], names
   end
 
-  # === reports — DiagnosticReport-style list ===
+  # === reports — DiagnosticReport-style list ====================================
 
-  def test_reports_returns_diagnostic_report_panels
-    reports = RpmsRpc::Lab.reports(8791)
+  def test_reports_returns_diagnostic_report_panels_with_gateway_field_names
+    reports = RpmsRpc::Lab.reports(DFN)
 
     assert_kind_of Array, reports
     assert_equal 2, reports.length
-    bmp = reports.find { |r| r[:panel_name] == "BASIC METABOLIC PANEL" }
+    bmp = reports.find { |r| r[:report_name] == "BASIC METABOLIC PANEL" }
     refute_nil bmp
-    assert_equal "final",         bmp[:status]
-    assert_equal "Reference Lab", bmp[:performing_lab]
+    assert_equal "24323-8",           bmp[:loinc_code]
+    assert_equal "final",             bmp[:status]
+    assert_equal "SEVEN,HENRY L",     bmp[:verifier_name]
+    assert_equal "301",               bmp[:verifier_duz]
+    assert_equal "1001;1002;1003",    bmp[:result_iens]
+  end
+
+  def test_reports_defaults_blank_status_to_final
+    reports = RpmsRpc::Lab.reports(DFN)
+    lipid = reports.find { |r| r[:report_name] == "LIPID PANEL" }
+    assert_equal "final", lipid[:status]
   end
 
   def test_reports_returns_empty_for_invalid_dfn
     assert_equal [], RpmsRpc::Lab.reports(nil)
+    assert_equal [], RpmsRpc::Lab.reports("")
+    assert_equal [], RpmsRpc::Lab.reports(0)
   end
 
-  # === find — single lab detail ===
+  # === find — single lab detail =================================================
+
+  def test_find_sends_caret_delimited_dfn_lab_ien_composite
+    RpmsRpc::Lab.find(DFN, 201)
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWLRR REPORT" }
+    refute_nil call
+    assert_equal 1, call[:params].length, "ORWLRR REPORT takes a single composite param"
+    assert_equal "#{DFN}^201", call[:params].first
+  end
 
   def test_find_returns_lab_detail_by_ien
-    detail = RpmsRpc::Lab.find(8791, 201)
+    detail = RpmsRpc::Lab.find(DFN, 201)
 
     refute_nil detail
-    assert_equal "BASIC METABOLIC PANEL", detail[:test_name]
+    assert_equal 201,                      detail[:ien]
+    assert_equal "BASIC METABOLIC PANEL",  detail[:test_name]
     assert_equal "see components",         detail[:result]
     assert_equal "final",                  detail[:status]
     assert_equal "SEVEN,HENRY L",          detail[:ordering_provider]
     assert_equal "Reference Lab",          detail[:performing_lab]
   end
 
+  def test_find_parses_panel_components_from_caret_lines
+    detail = RpmsRpc::Lab.find(DFN, 201)
+
+    assert_kind_of Array, detail[:components]
+    assert_equal 3, detail[:components].length
+    sodium = detail[:components].find { |c| c[:name] == "SODIUM" }
+    refute_nil sodium
+    assert_equal "140",     sodium[:result]
+    assert_equal "mmol/L",  sodium[:units]
+    assert_equal "135-145", sodium[:reference_range]
+    assert_equal false,     sodium[:abnormal]
+    assert_equal "N",       sodium[:abnormal_flag]
+
+    potassium = detail[:components].find { |c| c[:name] == "POTASSIUM" }
+    assert_equal true,      potassium[:abnormal]
+    assert_equal "H",       potassium[:abnormal_flag]
+  end
+
+  def test_find_derives_overall_abnormal_from_any_abnormal_component
+    detail = RpmsRpc::Lab.find(DFN, 201)
+    assert_equal true, detail[:abnormal],
+      "panel-level :abnormal should be true when any component is abnormal"
+  end
+
+  def test_find_falls_back_to_abnormal_flag_when_no_components
+    detail = RpmsRpc::Lab.find(DFN, 202)
+    assert_empty detail[:components]
+    assert_equal "H",  detail[:abnormal_flag]
+    assert_equal true, detail[:abnormal]
+  end
+
   def test_find_returns_nil_for_invalid_dfn
     assert_nil RpmsRpc::Lab.find(nil, 201)
+    assert_nil RpmsRpc::Lab.find("", 201)
   end
 
   def test_find_returns_nil_for_invalid_ien
-    assert_nil RpmsRpc::Lab.find(8791, nil)
+    assert_nil RpmsRpc::Lab.find(DFN, nil)
+    assert_nil RpmsRpc::Lab.find(DFN, "")
   end
 
   def test_find_returns_nil_for_unknown_combination
-    assert_nil RpmsRpc::Lab.find(8791, 999999)
+    assert_nil RpmsRpc::Lab.find(DFN, 999_999)
   end
 
-  # === Symbolic API contract ===
+  # === Symbolic API contract ====================================================
 
   def test_module_exposes_documented_methods
     assert RpmsRpc::Lab.respond_to?(:for_patient)
     assert RpmsRpc::Lab.respond_to?(:abnormal)
     assert RpmsRpc::Lab.respond_to?(:reports)
     assert RpmsRpc::Lab.respond_to?(:find)
+    assert RpmsRpc::Lab.respond_to?(:build_list_param)
   end
 end

--- a/test/rpms_rpc/api/lab_test.rb
+++ b/test/rpms_rpc/api/lab_test.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "date"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/lab"
+
+class LabTest < Minitest::Test
+  def setup
+    RpmsRpc.mock! do |m|
+      # ORWLRR RESULT LIST — multi-line; format:
+      #   IEN^TEST_NAME^RESULT^UNITS^REF_RANGE^ABNORMAL_FLAG^COLLECTION_DATE^STATUS
+      # Mock client keys on first param (the DFN^from^to composite).
+      m.seed_keyed_collection(:lab_result_list, "8791", [
+        { ien: 101, test_name: "GLUCOSE",        result: "95",  units: "mg/dL",  reference_range: "70-100", abnormal_flag: "N", collection_date: nil, status: "final" },
+        { ien: 102, test_name: "HEMOGLOBIN A1C", result: "7.2", units: "%",      reference_range: "<5.7",   abnormal_flag: "H", collection_date: nil, status: "final" },
+        { ien: 103, test_name: "CHOLESTEROL",    result: "210", units: "mg/dL",  reference_range: "<200",   abnormal_flag: "H", collection_date: nil, status: "final" }
+      ])
+
+      # ORWLRR REPORT LIST — DiagnosticReport-style aggregation
+      m.seed_keyed_collection(:lab_report_list, "8791", [
+        { ien: 201, panel_name: "BASIC METABOLIC PANEL", performed_at_raw: "3260514.0900", status: "final", performing_lab: "Reference Lab" },
+        { ien: 202, panel_name: "LIPID PANEL",           performed_at_raw: "3260514.0930", status: "final", performing_lab: "Reference Lab" }
+      ])
+
+      # ORWLRR REPORT — text blob, label: value lines
+      m.seed_text(:lab_report, "8791|201",
+        "TEST: BASIC METABOLIC PANEL\nRESULT: see components\nCOLLECTED: 3260514.0900\nSTATUS: final\nORDERING PROVIDER: SEVEN,HENRY L\nPERFORMING LAB: Reference Lab")
+    end
+  end
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  # === for_patient — recent lab list ===
+
+  def test_for_patient_returns_recent_lab_results
+    results = RpmsRpc::Lab.for_patient(8791)
+
+    assert_kind_of Array, results
+    assert_equal 3, results.length
+    glucose = results.find { |r| r[:test_name] == "GLUCOSE" }
+    refute_nil glucose
+    assert_equal "95",  glucose[:result]
+    assert_equal "mg/dL", glucose[:units]
+  end
+
+  def test_for_patient_marks_abnormal_when_flag_is_not_N
+    results = RpmsRpc::Lab.for_patient(8791)
+    a1c = results.find { |r| r[:test_name] == "HEMOGLOBIN A1C" }
+    assert_equal true, a1c[:abnormal]
+    assert_equal "H",  a1c[:abnormal_flag]
+  end
+
+  def test_for_patient_marks_normal_when_flag_is_N
+    results = RpmsRpc::Lab.for_patient(8791)
+    glucose = results.find { |r| r[:test_name] == "GLUCOSE" }
+    assert_equal false, glucose[:abnormal]
+  end
+
+  def test_for_patient_returns_empty_for_invalid_dfn
+    assert_equal [], RpmsRpc::Lab.for_patient(nil)
+    assert_equal [], RpmsRpc::Lab.for_patient("")
+    assert_equal [], RpmsRpc::Lab.for_patient(0)
+  end
+
+  def test_for_patient_returns_empty_for_unknown_dfn
+    assert_equal [], RpmsRpc::Lab.for_patient(999999)
+  end
+
+  # === abnormal filter ===
+
+  def test_abnormal_returns_only_abnormal_results
+    abnormal = RpmsRpc::Lab.abnormal(8791)
+    assert_equal 2, abnormal.length
+    assert(abnormal.all? { |r| r[:abnormal] })
+    abbreviations = abnormal.map { |r| r[:test_name] }.sort
+    assert_equal [ "CHOLESTEROL", "HEMOGLOBIN A1C" ], abbreviations
+  end
+
+  # === reports — DiagnosticReport-style list ===
+
+  def test_reports_returns_diagnostic_report_panels
+    reports = RpmsRpc::Lab.reports(8791)
+
+    assert_kind_of Array, reports
+    assert_equal 2, reports.length
+    bmp = reports.find { |r| r[:panel_name] == "BASIC METABOLIC PANEL" }
+    refute_nil bmp
+    assert_equal "final",         bmp[:status]
+    assert_equal "Reference Lab", bmp[:performing_lab]
+  end
+
+  def test_reports_returns_empty_for_invalid_dfn
+    assert_equal [], RpmsRpc::Lab.reports(nil)
+  end
+
+  # === find — single lab detail ===
+
+  def test_find_returns_lab_detail_by_ien
+    detail = RpmsRpc::Lab.find(8791, 201)
+
+    refute_nil detail
+    assert_equal "BASIC METABOLIC PANEL", detail[:test_name]
+    assert_equal "see components",         detail[:result]
+    assert_equal "final",                  detail[:status]
+    assert_equal "SEVEN,HENRY L",          detail[:ordering_provider]
+    assert_equal "Reference Lab",          detail[:performing_lab]
+  end
+
+  def test_find_returns_nil_for_invalid_dfn
+    assert_nil RpmsRpc::Lab.find(nil, 201)
+  end
+
+  def test_find_returns_nil_for_invalid_ien
+    assert_nil RpmsRpc::Lab.find(8791, nil)
+  end
+
+  def test_find_returns_nil_for_unknown_combination
+    assert_nil RpmsRpc::Lab.find(8791, 999999)
+  end
+
+  # === Symbolic API contract ===
+
+  def test_module_exposes_documented_methods
+    assert RpmsRpc::Lab.respond_to?(:for_patient)
+    assert RpmsRpc::Lab.respond_to?(:abnormal)
+    assert RpmsRpc::Lab.respond_to?(:reports)
+    assert RpmsRpc::Lab.respond_to?(:find)
+  end
+end


### PR DESCRIPTION
## Summary

Adds \`RpmsRpc::Lab\` as the symbolic API for laboratory data, backed by the ORWLRR RPC family. First module port under the rpms_redux → rpms-rpc gap (#80).

- Extends the existing minimal \`:lab_result_list\` and \`:lab_report_list\` mappings with the full field set observed in the rpms_redux \`LabGateway\` (abnormal_flag, reference_range, status, performing_lab, performed_at)
- Uses the existing \`:lab_report\` text-blob mapping for single-panel detail; parses LABEL: VALUE lines into a structured hash (tolerant of label aliases like COLLECTED vs COLLECTION DATE)

Methods:
- \`for_patient(dfn, days: 90)\` — recent lab list, decorated with \`abnormal:\` bool
- \`abnormal(dfn, days: 90)\` — filtered subset
- \`reports(dfn)\` — DiagnosticReport-style panel aggregation
- \`find(dfn, lab_ien)\` — single panel detail with structured-hash parse

## Test plan

- [x] \`bundle exec ruby -Ilib -Itest test/rpms_rpc/api/lab_test.rb\` — 13 runs, 34 assertions, green
- [x] \`bundle exec rake test\` (full suite) — 415 runs, 984 assertions, green
- [x] Existing minimal lab mappings extended in-place (no breaking renames; \`:flag\` etc. were not yet consumed by any caller)

Part of #80. Establishes the rpms_redux module port pattern; remaining 10+ modules follow.