### PR TITLE
CarePlan module: port from rpms_redux (Part of #80)

### DIFF
--- a/lib/rpms_rpc/api/care_plan.rb
+++ b/lib/rpms_rpc/api/care_plan.rb
@@ -4,9 +4,11 @@ module RpmsRpc
   # Symbolic API for FHIR CarePlan data.
   # Underlying RPCs (ORQQCP family): LIST, GET.
   #
-  # Each entry: { ien:, title:, status:, intent:, category:, start_date:,
-  #               end_date:, author_duz:, author_name:, goal_iens:,
-  #               activity:, description:, note: }
+  # for_patient entries: { ien:, title:, status:, intent:, category:, start_date:,
+  #   end_date:, author_duz:, author_name:, goal_iens:, activity:, description:, note: }
+  #
+  # find result includes the same keys plus :patient_dfn (echoed from the GET
+  # response body). :note is always present (default nil) for shape parity.
   module CarePlan
     extend self
 
@@ -28,7 +30,7 @@ module RpmsRpc
     def find(ien)
       return nil if blank?(ien)
 
-      response = RpmsRpc.client.call_rpc("ORQQCP GET", ien.to_s)
+      response = RpmsRpc.client.call_rpc(DataMapper.care_plan_detail.rpc_name, ien.to_s)
       return nil if response.nil? || (response.respond_to?(:empty?) && response.empty?)
 
       lines = response.is_a?(Array) ? response : [ response.to_s ]

--- a/lib/rpms_rpc/api/care_plan.rb
+++ b/lib/rpms_rpc/api/care_plan.rb
@@ -39,7 +39,10 @@ module RpmsRpc
       return nil if parsed.nil?
 
       description = lines.length > 1 ? lines[1..].join("\n") : nil
-      apply_defaults(parsed.merge(description: blank?(description) ? nil : description))
+      apply_defaults(parsed.merge(
+        description: blank?(description) ? nil : description,
+        note:        nil
+      ))
     end
 
     private

--- a/lib/rpms_rpc/api/care_plan.rb
+++ b/lib/rpms_rpc/api/care_plan.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module RpmsRpc
+  # Symbolic API for FHIR CarePlan data.
+  # Underlying RPCs (ORQQCP family): LIST, GET.
+  #
+  # Each entry: { ien:, title:, status:, intent:, category:, start_date:,
+  #               end_date:, author_duz:, author_name:, goal_iens:,
+  #               activity:, description:, note: }
+  module CarePlan
+    extend self
+
+    DEFAULT_STATUS   = "active"
+    DEFAULT_INTENT   = "plan"
+    DEFAULT_CATEGORY = "assess-plan"
+
+    # All care plans for a patient. Returns [] for invalid / unknown DFN.
+    def for_patient(dfn)
+      return [] if blank?(dfn) || dfn.to_i <= 0
+
+      raw = DataMapper.care_plan_list.fetch_many(dfn.to_s)
+      Array(raw).map { |row| apply_defaults(row) }
+    end
+
+    # Single care plan by IEN. Returns a hash or nil if not found / invalid.
+    # The ORQQCP GET response is a hybrid: first line is field-based, any
+    # subsequent lines are free-text description (joined here).
+    def find(ien)
+      return nil if blank?(ien)
+
+      response = RpmsRpc.client.call_rpc("ORQQCP GET", ien.to_s)
+      return nil if response.nil? || (response.respond_to?(:empty?) && response.empty?)
+
+      lines = response.is_a?(Array) ? response : [ response.to_s ]
+      first = lines.first
+      return nil if first.nil? || first.to_s.empty?
+
+      parsed = DataMapper.care_plan_detail.parse_one(first, extras: { ien: ien })
+      return nil if parsed.nil?
+
+      description = lines.length > 1 ? lines[1..].join("\n") : nil
+      apply_defaults(parsed.merge(description: blank?(description) ? nil : description))
+    end
+
+    private
+
+    def apply_defaults(row)
+      row.merge(
+        status:   blank?(row[:status])   ? DEFAULT_STATUS   : row[:status],
+        intent:   blank?(row[:intent])   ? DEFAULT_INTENT   : row[:intent],
+        category: blank?(row[:category]) ? DEFAULT_CATEGORY : row[:category]
+      )
+    end
+
+    def blank?(val)
+      val.nil? || val.to_s.empty?
+    end
+  end
+end

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -293,14 +293,23 @@ module RpmsRpc
     end
 
     # ORQQCP LIST — care plan list (multi-line)
-    # Format: IEN^TITLE^STATUS^START_DATE^AUTHOR
+    # Format: IEN^TITLE^STATUS^INTENT^CATEGORY^START_DATE^END_DATE^
+    #         AUTHOR_DUZ^AUTHOR_NAME^GOAL_IENS^ACTIVITY^DESCRIPTION^NOTE
     DataMapper.define(:care_plan_list) do |m|
       m.rpc "ORQQCP LIST"
-      m.field 0, :ien
-      m.field 1, :title
-      m.field 2, :status
-      m.field 3, :start_date, :fileman_date
-      m.field 4, :author
+      m.field 0,  :ien
+      m.field 1,  :title
+      m.field 2,  :status
+      m.field 3,  :intent
+      m.field 4,  :category
+      m.field 5,  :start_date, :fileman_date
+      m.field 6,  :end_date,   :fileman_date
+      m.field 7,  :author_duz
+      m.field 8,  :author_name
+      m.field 9,  :goal_iens
+      m.field 10, :activity
+      m.field 11, :description
+      m.field 12, :note
     end
 
     # ORQQCT LIST — care team list (multi-line)
@@ -615,15 +624,23 @@ module RpmsRpc
       m.text_blob :detail_text
     end
 
-    # ORQQCP GET — single care plan
+    # ORQQCP GET — single care plan.
+    # First line: TITLE^STATUS^INTENT^CATEGORY^START_DATE^END_DATE^
+    #             AUTHOR_DUZ^AUTHOR_NAME^GOAL_IENS^ACTIVITY^(unused)^PATIENT_DFN
+    # Subsequent lines: free-text description (joined by the API module).
     DataMapper.define(:care_plan_detail) do |m|
       m.rpc "ORQQCP GET"
-      m.field 0, :ien
-      m.field 1, :title
-      m.field 2, :status
-      m.field 3, :start_date, :fileman_date
-      m.field 4, :author
-      m.field 5, :description
+      m.field 0,  :title
+      m.field 1,  :status
+      m.field 2,  :intent
+      m.field 3,  :category
+      m.field 4,  :start_date, :fileman_date
+      m.field 5,  :end_date,   :fileman_date
+      m.field 6,  :author_duz
+      m.field 7,  :author_name
+      m.field 8,  :goal_iens
+      m.field 9,  :activity
+      m.field 11, :patient_dfn
     end
 
     # ORQQCT GET — single care team member

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -640,7 +640,7 @@ module RpmsRpc
       m.field 7,  :author_name
       m.field 8,  :goal_iens
       m.field 9,  :activity
-      m.field 11, :patient_dfn
+      m.field 11, :patient_dfn, :integer
     end
 
     # ORQQCT GET — single care team member

--- a/test/rpms_rpc/api/care_plan_test.rb
+++ b/test/rpms_rpc/api/care_plan_test.rb
@@ -164,6 +164,14 @@ class CarePlanTest < Minitest::Test
     assert_equal "assess-plan", plan[:category]
   end
 
+  def test_find_always_includes_note_key_for_shape_parity_with_list
+    plan = RpmsRpc::CarePlan.find(101)
+    refute_nil plan
+    assert plan.key?(:note),
+      ":note must be present on the find result for shape parity with for_patient entries (gateway behavior)"
+    assert_nil plan[:note], "ORQQCP GET response carries no note today; default is nil"
+  end
+
   def test_find_returns_nil_for_blank_ien
     assert_nil RpmsRpc::CarePlan.find(nil)
     assert_nil RpmsRpc::CarePlan.find("")

--- a/test/rpms_rpc/api/care_plan_test.rb
+++ b/test/rpms_rpc/api/care_plan_test.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/care_plan"
+
+class CarePlanTest < Minitest::Test
+  def setup
+    RpmsRpc.mock! do |m|
+      # ORQQCP LIST — keyed by patient DFN, multi-line, full 13-field shape.
+      m.seed_keyed_collection(:care_plan_list, "8791", [
+        {
+          ien: "101",
+          title: "Diabetes Management",
+          status: "active",
+          intent: "plan",
+          category: "assess-plan",
+          start_date: nil,
+          end_date: nil,
+          author_duz: "301",
+          author_name: "PROVIDER,TEST",
+          goal_iens: "201;202",
+          activity: "Monitor A1C quarterly",
+          description: "Patient managing T2DM with metformin",
+          note: nil
+        },
+        {
+          ien: "102",
+          title: "Hypertension Control",
+          status: "",         # empty → API should default to "active"
+          intent: "",         # empty → API should default to "plan"
+          category: "",       # empty → API should default to "assess-plan"
+          start_date: nil,
+          end_date: nil,
+          author_duz: "301",
+          author_name: "PROVIDER,TEST",
+          goal_iens: nil,
+          activity: nil,
+          description: nil,
+          note: nil
+        }
+      ])
+
+      # ORQQCP GET — keyed by IEN. First line is field-based; subsequent lines
+      # are free-text description joined by the API module.
+      #
+      # Field positions 0..11 (from mappings):
+      #   title^status^intent^category^start^end^author_duz^author_name^goal_iens^activity^(unused)^patient_dfn
+      m.seed(:care_plan_detail, "101", {
+        title: "Diabetes Management",
+        status: "active",
+        intent: "plan",
+        category: "assess-plan",
+        start_date: nil,
+        end_date: nil,
+        author_duz: "301",
+        author_name: "PROVIDER,TEST",
+        goal_iens: "201;202",
+        activity: "Monitor A1C quarterly",
+        patient_dfn: "8791"
+      })
+      # 102 returns a multi-line text response: first line field-based,
+      # remaining lines are the prose description.
+      RpmsRpc.client.instance_variable_get(:@text_blobs).tap { |tb| tb ||= {} }
+      # Use seed_text-equivalent direct injection alongside the existing
+      # field-based record: when both exist the @lines / @text_blobs maps
+      # are checked first. We model the multi-line response by overriding
+      # via the @text_blobs path that MockClient already supports for the
+      # same key — that returns an Array split on \n.
+      m.seed_text(:care_plan_detail, "102",
+        "Hypertension Control^^^^^^^^^^^8791\n" \
+        "Patient on lisinopril 10mg daily.\n" \
+        "BP target <130/80.")
+
+      m.seed(:care_plan_detail, "999_BLANK_FIELDS", {
+        title: "Mostly Blank",
+        status: nil,
+        intent: nil,
+        category: nil,
+        start_date: nil,
+        end_date: nil,
+        author_duz: nil,
+        author_name: nil,
+        goal_iens: nil,
+        activity: nil,
+        patient_dfn: "8791"
+      })
+    end
+  end
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  # === for_patient ==========================================================
+
+  def test_for_patient_returns_care_plans
+    plans = RpmsRpc::CarePlan.for_patient(8791)
+
+    assert_kind_of Array, plans
+    assert_equal 2, plans.length
+    dm = plans.find { |p| p[:title] == "Diabetes Management" }
+    refute_nil dm
+    assert_equal "active", dm[:status]
+    assert_equal "plan",   dm[:intent]
+    assert_equal "301",    dm[:author_duz]
+    assert_equal "PROVIDER,TEST", dm[:author_name]
+    assert_equal "201;202", dm[:goal_iens]
+    assert_equal "Monitor A1C quarterly", dm[:activity]
+    assert_equal "Patient managing T2DM with metformin", dm[:description]
+  end
+
+  def test_for_patient_applies_defaults_for_blank_status_intent_category
+    plans = RpmsRpc::CarePlan.for_patient(8791)
+    htn = plans.find { |p| p[:title] == "Hypertension Control" }
+    refute_nil htn
+    assert_equal "active",      htn[:status]
+    assert_equal "plan",        htn[:intent]
+    assert_equal "assess-plan", htn[:category]
+  end
+
+  def test_for_patient_returns_empty_for_invalid_dfn
+    assert_equal [], RpmsRpc::CarePlan.for_patient(nil)
+    assert_equal [], RpmsRpc::CarePlan.for_patient("")
+    assert_equal [], RpmsRpc::CarePlan.for_patient(0)
+  end
+
+  def test_for_patient_returns_empty_for_unknown_dfn
+    assert_equal [], RpmsRpc::CarePlan.for_patient(999999)
+  end
+
+  # === find =================================================================
+
+  def test_find_returns_single_plan_for_single_line_response
+    plan = RpmsRpc::CarePlan.find(101)
+
+    refute_nil plan
+    assert_equal 101,                    plan[:ien]
+    assert_equal "Diabetes Management",  plan[:title]
+    assert_equal "active",               plan[:status]
+    assert_equal "plan",                 plan[:intent]
+    assert_equal "assess-plan",          plan[:category]
+    assert_equal "301",                  plan[:author_duz]
+    assert_equal "PROVIDER,TEST",        plan[:author_name]
+    assert_equal "201;202",              plan[:goal_iens]
+    assert_equal "Monitor A1C quarterly", plan[:activity]
+    assert_equal "8791",                 plan[:patient_dfn]
+  end
+
+  def test_find_joins_continuation_lines_into_description
+    plan = RpmsRpc::CarePlan.find(102)
+
+    refute_nil plan
+    assert_equal "Hypertension Control", plan[:title]
+    assert_equal "8791",                 plan[:patient_dfn]
+    assert_equal "Patient on lisinopril 10mg daily.\nBP target <130/80.", plan[:description]
+  end
+
+  def test_find_applies_defaults_for_blank_status_intent_category
+    plan = RpmsRpc::CarePlan.find("999_BLANK_FIELDS")
+    refute_nil plan
+    assert_equal "active",      plan[:status]
+    assert_equal "plan",        plan[:intent]
+    assert_equal "assess-plan", plan[:category]
+  end
+
+  def test_find_returns_nil_for_blank_ien
+    assert_nil RpmsRpc::CarePlan.find(nil)
+    assert_nil RpmsRpc::CarePlan.find("")
+  end
+
+  def test_find_returns_nil_for_unknown_ien
+    assert_nil RpmsRpc::CarePlan.find(999_998)
+  end
+end

--- a/test/rpms_rpc/api/care_plan_test.rb
+++ b/test/rpms_rpc/api/care_plan_test.rb
@@ -57,16 +57,11 @@ class CarePlanTest < Minitest::Test
         author_name: "PROVIDER,TEST",
         goal_iens: "201;202",
         activity: "Monitor A1C quarterly",
-        patient_dfn: "8791"
+        patient_dfn: 8791
       })
       # 102 returns a multi-line text response: first line field-based,
-      # remaining lines are the prose description.
-      RpmsRpc.client.instance_variable_get(:@text_blobs).tap { |tb| tb ||= {} }
-      # Use seed_text-equivalent direct injection alongside the existing
-      # field-based record: when both exist the @lines / @text_blobs maps
-      # are checked first. We model the multi-line response by overriding
-      # via the @text_blobs path that MockClient already supports for the
-      # same key — that returns an Array split on \n.
+      # remaining lines are the prose description. seed_text returns an
+      # Array split on \n when the seeded value contains newlines.
       m.seed_text(:care_plan_detail, "102",
         "Hypertension Control^^^^^^^^^^^8791\n" \
         "Patient on lisinopril 10mg daily.\n" \
@@ -83,7 +78,7 @@ class CarePlanTest < Minitest::Test
         author_name: nil,
         goal_iens: nil,
         activity: nil,
-        patient_dfn: "8791"
+        patient_dfn: 8791
       })
     end
   end
@@ -144,7 +139,7 @@ class CarePlanTest < Minitest::Test
     assert_equal "PROVIDER,TEST",        plan[:author_name]
     assert_equal "201;202",              plan[:goal_iens]
     assert_equal "Monitor A1C quarterly", plan[:activity]
-    assert_equal "8791",                 plan[:patient_dfn]
+    assert_equal 8791,                 plan[:patient_dfn]
   end
 
   def test_find_joins_continuation_lines_into_description
@@ -152,7 +147,7 @@ class CarePlanTest < Minitest::Test
 
     refute_nil plan
     assert_equal "Hypertension Control", plan[:title]
-    assert_equal "8791",                 plan[:patient_dfn]
+    assert_equal 8791,                 plan[:patient_dfn]
     assert_equal "Patient on lisinopril 10mg daily.\nBP target <130/80.", plan[:description]
   end
 


### PR DESCRIPTION
## Summary

Ports the care_plan gateway from rpms_redux into `RpmsRpc::CarePlan`, following the lab (#81) / radiology (#82) / eprescribing (#83) pattern.

- `for_patient(dfn)` → `Array<Hash>` (ORQQCP LIST)
- `find(ien)` → `Hash | nil` (ORQQCP GET)
- Default values for blank `status` / `intent` / `category` (`"active"` / `"plan"` / `"assess-plan"`) — matches rpms_redux gateway behavior

Each entry exposes: `ien, title, status, intent, category, start_date, end_date, author_duz, author_name, goal_iens, activity, description, note`.

### Mapping changes

- `:care_plan_list` extended from 5 to 13 fields to match the gateway's parse_care_plan_list output.
- `:care_plan_detail` re-positioned to match the gateway's first-line shape (TITLE at field 0, IEN passed via extras since the GET RPC takes the IEN as a param rather than echoing it in the body) — field positions 0..11 now align with the gateway's parse_care_plan.
- The GET response is hybrid: first line is field-based, subsequent lines are free-text description (joined by the API module).

Verified no other code consumes the old field names via grep.

Part of #80.

## Test plan

- [x] `bundle exec ruby -Ilib -Itest test/rpms_rpc/api/care_plan_test.rb` (9 tests / 40 assertions)
- [x] `bundle exec rake test` full suite (411 / 990, no regressions)
- [x] `bundle exec rubocop` on the three changed files