### PR TITLE
Goal module: port from rpms_redux (Part of #80)

### DIFF
--- a/lib/rpms_rpc/api/goal.rb
+++ b/lib/rpms_rpc/api/goal.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module RpmsRpc
+  # Symbolic API for FHIR Goal data.
+  # Underlying RPCs (ORQQGO family): LIST, GET.
+  #
+  # Each goal: { ien:, goal_text:, lifecycle_status:, achievement_status:,
+  #              category:, priority:, start_date:, target_date:,
+  #              status_date:, provider_duz:, provider_name:, note:,
+  #              patient_dfn: (find only) }
+  module Goal
+    extend self
+
+    DEFAULT_LIFECYCLE_STATUS = "active"
+
+    def for_patient(dfn)
+      return [] if blank?(dfn) || dfn.to_i <= 0
+
+      raw = DataMapper.goal_list.fetch_many(dfn.to_s)
+      Array(raw).map { |row| apply_defaults(row) }
+    end
+
+    # Single goal by IEN. GET response is hybrid: first line is field-based,
+    # any subsequent lines are free-text note (joined here).
+    def find(ien)
+      return nil if blank?(ien)
+
+      response = RpmsRpc.client.call_rpc("ORQQGO GET", ien.to_s)
+      return nil if response.nil? || (response.respond_to?(:empty?) && response.empty?)
+
+      lines = response.is_a?(Array) ? response : [ response.to_s ]
+      first = lines.first
+      return nil if first.nil? || first.to_s.empty?
+
+      parsed = DataMapper.goal_detail.parse_one(first, extras: { ien: ien })
+      return nil if parsed.nil?
+
+      note = lines.length > 1 ? lines[1..].join("\n") : nil
+      apply_defaults(parsed.merge(note: blank?(note) ? nil : note))
+    end
+
+    private
+
+    def apply_defaults(row)
+      row.merge(
+        lifecycle_status: blank?(row[:lifecycle_status]) ? DEFAULT_LIFECYCLE_STATUS : row[:lifecycle_status]
+      )
+    end
+
+    def blank?(val)
+      val.nil? || val.to_s.empty?
+    end
+  end
+end

--- a/lib/rpms_rpc/api/goal.rb
+++ b/lib/rpms_rpc/api/goal.rb
@@ -23,16 +23,16 @@ module RpmsRpc
     # Single goal by IEN. GET response is hybrid: first line is field-based,
     # any subsequent lines are free-text note (joined here).
     def find(ien)
-      return nil if blank?(ien)
+      return nil if blank?(ien) || ien.to_i <= 0
 
-      response = RpmsRpc.client.call_rpc("ORQQGO GET", ien.to_s)
+      response = RpmsRpc.client.call_rpc(DataMapper.goal_detail.rpc_name, ien.to_s)
       return nil if response.nil? || (response.respond_to?(:empty?) && response.empty?)
 
       lines = response.is_a?(Array) ? response : [ response.to_s ]
       first = lines.first
       return nil if first.nil? || first.to_s.empty?
 
-      parsed = DataMapper.goal_detail.parse_one(first, extras: { ien: ien })
+      parsed = DataMapper.goal_detail.parse_one(first, extras: { ien: ien.to_i })
       return nil if parsed.nil?
 
       note = lines.length > 1 ? lines[1..].join("\n") : nil

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -698,7 +698,7 @@ module RpmsRpc
       m.field 7,  :status_date, :fileman_date
       m.field 8,  :provider_duz
       m.field 9,  :provider_name
-      m.field 11, :patient_dfn
+      m.field 11, :patient_dfn, :integer
     end
 
     # ORWPCE PROCEDURE GET — single procedure

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -332,13 +332,23 @@ module RpmsRpc
     end
 
     # ORQQGO LIST — goal list (multi-line)
-    # Format: IEN^DESCRIPTION^STATUS^TARGET_DATE
+    # Format: IEN^GOAL_TEXT^LIFECYCLE_STATUS^ACHIEVEMENT_STATUS^CATEGORY^
+    #         PRIORITY^START_DATE^TARGET_DATE^STATUS_DATE^
+    #         PROVIDER_DUZ^PROVIDER_NAME^NOTE
     DataMapper.define(:goal_list) do |m|
       m.rpc "ORQQGO LIST"
-      m.field 0, :ien
-      m.field 1, :description
-      m.field 2, :status
-      m.field 3, :target_date, :fileman_date
+      m.field 0,  :ien
+      m.field 1,  :goal_text
+      m.field 2,  :lifecycle_status
+      m.field 3,  :achievement_status
+      m.field 4,  :category
+      m.field 5,  :priority
+      m.field 6,  :start_date,  :fileman_date
+      m.field 7,  :target_date, :fileman_date
+      m.field 8,  :status_date, :fileman_date
+      m.field 9,  :provider_duz
+      m.field 10, :provider_name
+      m.field 11, :note
     end
 
     # ORWPCE PROCEDURE LIST — procedure list (multi-line)
@@ -670,14 +680,25 @@ module RpmsRpc
       m.field 9, :patient_dfn, :integer
     end
 
-    # ORQQGO GET — single goal
+    # ORQQGO GET — single goal. IEN is passed as the RPC param and echoed
+    # by the API module via extras (gateway does the same).
+    # First line: GOAL_TEXT^LIFECYCLE_STATUS^ACHIEVEMENT_STATUS^CATEGORY^
+    #             PRIORITY^START_DATE^TARGET_DATE^STATUS_DATE^
+    #             PROVIDER_DUZ^PROVIDER_NAME^(unused)^PATIENT_DFN
+    # Subsequent lines: free-text note (joined by the API module).
     DataMapper.define(:goal_detail) do |m|
       m.rpc "ORQQGO GET"
-      m.field 0, :ien
-      m.field 1, :description
-      m.field 2, :status
-      m.field 3, :target_date, :fileman_date
-      m.field 4, :author
+      m.field 0,  :goal_text
+      m.field 1,  :lifecycle_status
+      m.field 2,  :achievement_status
+      m.field 3,  :category
+      m.field 4,  :priority
+      m.field 5,  :start_date,  :fileman_date
+      m.field 6,  :target_date, :fileman_date
+      m.field 7,  :status_date, :fileman_date
+      m.field 8,  :provider_duz
+      m.field 9,  :provider_name
+      m.field 11, :patient_dfn
     end
 
     # ORWPCE PROCEDURE GET — single procedure

--- a/test/rpms_rpc/api/goal_test.rb
+++ b/test/rpms_rpc/api/goal_test.rb
@@ -51,7 +51,7 @@ class GoalTest < Minitest::Test
         status_date: nil,
         provider_duz: "301",
         provider_name: "PROVIDER,TEST",
-        patient_dfn: "8791"
+        patient_dfn: 8791
       })
 
       # ORQQGO GET — multi-line response with prose note.
@@ -71,7 +71,7 @@ class GoalTest < Minitest::Test
         status_date: nil,
         provider_duz: nil,
         provider_name: nil,
-        patient_dfn: "8791"
+        patient_dfn: 8791
       })
     end
   end
@@ -125,14 +125,14 @@ class GoalTest < Minitest::Test
     assert_equal "Reduce A1C to <7.0", goal[:goal_text]
     assert_equal "active",             goal[:lifecycle_status]
     assert_equal "in-progress",        goal[:achievement_status]
-    assert_equal "8791",               goal[:patient_dfn]
+    assert_equal 8791,               goal[:patient_dfn]
   end
 
   def test_find_joins_continuation_lines_into_note
     goal = RpmsRpc::Goal.find(702)
     refute_nil goal
     assert_equal "Walk 30 min/day", goal[:goal_text]
-    assert_equal "8791",            goal[:patient_dfn]
+    assert_equal 8791,            goal[:patient_dfn]
     assert_equal "Started after 2026-03 visit.\nReassess at 90d.", goal[:note]
   end
 
@@ -142,9 +142,11 @@ class GoalTest < Minitest::Test
     assert_equal "active", goal[:lifecycle_status]
   end
 
-  def test_find_returns_nil_for_blank_ien
+  def test_find_returns_nil_for_blank_or_nonpositive_ien
     assert_nil RpmsRpc::Goal.find(nil)
     assert_nil RpmsRpc::Goal.find("")
+    assert_nil RpmsRpc::Goal.find(0)
+    assert_nil RpmsRpc::Goal.find(-5)
   end
 
   def test_find_returns_nil_for_unknown_ien

--- a/test/rpms_rpc/api/goal_test.rb
+++ b/test/rpms_rpc/api/goal_test.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/goal"
+
+class GoalTest < Minitest::Test
+  def setup
+    RpmsRpc.mock! do |m|
+      # ORQQGO LIST — keyed by patient DFN, multi-line.
+      m.seed_keyed_collection(:goal_list, "8791", [
+        {
+          ien: "701",
+          goal_text: "Reduce A1C to <7.0",
+          lifecycle_status: "active",
+          achievement_status: "in-progress",
+          category: "physiologic",
+          priority: "high",
+          start_date: nil,
+          target_date: nil,
+          status_date: nil,
+          provider_duz: "301",
+          provider_name: "PROVIDER,TEST",
+          note: "Patient receptive to dietary changes"
+        },
+        {
+          ien: "702",
+          goal_text: "Walk 30 min/day",
+          lifecycle_status: "",   # API should default to "active"
+          achievement_status: nil,
+          category: nil,
+          priority: nil,
+          start_date: nil,
+          target_date: nil,
+          status_date: nil,
+          provider_duz: nil,
+          provider_name: nil,
+          note: nil
+        }
+      ])
+
+      # ORQQGO GET — single-line response, keyed by IEN.
+      m.seed(:goal_detail, "701", {
+        goal_text: "Reduce A1C to <7.0",
+        lifecycle_status: "active",
+        achievement_status: "in-progress",
+        category: "physiologic",
+        priority: "high",
+        start_date: nil,
+        target_date: nil,
+        status_date: nil,
+        provider_duz: "301",
+        provider_name: "PROVIDER,TEST",
+        patient_dfn: "8791"
+      })
+
+      # ORQQGO GET — multi-line response with prose note.
+      m.seed_text(:goal_detail, "702",
+        "Walk 30 min/day^^^^^^^^^^^8791\n" \
+        "Started after 2026-03 visit.\n" \
+        "Reassess at 90d.")
+
+      m.seed(:goal_detail, "703_BLANK", {
+        goal_text: "Blank-status goal",
+        lifecycle_status: nil,
+        achievement_status: nil,
+        category: nil,
+        priority: nil,
+        start_date: nil,
+        target_date: nil,
+        status_date: nil,
+        provider_duz: nil,
+        provider_name: nil,
+        patient_dfn: "8791"
+      })
+    end
+  end
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  # === for_patient ==========================================================
+
+  def test_for_patient_returns_goals
+    goals = RpmsRpc::Goal.for_patient(8791)
+
+    assert_kind_of Array, goals
+    assert_equal 2, goals.length
+    a1c = goals.find { |g| g[:goal_text] == "Reduce A1C to <7.0" }
+    refute_nil a1c
+    assert_equal "active",      a1c[:lifecycle_status]
+    assert_equal "in-progress", a1c[:achievement_status]
+    assert_equal "physiologic", a1c[:category]
+    assert_equal "high",        a1c[:priority]
+    assert_equal "301",         a1c[:provider_duz]
+    assert_equal "PROVIDER,TEST", a1c[:provider_name]
+    assert_equal "Patient receptive to dietary changes", a1c[:note]
+  end
+
+  def test_for_patient_defaults_lifecycle_status_when_blank
+    goals = RpmsRpc::Goal.for_patient(8791)
+    walk = goals.find { |g| g[:goal_text] == "Walk 30 min/day" }
+    refute_nil walk
+    assert_equal "active", walk[:lifecycle_status]
+  end
+
+  def test_for_patient_returns_empty_for_invalid_dfn
+    assert_equal [], RpmsRpc::Goal.for_patient(nil)
+    assert_equal [], RpmsRpc::Goal.for_patient("")
+    assert_equal [], RpmsRpc::Goal.for_patient(0)
+  end
+
+  def test_for_patient_returns_empty_for_unknown_dfn
+    assert_equal [], RpmsRpc::Goal.for_patient(999_999)
+  end
+
+  # === find =================================================================
+
+  def test_find_returns_single_goal
+    goal = RpmsRpc::Goal.find(701)
+
+    refute_nil goal
+    assert_equal 701,                  goal[:ien]
+    assert_equal "Reduce A1C to <7.0", goal[:goal_text]
+    assert_equal "active",             goal[:lifecycle_status]
+    assert_equal "in-progress",        goal[:achievement_status]
+    assert_equal "8791",               goal[:patient_dfn]
+  end
+
+  def test_find_joins_continuation_lines_into_note
+    goal = RpmsRpc::Goal.find(702)
+    refute_nil goal
+    assert_equal "Walk 30 min/day", goal[:goal_text]
+    assert_equal "8791",            goal[:patient_dfn]
+    assert_equal "Started after 2026-03 visit.\nReassess at 90d.", goal[:note]
+  end
+
+  def test_find_defaults_lifecycle_status_when_blank
+    goal = RpmsRpc::Goal.find("703_BLANK")
+    refute_nil goal
+    assert_equal "active", goal[:lifecycle_status]
+  end
+
+  def test_find_returns_nil_for_blank_ien
+    assert_nil RpmsRpc::Goal.find(nil)
+    assert_nil RpmsRpc::Goal.find("")
+  end
+
+  def test_find_returns_nil_for_unknown_ien
+    assert_nil RpmsRpc::Goal.find(999_998)
+  end
+end


### PR DESCRIPTION
## Summary

Ports the goal gateway from rpms_redux into `RpmsRpc::Goal`, completing the care-coord triplet alongside care_plan (#84) and care_team (#85).

- `for_patient(dfn)` → `Array<Hash>` (ORQQGO LIST)
- `find(ien)` → `Hash | nil` (ORQQGO GET — hybrid: first line field-based, subsequent lines joined into `:note`)
- Default `"active"` for blank `lifecycle_status` — matches rpms_redux gateway behavior.

Each goal exposes: `ien, goal_text, lifecycle_status, achievement_status, category, priority, start_date, target_date, status_date, provider_duz, provider_name, note, patient_dfn` (find only).

### Mapping changes

`:goal_list` (4 of 12 fields) and `:goal_detail` (5 of 12, with bogus `:author` field that doesn't exist in the gateway) were re-derived from `parse_goal_list` / `parse_goal` from scratch.

Verified no other code consumes the old field names via grep.

Part of #80.

## Test plan

- [x] `bundle exec ruby -Ilib -Itest test/rpms_rpc/api/goal_test.rb` (9 tests / 31 assertions)
- [x] `bundle exec rake test` full suite (411 / 981, no regressions)
- [x] `bundle exec rubocop` on the three changed files