### PR TITLE
Eprescribing module: port from rpms_redux (Part of #80)

### DIFF
--- a/lib/rpms_rpc/api/eprescribing.rb
+++ b/lib/rpms_rpc/api/eprescribing.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module RpmsRpc
+  # Symbolic API for e-prescribing.
+  # Underlying RPCs (PSO* family): PSO NEW RX, PSO ERX STATUS, PSO CANCEL RX.
+  #
+  # Return shapes are plain hashes — engine-layer callers wrap these in a
+  # Result + state machine (see lakeraven-ehr Rpms::Eprescribing).
+  module Eprescribing
+    extend self
+
+    RX_PARAM_ORDER = %i[
+      patient_dfn
+      medication_code
+      medication_display
+      dosage_instruction
+      route
+      frequency
+      dispense_quantity
+      refills
+      days_supply
+      pharmacy_ien
+      requester_duz
+    ].freeze
+
+    CANONICAL_STATUS = {
+      "transmitted" => "transmitted",
+      "sent"        => "transmitted",
+      "delivered"   => "delivered",
+      "received"    => "delivered",
+      "cancelled"   => "cancelled",
+      "voided"      => "cancelled",
+      "error"       => "error",
+      "failed"      => "error"
+    }.freeze
+
+    # Transmit a prescription. Returns:
+    #   { success: true, transmission_id: "..." }
+    #   { success: false, error: "..." }
+    def transmit(attrs)
+      param = build_rx_param(attrs)
+      result = DataMapper.prescription_new.fetch_one(param)
+      return { success: false, error: "Empty response from RPMS" } if result.nil?
+
+      if result[:success]
+        { success: true, transmission_id: result[:rx_ien_or_error].to_s }
+      else
+        { success: false, error: result[:rx_ien_or_error] || "Unknown RPMS error" }
+      end
+    end
+
+    # Check transmission status. Returns:
+    #   { status: "transmitted" | "delivered" | "cancelled" | "error" | "queued" }
+    # plus { error: "..." } when status is "error".
+    def status(transmission_id)
+      return { status: "error", error: "transmission_id is required" } if blank?(transmission_id)
+
+      result = DataMapper.erx_status.fetch_one(transmission_id.to_s)
+      return { status: "error", error: "Empty response from RPMS" } if result.nil?
+
+      mapped = CANONICAL_STATUS.fetch(result[:status].to_s.strip.downcase, "queued")
+      out = { status: mapped }
+      out[:error] = result[:message] if mapped == "error" && !blank?(result[:message])
+      out
+    end
+
+    # Cancel a transmitted prescription. Returns:
+    #   { success: true }
+    #   { success: false, error: "..." }
+    def cancel(transmission_id, reason: nil)
+      return { success: false, error: "transmission_id is required" } if blank?(transmission_id)
+
+      param  = blank?(reason) ? transmission_id.to_s : "#{transmission_id}^#{reason}"
+      result = DataMapper.prescription_cancel.fetch_one(param)
+      return { success: false, error: "Empty response from RPMS" } if result.nil?
+
+      if result[:success]
+        { success: true }
+      else
+        { success: false, error: result[:message] || "Unknown RPMS error" }
+      end
+    end
+
+    # Build the PSO NEW RX caret-delimited single-param payload from an attrs hash.
+    # Public so callers and tests can observe the wire shape.
+    def build_rx_param(attrs)
+      RX_PARAM_ORDER.map { |k| attrs[k].to_s }.join("^")
+    end
+
+    private
+
+    def blank?(val)
+      val.nil? || val.to_s.empty?
+    end
+  end
+end

--- a/lib/rpms_rpc/api/eprescribing.rb
+++ b/lib/rpms_rpc/api/eprescribing.rb
@@ -38,6 +38,8 @@ module RpmsRpc
     #   { success: true, transmission_id: "..." }
     #   { success: false, error: "..." }
     def transmit(attrs)
+      return { success: false, error: "attrs hash is required" } unless attrs.is_a?(Hash)
+
       param = build_rx_param(attrs)
       result = DataMapper.prescription_new.fetch_one(param)
       return { success: false, error: "Empty response from RPMS" } if result.nil?
@@ -60,7 +62,9 @@ module RpmsRpc
 
       mapped = CANONICAL_STATUS.fetch(result[:status].to_s.strip.downcase, "queued")
       out = { status: mapped }
-      out[:error] = result[:message] if mapped == "error" && !blank?(result[:message])
+      if mapped == "error"
+        out[:error] = blank?(result[:message]) ? "RPMS reported error" : result[:message]
+      end
       out
     end
 

--- a/lib/rpms_rpc/api/eprescribing.rb
+++ b/lib/rpms_rpc/api/eprescribing.rb
@@ -90,7 +90,7 @@ module RpmsRpc
     private
 
     def blank?(val)
-      val.nil? || val.to_s.empty?
+      val.nil? || val.to_s.strip.empty?
     end
   end
 end

--- a/test/rpms_rpc/api/eprescribing_test.rb
+++ b/test/rpms_rpc/api/eprescribing_test.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/eprescribing"
+
+class EprescribingTest < Minitest::Test
+  RX_ATTRS = {
+    patient_dfn:         "8791",
+    medication_code:     "12345",
+    medication_display:  "AMOXICILLIN 500MG CAP",
+    dosage_instruction:  "1 PO TID",
+    route:               "PO",
+    frequency:           "TID",
+    dispense_quantity:   21,
+    refills:             0,
+    days_supply:         7,
+    pharmacy_ien:        "1",
+    requester_duz:       "301"
+  }.freeze
+
+  RX_COMPOSITE = "8791^12345^AMOXICILLIN 500MG CAP^1 PO TID^PO^TID^21^0^7^1^301"
+
+  def setup
+    RpmsRpc.mock! do |m|
+      # PSO NEW RX — success: "1^<tx_id>", failure: "0^<error>"
+      m.seed(:prescription_new, RX_COMPOSITE,                { success: true,  rx_ien_or_error: "TX001" })
+      m.seed(:prescription_new, "FAIL^x^x^x^x^x^x^x^x^x^x",  { success: false, rx_ien_or_error: "Pharmacy IEN missing" })
+
+      # PSO ERX STATUS — various raw status strings
+      m.seed(:erx_status, "TX001",       { status: "delivered",   message: nil })
+      m.seed(:erx_status, "TX-SENT",     { status: "sent",        message: nil })
+      m.seed(:erx_status, "TX-VOID",     { status: "voided",      message: nil })
+      m.seed(:erx_status, "TX-XMIT",     { status: "transmitted", message: nil })
+      m.seed(:erx_status, "TX-FAIL",     { status: "failed",      message: "downstream timeout" })
+      m.seed(:erx_status, "TX-WEIRD",    { status: "pending",     message: nil })
+
+      # PSO CANCEL RX — success: "1^Cancelled", failure: "0^<error>"
+      m.seed(:prescription_cancel, "TX001",                          { success: true,  message: "Cancelled" })
+      m.seed(:prescription_cancel, "TX001^patient request",          { success: true,  message: "Cancelled" })
+      m.seed(:prescription_cancel, "TX-NOPE",                        { success: false, message: "Not found" })
+    end
+  end
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  # === transmit ============================================================
+
+  def test_transmit_returns_success_with_transmission_id
+    result = RpmsRpc::Eprescribing.transmit(RX_ATTRS)
+
+    assert_equal true,    result[:success]
+    assert_equal "TX001", result[:transmission_id]
+  end
+
+  def test_transmit_returns_failure_with_error_message
+    bad = RX_ATTRS.merge(patient_dfn: "FAIL", medication_code: "x", medication_display: "x",
+                         dosage_instruction: "x", route: "x", frequency: "x",
+                         dispense_quantity: "x", refills: "x", days_supply: "x",
+                         pharmacy_ien: "x", requester_duz: "x")
+
+    result = RpmsRpc::Eprescribing.transmit(bad)
+
+    assert_equal false, result[:success]
+    assert_equal "Pharmacy IEN missing", result[:error]
+  end
+
+  def test_transmit_returns_failure_for_empty_response
+    # Unseeded composite → MockClient returns "" → fetch_one returns nil
+    result = RpmsRpc::Eprescribing.transmit(RX_ATTRS.merge(patient_dfn: "UNKNOWN"))
+
+    assert_equal false, result[:success]
+    refute_nil result[:error]
+  end
+
+  def test_transmit_sends_caret_delimited_composite_to_rpc
+    RpmsRpc::Eprescribing.transmit(RX_ATTRS)
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "PSO NEW RX" }
+    refute_nil call, "Expected PSO NEW RX to fire"
+    assert_equal 1, call[:params].length, "PSO NEW RX takes a single composite param"
+    assert_equal RX_COMPOSITE, call[:params].first
+  end
+
+  # === status ==============================================================
+
+  def test_status_returns_canonical_delivered
+    assert_equal "delivered", RpmsRpc::Eprescribing.status("TX001")[:status]
+  end
+
+  def test_status_maps_sent_to_transmitted
+    assert_equal "transmitted", RpmsRpc::Eprescribing.status("TX-SENT")[:status]
+  end
+
+  def test_status_passes_transmitted_through_as_transmitted
+    assert_equal "transmitted", RpmsRpc::Eprescribing.status("TX-XMIT")[:status]
+  end
+
+  def test_status_maps_voided_to_cancelled
+    assert_equal "cancelled", RpmsRpc::Eprescribing.status("TX-VOID")[:status]
+  end
+
+  def test_status_maps_failed_to_error_and_surfaces_message
+    result = RpmsRpc::Eprescribing.status("TX-FAIL")
+    assert_equal "error", result[:status]
+    assert_equal "downstream timeout", result[:error]
+  end
+
+  def test_status_returns_queued_for_unknown_status_string
+    assert_equal "queued", RpmsRpc::Eprescribing.status("TX-WEIRD")[:status]
+  end
+
+  def test_status_returns_error_for_blank_transmission_id
+    nil_result = RpmsRpc::Eprescribing.status(nil)
+    empty_result = RpmsRpc::Eprescribing.status("")
+    assert_equal "error", nil_result[:status]
+    assert_equal "error", empty_result[:status]
+    refute_nil nil_result[:error]
+  end
+
+  def test_status_returns_error_when_no_response
+    result = RpmsRpc::Eprescribing.status("TX-UNKNOWN")
+    assert_equal "error", result[:status]
+  end
+
+  # === cancel ==============================================================
+
+  def test_cancel_returns_success_without_reason
+    result = RpmsRpc::Eprescribing.cancel("TX001")
+
+    assert_equal true, result[:success]
+    refute result.key?(:error), "success should not carry :error"
+  end
+
+  def test_cancel_returns_success_with_reason
+    result = RpmsRpc::Eprescribing.cancel("TX001", reason: "patient request")
+
+    assert_equal true, result[:success]
+  end
+
+  def test_cancel_sends_bare_id_when_reason_blank
+    RpmsRpc::Eprescribing.cancel("TX001")
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "PSO CANCEL RX" }
+    refute_nil call
+    assert_equal "TX001", call[:params].first
+  end
+
+  def test_cancel_sends_caret_composite_when_reason_present
+    RpmsRpc::Eprescribing.cancel("TX001", reason: "patient request")
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "PSO CANCEL RX" }
+    refute_nil call
+    assert_equal "TX001^patient request", call[:params].first
+  end
+
+  def test_cancel_returns_failure_with_error_message
+    result = RpmsRpc::Eprescribing.cancel("TX-NOPE")
+
+    assert_equal false, result[:success]
+    assert_equal "Not found", result[:error]
+  end
+
+  def test_cancel_returns_failure_for_blank_transmission_id
+    nil_result   = RpmsRpc::Eprescribing.cancel(nil)
+    empty_result = RpmsRpc::Eprescribing.cancel("", reason: "x")
+
+    assert_equal false, nil_result[:success]
+    assert_equal false, empty_result[:success]
+    refute_nil nil_result[:error]
+  end
+
+  # === build_rx_param (public for observability) ===========================
+
+  def test_build_rx_param_joins_attrs_in_pso_new_rx_order
+    assert_equal RX_COMPOSITE, RpmsRpc::Eprescribing.build_rx_param(RX_ATTRS)
+  end
+end

--- a/test/rpms_rpc/api/eprescribing_test.rb
+++ b/test/rpms_rpc/api/eprescribing_test.rb
@@ -33,6 +33,7 @@ class EprescribingTest < Minitest::Test
       m.seed(:erx_status, "TX-VOID",     { status: "voided",      message: nil })
       m.seed(:erx_status, "TX-XMIT",     { status: "transmitted", message: nil })
       m.seed(:erx_status, "TX-FAIL",     { status: "failed",      message: "downstream timeout" })
+      m.seed(:erx_status, "TX-FAIL-NOMSG", { status: "error",     message: nil })
       m.seed(:erx_status, "TX-WEIRD",    { status: "pending",     message: nil })
 
       # PSO CANCEL RX — success: "1^Cancelled", failure: "0^<error>"
@@ -84,6 +85,16 @@ class EprescribingTest < Minitest::Test
     assert_equal RX_COMPOSITE, call[:params].first
   end
 
+  def test_transmit_rejects_non_hash_attrs
+    [ nil, "string", 42, [ :a, :b ] ].each do |bad|
+      result = RpmsRpc::Eprescribing.transmit(bad)
+      assert_equal false, result[:success], "transmit(#{bad.inspect}) should fail"
+      refute_nil result[:error]
+    end
+    refute RpmsRpc.client.received_calls.any? { |c| c[:rpc] == "PSO NEW RX" },
+      "PSO NEW RX should not fire for non-Hash attrs"
+  end
+
   # === status ==============================================================
 
   def test_status_returns_canonical_delivered
@@ -106,6 +117,14 @@ class EprescribingTest < Minitest::Test
     result = RpmsRpc::Eprescribing.status("TX-FAIL")
     assert_equal "error", result[:status]
     assert_equal "downstream timeout", result[:error]
+  end
+
+  def test_status_always_includes_error_key_when_status_is_error
+    result = RpmsRpc::Eprescribing.status("TX-FAIL-NOMSG")
+    assert_equal "error", result[:status]
+    assert result.key?(:error),
+      ":error key must always be present when status is 'error', even when RPMS sends no message"
+    refute_nil result[:error]
   end
 
   def test_status_returns_queued_for_unknown_status_string

--- a/test/rpms_rpc/api/eprescribing_test.rb
+++ b/test/rpms_rpc/api/eprescribing_test.rb
@@ -125,6 +125,15 @@ class EprescribingTest < Minitest::Test
     assert_equal "error", result[:status]
   end
 
+  def test_status_rejects_whitespace_only_transmission_id
+    result = RpmsRpc::Eprescribing.status("   ")
+
+    assert_equal "error", result[:status]
+    refute_nil result[:error]
+    refute RpmsRpc.client.received_calls.any? { |c| c[:rpc] == "PSO ERX STATUS" },
+      "PSO ERX STATUS should not fire when transmission_id is whitespace-only"
+  end
+
   # === cancel ==============================================================
 
   def test_cancel_returns_success_without_reason
@@ -168,6 +177,24 @@ class EprescribingTest < Minitest::Test
     assert_equal false, nil_result[:success]
     assert_equal false, empty_result[:success]
     refute_nil nil_result[:error]
+  end
+
+  def test_cancel_rejects_whitespace_only_transmission_id
+    result = RpmsRpc::Eprescribing.cancel("   ", reason: "patient request")
+
+    assert_equal false, result[:success]
+    refute_nil result[:error]
+    refute RpmsRpc.client.received_calls.any? { |c| c[:rpc] == "PSO CANCEL RX" },
+      "PSO CANCEL RX should not fire when transmission_id is whitespace-only"
+  end
+
+  def test_cancel_sends_bare_id_when_reason_is_whitespace_only
+    RpmsRpc::Eprescribing.cancel("TX001", reason: "   ")
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "PSO CANCEL RX" }
+    refute_nil call
+    assert_equal "TX001", call[:params].first,
+      "whitespace-only reason should be treated as no reason, sending bare id"
   end
 
   # === build_rx_param (public for observability) ===========================


### PR DESCRIPTION
## Summary

Ports the eprescribing gateway from rpms_redux into `RpmsRpc::Eprescribing`, following the lab (#81) / radiology (#82) pattern.

- `transmit(attrs)` → `{success:, transmission_id:}` or `{success:, error:}` (PSO NEW RX)
- `status(transmission_id)` → `{status:}` canonical-mapped, plus `:error` on failure (PSO ERX STATUS)
- `cancel(transmission_id, reason: nil)` → `{success:}` or `{success:, error:}` (PSO CANCEL RX)
- `build_rx_param(attrs)` exposed for wire-shape observability

Canonical statuses: `transmitted` | `delivered` | `cancelled` | `error` | `queued`. Engine layer is responsible for any state-machine wrapping over these snapshots.

Existing `:prescription_new`, `:erx_status`, `:prescription_cancel` mappings reused as-is — the gateway's parse logic already aligns with their field positions.

Part of #80.

## Test plan

- [x] `bundle exec ruby -Ilib -Itest test/rpms_rpc/api/eprescribing_test.rb` (19 tests / 33 assertions)
- [x] `bundle exec rake test` full suite (421 / 983, no regressions)
- [x] `bundle exec rubocop` on the two new files