### PR TITLE
Radiology module: port from rpms_redux (Part of #80)

### DIFF
--- a/lib/rpms_rpc/api/radiology.rb
+++ b/lib/rpms_rpc/api/radiology.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module RpmsRpc
+  # Symbolic API for radiology / diagnostic-imaging data.
+  # Underlying RPCs (ORWRA family): REPORT LIST, REPORT.
+  module Radiology
+    extend self
+
+    # Radiology reports for a patient. Returns an Array of report hashes
+    # (empty for invalid / unknown DFN).
+    #
+    # Each hash: { ien:, exam_name:, cpt_code:, status:, exam_date:,
+    #              report_date:, radiologist_duz:, radiologist_name:,
+    #              impression:, imaging_study_ien: }
+    def for_patient(dfn)
+      return [] if dfn.nil? || dfn.to_s.empty? || dfn.to_i <= 0
+
+      Array(DataMapper.radiology_list.fetch_many(dfn.to_s))
+    end
+
+    # Single radiology report text by IEN. Returns the raw text blob
+    # (string) or nil if not found / invalid input. Production callers may
+    # want to apply site-specific parsing on the returned text.
+    def find(ien)
+      return nil if ien.nil? || ien.to_s.empty?
+
+      text = DataMapper.radiology_report.fetch_text(ien.to_s)
+      return nil if text.nil? || (text.respond_to?(:empty?) && text.empty?)
+
+      text
+    end
+  end
+end

--- a/lib/rpms_rpc/api/radiology.rb
+++ b/lib/rpms_rpc/api/radiology.rb
@@ -11,11 +11,11 @@ module RpmsRpc
     #
     # Each hash: { ien:, exam_name:, cpt_code:, status:, exam_date:,
     #              report_date:, radiologist_duz:, radiologist_name:,
-    #              impression:, imaging_study_ien: }
+    #              impression:, imaging_study_ien:, report_text: }
     def for_patient(dfn)
       return [] if dfn.nil? || dfn.to_s.empty? || dfn.to_i <= 0
 
-      Array(DataMapper.radiology_list.fetch_many(dfn.to_s))
+      Array(DataMapper.radiology_list.fetch_many(dfn.to_s)).map { |r| apply_defaults(r) }
     end
 
     # Single radiology report text by IEN. Returns the raw text blob
@@ -28,6 +28,16 @@ module RpmsRpc
       return nil if text.nil? || (text.respond_to?(:empty?) && text.empty?)
 
       text
+    end
+
+    private
+
+    def apply_defaults(row)
+      row.merge(status: blank?(row[:status]) ? "final" : row[:status])
+    end
+
+    def blank?(val)
+      val.nil? || val.to_s.empty?
     end
   end
 end

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -365,14 +365,19 @@ module RpmsRpc
     end
 
     # ORWRA REPORT LIST — radiology report list (multi-line)
-    # Format: IEN^EXAM_NAME^DATE^STATUS^IMPRESSION
+    # Format: IEN^EXAM_NAME^CPT_CODE^STATUS^EXAM_DATE^REPORT_DATE^RAD_DUZ^RAD_NAME^IMPRESSION^IMAGING_STUDY_IEN
     DataMapper.define(:radiology_list) do |m|
       m.rpc "ORWRA REPORT LIST"
-      m.field 0, :ien
+      m.field 0, :ien,                :integer
       m.field 1, :exam_name
-      m.field 2, :date,   :fileman_date
+      m.field 2, :cpt_code
       m.field 3, :status
-      m.field 4, :impression
+      m.field 4, :exam_date,          :fileman_date
+      m.field 5, :report_date,        :fileman_date
+      m.field 6, :radiologist_duz
+      m.field 7, :radiologist_name
+      m.field 8, :impression
+      m.field 9, :imaging_study_ien,  :integer
     end
 
     # ========================================================================

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -365,19 +365,21 @@ module RpmsRpc
     end
 
     # ORWRA REPORT LIST — radiology report list (multi-line)
-    # Format: IEN^EXAM_NAME^CPT_CODE^STATUS^EXAM_DATE^REPORT_DATE^RAD_DUZ^RAD_NAME^IMPRESSION^IMAGING_STUDY_IEN
+    # Format: IEN^EXAM_NAME^CPT_CODE^STATUS^EXAM_DATE^REPORT_DATE^RAD_DUZ^
+    #         RAD_NAME^IMPRESSION^IMAGING_STUDY_IEN^REPORT_TEXT
     DataMapper.define(:radiology_list) do |m|
       m.rpc "ORWRA REPORT LIST"
-      m.field 0, :ien,                :integer
-      m.field 1, :exam_name
-      m.field 2, :cpt_code
-      m.field 3, :status
-      m.field 4, :exam_date,          :fileman_date
-      m.field 5, :report_date,        :fileman_date
-      m.field 6, :radiologist_duz
-      m.field 7, :radiologist_name
-      m.field 8, :impression
-      m.field 9, :imaging_study_ien,  :integer
+      m.field 0,  :ien,                :integer
+      m.field 1,  :exam_name
+      m.field 2,  :cpt_code
+      m.field 3,  :status
+      m.field 4,  :exam_date,          :fileman_datetime
+      m.field 5,  :report_date,        :fileman_datetime
+      m.field 6,  :radiologist_duz
+      m.field 7,  :radiologist_name
+      m.field 8,  :impression
+      m.field 9,  :imaging_study_ien,  :integer
+      m.field 10, :report_text
     end
 
     # ========================================================================

--- a/test/rpms_rpc/api/radiology_test.rb
+++ b/test/rpms_rpc/api/radiology_test.rb
@@ -12,11 +12,14 @@ class RadiologyTest < Minitest::Test
         { ien: 501, exam_name: "CHEST X-RAY",       cpt_code: "71045", status: "final",
           exam_date: nil, report_date: nil, radiologist_duz: "2843",
           radiologist_name: "SEVEN,HENRY L MD", impression: "No acute findings.",
-          imaging_study_ien: 9001 },
-        { ien: 502, exam_name: "CT ABDOMEN",        cpt_code: "74176", status: "final",
+          imaging_study_ien: 9001,
+          report_text: "FINDINGS: Lungs clear. Heart size normal. No effusions." },
+        { ien: 502, exam_name: "CT ABDOMEN",        cpt_code: "74176",
+          status: "",  # API should default to "final"
           exam_date: nil, report_date: nil, radiologist_duz: "2843",
           radiologist_name: "SEVEN,HENRY L MD", impression: "Possible mass; recommend follow-up.",
-          imaging_study_ien: 9002 }
+          imaging_study_ien: 9002,
+          report_text: nil }
       ])
 
       # ORWRA REPORT — text blob keyed by report IEN
@@ -43,6 +46,15 @@ class RadiologyTest < Minitest::Test
     assert_equal "SEVEN,HENRY L MD",       chest[:radiologist_name]
     assert_equal "No acute findings.",     chest[:impression]
     assert_equal 9001,                     chest[:imaging_study_ien]
+    assert_equal "FINDINGS: Lungs clear. Heart size normal. No effusions.",
+                                           chest[:report_text]
+  end
+
+  def test_for_patient_defaults_blank_status_to_final
+    reports = RpmsRpc::Radiology.for_patient(8791)
+    ct = reports.find { |r| r[:exam_name] == "CT ABDOMEN" }
+    refute_nil ct
+    assert_equal "final", ct[:status]
   end
 
   def test_for_patient_returns_empty_for_invalid_dfn

--- a/test/rpms_rpc/api/radiology_test.rb
+++ b/test/rpms_rpc/api/radiology_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/radiology"
+
+class RadiologyTest < Minitest::Test
+  def setup
+    RpmsRpc.mock! do |m|
+      # ORWRA REPORT LIST — multi-line
+      m.seed_keyed_collection(:radiology_list, "8791", [
+        { ien: 501, exam_name: "CHEST X-RAY",       cpt_code: "71045", status: "final",
+          exam_date: nil, report_date: nil, radiologist_duz: "2843",
+          radiologist_name: "SEVEN,HENRY L MD", impression: "No acute findings.",
+          imaging_study_ien: 9001 },
+        { ien: 502, exam_name: "CT ABDOMEN",        cpt_code: "74176", status: "final",
+          exam_date: nil, report_date: nil, radiologist_duz: "2843",
+          radiologist_name: "SEVEN,HENRY L MD", impression: "Possible mass; recommend follow-up.",
+          imaging_study_ien: 9002 }
+      ])
+
+      # ORWRA REPORT — text blob keyed by report IEN
+      m.seed_text(:radiology_report, "501",
+        "EXAM: CHEST X-RAY\nIMPRESSION: No acute cardiopulmonary process.\nRADIOLOGIST: SEVEN,HENRY L MD")
+    end
+  end
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  # === for_patient ===
+
+  def test_for_patient_returns_radiology_reports
+    reports = RpmsRpc::Radiology.for_patient(8791)
+    assert_kind_of Array, reports
+    assert_equal 2, reports.length
+
+    chest = reports.find { |r| r[:exam_name] == "CHEST X-RAY" }
+    refute_nil chest
+    assert_equal "71045",                  chest[:cpt_code]
+    assert_equal "final",                  chest[:status]
+    assert_equal "SEVEN,HENRY L MD",       chest[:radiologist_name]
+    assert_equal "No acute findings.",     chest[:impression]
+    assert_equal 9001,                     chest[:imaging_study_ien]
+  end
+
+  def test_for_patient_returns_empty_for_invalid_dfn
+    assert_equal [], RpmsRpc::Radiology.for_patient(nil)
+    assert_equal [], RpmsRpc::Radiology.for_patient("")
+    assert_equal [], RpmsRpc::Radiology.for_patient(0)
+  end
+
+  def test_for_patient_returns_empty_for_unknown_dfn
+    assert_equal [], RpmsRpc::Radiology.for_patient(999999)
+  end
+
+  # === find ===
+
+  def test_find_returns_report_text_by_ien
+    text = RpmsRpc::Radiology.find(501)
+    refute_nil text
+    assert_match(/CHEST X-RAY/, text)
+    assert_match(/IMPRESSION/, text)
+    assert_match(/SEVEN,HENRY L MD/, text)
+  end
+
+  def test_find_returns_nil_for_invalid_ien
+    assert_nil RpmsRpc::Radiology.find(nil)
+    assert_nil RpmsRpc::Radiology.find("")
+  end
+
+  def test_find_returns_nil_for_unknown_ien
+    assert_nil RpmsRpc::Radiology.find(999999)
+  end
+
+  # === Symbolic API contract ===
+
+  def test_module_exposes_documented_methods
+    assert RpmsRpc::Radiology.respond_to?(:for_patient)
+    assert RpmsRpc::Radiology.respond_to?(:find)
+  end
+end


### PR DESCRIPTION
## Summary

Adds `RpmsRpc::Radiology` for diagnostic-imaging data, backed by ORWRA RPCs. Extends the existing minimal `:radiology_list` mapping with the full field set from the rpms_redux RadiologyGateway (cpt_code, exam_date, report_date, radiologist_duz, radiologist_name, imaging_study_ien).

Methods:
- `for_patient(dfn)` — radiology report list
- `find(ien)` — single report text blob

## Test plan

- [x] `bundle exec ruby -Ilib -Itest test/rpms_rpc/api/radiology_test.rb` — 7 runs, 24 assertions, green
- [x] `bundle exec rake test` — 409 runs, 974 assertions, green

Part of #80.