### PR TITLE
CareTeam module: port from rpms_redux (Part of #80)

### DIFF
--- a/lib/rpms_rpc/api/care_team.rb
+++ b/lib/rpms_rpc/api/care_team.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module RpmsRpc
+  # Symbolic API for FHIR CareTeam data.
+  # Underlying RPCs (ORQQCT family): LIST, GET.
+  #
+  # Each team: { ien:, team_name:, status:, category:, start_date:,
+  #              end_date:, participants:, reason_code:, reason_display:,
+  #              organization:, patient_dfn: (find only) }
+  #
+  # Participants are parsed from the sub-encoded RPMS string
+  #   DUZ~NAME~ROLE~START~END;DUZ~NAME~ROLE~START~END
+  # into [{ duz:, name:, role:, start_date:, end_date: }, ...].
+  module CareTeam
+    extend self
+
+    DEFAULT_STATUS = "active"
+
+    def for_patient(dfn)
+      return [] if blank?(dfn) || dfn.to_i <= 0
+
+      raw = DataMapper.care_team_list.fetch_many(dfn.to_s)
+      Array(raw).map { |row| decorate(row) }
+    end
+
+    def find(ien)
+      return nil if blank?(ien)
+
+      parsed = DataMapper.care_team_detail.fetch_one(ien.to_s, extras: { ien: ien })
+      return nil if parsed.nil?
+
+      decorate(parsed)
+    end
+
+    private
+
+    def decorate(row)
+      row.merge(
+        status:       blank?(row[:status]) ? DEFAULT_STATUS : row[:status],
+        participants: parse_participants(row[:participants_raw])
+      ).tap { |h| h.delete(:participants_raw) }
+    end
+
+    def parse_participants(raw)
+      return [] if blank?(raw)
+
+      raw.to_s.split(";").filter_map do |chunk|
+        parts = chunk.split("~")
+        next if parts.empty? || parts.first.to_s.empty?
+
+        {
+          duz:        parts[0],
+          name:       parts[1],
+          role:       parts[2],
+          start_date: parts[3],
+          end_date:   parts[4]
+        }
+      end
+    end
+
+    def blank?(val)
+      val.nil? || val.to_s.empty?
+    end
+  end
+end

--- a/lib/rpms_rpc/api/care_team.rb
+++ b/lib/rpms_rpc/api/care_team.rb
@@ -24,7 +24,7 @@ module RpmsRpc
     end
 
     def find(ien)
-      return nil if blank?(ien)
+      return nil if blank?(ien) || ien.to_i <= 0
 
       parsed = DataMapper.care_team_detail.fetch_one(ien.to_s, extras: { ien: ien })
       return nil if parsed.nil?
@@ -45,17 +45,24 @@ module RpmsRpc
       return [] if blank?(raw)
 
       raw.to_s.split(";").filter_map do |chunk|
-        parts = chunk.split("~")
+        parts = chunk.split("~", -1)
         next if parts.empty? || parts.first.to_s.empty?
 
         {
-          duz:        parts[0],
-          name:       parts[1],
-          role:       parts[2],
-          start_date: parts[3],
-          end_date:   parts[4]
+          duz:        presence(parts[0]),
+          name:       presence(parts[1]),
+          role:       presence(parts[2]),
+          start_date: presence(parts[3]),
+          end_date:   presence(parts[4])
         }
       end
+    end
+
+    def presence(val)
+      return nil if val.nil?
+
+      s = val.to_s
+      s.empty? ? nil : s
     end
 
     def blank?(val)

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -313,13 +313,22 @@ module RpmsRpc
     end
 
     # ORQQCT LIST — care team list (multi-line)
-    # Format: IEN^NAME^ROLE^START_DATE
+    # Format: IEN^TEAM_NAME^STATUS^CATEGORY^START_DATE^END_DATE^
+    #         PARTICIPANTS^REASON_CODE^REASON_DISPLAY^ORGANIZATION
+    # The PARTICIPANTS field is a sub-encoded string parsed by the API module:
+    #   DUZ~NAME~ROLE~START~END;DUZ~NAME~ROLE~START~END;...
     DataMapper.define(:care_team_list) do |m|
       m.rpc "ORQQCT LIST"
       m.field 0, :ien
-      m.field 1, :name
-      m.field 2, :role
-      m.field 3, :start_date, :fileman_date
+      m.field 1, :team_name
+      m.field 2, :status
+      m.field 3, :category
+      m.field 4, :start_date, :fileman_date
+      m.field 5, :end_date,   :fileman_date
+      m.field 6, :participants_raw
+      m.field 7, :reason_code
+      m.field 8, :reason_display
+      m.field 9, :organization
     end
 
     # ORQQGO LIST — goal list (multi-line)
@@ -643,14 +652,22 @@ module RpmsRpc
       m.field 11, :patient_dfn, :integer
     end
 
-    # ORQQCT GET — single care team member
+    # ORQQCT GET — single care team. IEN is passed as the RPC param and
+    # echoed by the API module via extras (gateway does the same).
+    # First line: TEAM_NAME^STATUS^CATEGORY^START_DATE^END_DATE^
+    #             PARTICIPANTS^REASON_CODE^REASON_DISPLAY^ORGANIZATION^PATIENT_DFN
     DataMapper.define(:care_team_detail) do |m|
       m.rpc "ORQQCT GET"
-      m.field 0, :ien
-      m.field 1, :name
-      m.field 2, :role
+      m.field 0, :team_name
+      m.field 1, :status
+      m.field 2, :category
       m.field 3, :start_date, :fileman_date
-      m.field 4, :phone
+      m.field 4, :end_date,   :fileman_date
+      m.field 5, :participants_raw
+      m.field 6, :reason_code
+      m.field 7, :reason_display
+      m.field 8, :organization
+      m.field 9, :patient_dfn
     end
 
     # ORQQGO GET — single goal

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -667,7 +667,7 @@ module RpmsRpc
       m.field 6, :reason_code
       m.field 7, :reason_display
       m.field 8, :organization
-      m.field 9, :patient_dfn
+      m.field 9, :patient_dfn, :integer
     end
 
     # ORQQGO GET — single goal

--- a/test/rpms_rpc/api/care_team_test.rb
+++ b/test/rpms_rpc/api/care_team_test.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/care_team"
+
+class CareTeamTest < Minitest::Test
+  # Participants sub-encoded format: DUZ~NAME~ROLE~START~END;DUZ~NAME~ROLE~START~END
+  PARTICIPANTS_RAW = "301~SMITH,JANE~primary;405~JONES,BOB~consulting~3260101~3260601"
+
+  def setup
+    RpmsRpc.mock! do |m|
+      # ORQQCT LIST — keyed by patient DFN, multi-line.
+      m.seed_keyed_collection(:care_team_list, "8791", [
+        {
+          ien: "501",
+          team_name: "Primary Care Team",
+          status: "active",
+          category: "longitudinal",
+          start_date: nil,
+          end_date: nil,
+          participants_raw: PARTICIPANTS_RAW,
+          reason_code: "Z00.00",
+          reason_display: "General adult medical examination",
+          organization: "Test Clinic"
+        },
+        {
+          ien: "502",
+          team_name: "Endocrinology Team",
+          status: "",           # API should default to "active"
+          category: nil,
+          start_date: nil,
+          end_date: nil,
+          participants_raw: nil, # API should yield empty []
+          reason_code: nil,
+          reason_display: nil,
+          organization: nil
+        }
+      ])
+
+      # ORQQCT GET — single-line field-based response, keyed by IEN.
+      m.seed(:care_team_detail, "501", {
+        team_name: "Primary Care Team",
+        status: "active",
+        category: "longitudinal",
+        start_date: nil,
+        end_date: nil,
+        participants_raw: PARTICIPANTS_RAW,
+        reason_code: "Z00.00",
+        reason_display: "General adult medical examination",
+        organization: "Test Clinic",
+        patient_dfn: "8791"
+      })
+
+      m.seed(:care_team_detail, "503_NO_PARTICIPANTS", {
+        team_name: "Empty Team",
+        status: nil,
+        category: nil,
+        start_date: nil,
+        end_date: nil,
+        participants_raw: nil,
+        reason_code: nil,
+        reason_display: nil,
+        organization: nil,
+        patient_dfn: "8791"
+      })
+    end
+  end
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  # === for_patient ==========================================================
+
+  def test_for_patient_returns_care_teams
+    teams = RpmsRpc::CareTeam.for_patient(8791)
+
+    assert_kind_of Array, teams
+    assert_equal 2, teams.length
+    pc = teams.find { |t| t[:team_name] == "Primary Care Team" }
+    refute_nil pc
+    assert_equal "active",       pc[:status]
+    assert_equal "longitudinal", pc[:category]
+    assert_equal "Z00.00",       pc[:reason_code]
+    assert_equal "Test Clinic",  pc[:organization]
+  end
+
+  def test_for_patient_parses_participants_into_hashes
+    teams = RpmsRpc::CareTeam.for_patient(8791)
+    pc = teams.find { |t| t[:team_name] == "Primary Care Team" }
+    participants = pc[:participants]
+
+    assert_kind_of Array, participants
+    assert_equal 2, participants.length
+
+    smith = participants.find { |p| p[:duz] == "301" }
+    refute_nil smith
+    assert_equal "SMITH,JANE", smith[:name]
+    assert_equal "primary",    smith[:role]
+
+    jones = participants.find { |p| p[:duz] == "405" }
+    refute_nil jones
+    assert_equal "consulting", jones[:role]
+    assert_equal "3260101",    jones[:start_date]
+    assert_equal "3260601",    jones[:end_date]
+  end
+
+  def test_for_patient_defaults_status_and_yields_empty_participants_when_blank
+    teams = RpmsRpc::CareTeam.for_patient(8791)
+    endo = teams.find { |t| t[:team_name] == "Endocrinology Team" }
+    refute_nil endo
+    assert_equal "active", endo[:status]
+    assert_equal [],       endo[:participants]
+  end
+
+  def test_for_patient_returns_empty_for_invalid_dfn
+    assert_equal [], RpmsRpc::CareTeam.for_patient(nil)
+    assert_equal [], RpmsRpc::CareTeam.for_patient("")
+    assert_equal [], RpmsRpc::CareTeam.for_patient(0)
+  end
+
+  def test_for_patient_returns_empty_for_unknown_dfn
+    assert_equal [], RpmsRpc::CareTeam.for_patient(999_999)
+  end
+
+  # === find =================================================================
+
+  def test_find_returns_single_team
+    team = RpmsRpc::CareTeam.find(501)
+
+    refute_nil team
+    assert_equal 501,                  team[:ien]
+    assert_equal "Primary Care Team",  team[:team_name]
+    assert_equal "active",             team[:status]
+    assert_equal "longitudinal",       team[:category]
+    assert_equal "Test Clinic",        team[:organization]
+    assert_equal "8791",               team[:patient_dfn]
+  end
+
+  def test_find_parses_participants_in_detail_response
+    team = RpmsRpc::CareTeam.find(501)
+    assert_equal 2, team[:participants].length
+    smith = team[:participants].find { |p| p[:duz] == "301" }
+    assert_equal "SMITH,JANE", smith[:name]
+  end
+
+  def test_find_defaults_status_and_empty_participants_for_blank_response
+    team = RpmsRpc::CareTeam.find("503_NO_PARTICIPANTS")
+    refute_nil team
+    assert_equal "active", team[:status]
+    assert_equal [],       team[:participants]
+  end
+
+  def test_find_returns_nil_for_blank_ien
+    assert_nil RpmsRpc::CareTeam.find(nil)
+    assert_nil RpmsRpc::CareTeam.find("")
+  end
+
+  def test_find_returns_nil_for_unknown_ien
+    assert_nil RpmsRpc::CareTeam.find(999_998)
+  end
+end

--- a/test/rpms_rpc/api/care_team_test.rb
+++ b/test/rpms_rpc/api/care_team_test.rb
@@ -5,8 +5,10 @@ require "rpms_rpc/mock_client"
 require "rpms_rpc/api/care_team"
 
 class CareTeamTest < Minitest::Test
-  # Participants sub-encoded format: DUZ~NAME~ROLE~START~END;DUZ~NAME~ROLE~START~END
-  PARTICIPANTS_RAW = "301~SMITH,JANE~primary;405~JONES,BOB~consulting~3260101~3260601"
+  # Participants sub-encoded format: DUZ~NAME~ROLE~START~END;DUZ~NAME~ROLE~START~END.
+  # Trailing fields may be empty — first chunk uses `~~` placeholders to demonstrate
+  # the 5-field shape is preserved even when START/END are blank.
+  PARTICIPANTS_RAW = "301~SMITH,JANE~primary~~;405~JONES,BOB~consulting~3260101~3260601"
 
   def setup
     RpmsRpc.mock! do |m|
@@ -49,7 +51,7 @@ class CareTeamTest < Minitest::Test
         reason_code: "Z00.00",
         reason_display: "General adult medical examination",
         organization: "Test Clinic",
-        patient_dfn: "8791"
+        patient_dfn: 8791
       })
 
       m.seed(:care_team_detail, "503_NO_PARTICIPANTS", {
@@ -62,7 +64,7 @@ class CareTeamTest < Minitest::Test
         reason_code: nil,
         reason_display: nil,
         organization: nil,
-        patient_dfn: "8791"
+        patient_dfn: 8791
       })
     end
   end
@@ -98,6 +100,8 @@ class CareTeamTest < Minitest::Test
     refute_nil smith
     assert_equal "SMITH,JANE", smith[:name]
     assert_equal "primary",    smith[:role]
+    assert_nil   smith[:start_date], "blank trailing fields should normalize to nil"
+    assert_nil   smith[:end_date]
 
     jones = participants.find { |p| p[:duz] == "405" }
     refute_nil jones
@@ -135,7 +139,7 @@ class CareTeamTest < Minitest::Test
     assert_equal "active",             team[:status]
     assert_equal "longitudinal",       team[:category]
     assert_equal "Test Clinic",        team[:organization]
-    assert_equal "8791",               team[:patient_dfn]
+    assert_equal 8791,                 team[:patient_dfn]
   end
 
   def test_find_parses_participants_in_detail_response
@@ -152,9 +156,11 @@ class CareTeamTest < Minitest::Test
     assert_equal [],       team[:participants]
   end
 
-  def test_find_returns_nil_for_blank_ien
+  def test_find_returns_nil_for_blank_or_nonpositive_ien
     assert_nil RpmsRpc::CareTeam.find(nil)
     assert_nil RpmsRpc::CareTeam.find("")
+    assert_nil RpmsRpc::CareTeam.find(0)
+    assert_nil RpmsRpc::CareTeam.find(-5)
   end
 
   def test_find_returns_nil_for_unknown_ien


### PR DESCRIPTION
## Summary

Ports the care_team gateway from rpms_redux into `RpmsRpc::CareTeam`, following the lab (#81) / radiology (#82) / eprescribing (#83) / care_plan (#84) pattern.

- `for_patient(dfn)` → `Array<Hash>` (ORQQCT LIST)
- `find(ien)` → `Hash | nil` (ORQQCT GET)
- Participants parsed from the sub-encoded RPMS string `DUZ~NAME~ROLE~START~END;DUZ~NAME~ROLE~START~END` into an array of `{duz:, name:, role:, start_date:, end_date:}` hashes.
- Default `"active"` for blank `status` — matches rpms_redux gateway behavior.

### Mapping changes

The existing `:care_team_list` (4 of 10 fields) and `:care_team_detail` (with bogus `:role` and `:phone` fields that don't exist in the gateway) were re-derived from `parse_care_team_list` / `parse_care_team` from scratch:

- `:care_team_list` now exposes 10 fields matching `IEN^TEAM_NAME^STATUS^CATEGORY^START^END^PARTICIPANTS^REASON_CODE^REASON_DISPLAY^ORGANIZATION`.
- `:care_team_detail` IEN is passed via extras (since GET takes IEN as the RPC param), first line is the 10-field shape ending in `PATIENT_DFN`.

Verified no other code consumes the old field names via grep.

Part of #80.

## Test plan

- [x] `bundle exec ruby -Ilib -Itest test/rpms_rpc/api/care_team_test.rb` (10 tests / 38 assertions)
- [x] `bundle exec rake test` full suite (412 / 988, no regressions)
- [x] `bundle exec rubocop` on the three changed files