### PR TITLE
Device module: port from rpms_redux (Part of #80)

### DIFF
--- a/lib/rpms_rpc/api/device.rb
+++ b/lib/rpms_rpc/api/device.rb
@@ -5,13 +5,13 @@ module RpmsRpc
     extend self
 
     def for_patient(dfn)
-      return [] if blank?(dfn)
+      return [] if blank?(dfn) || dfn.to_i <= 0
 
       DataMapper.device_list.fetch_many(dfn.to_s).map { |device| apply_defaults(device) }
     end
 
     def find(ien)
-      return nil if blank?(ien)
+      return nil if blank?(ien) || ien.to_i <= 0
 
       device = DataMapper.device_detail.fetch_one(ien.to_s, extras: { ien: ien.to_s })
       apply_defaults(device) if device
@@ -19,6 +19,9 @@ module RpmsRpc
 
     private
 
+    # Gateway behavior: `fields[3] || "active"`. Empty string is truthy in Ruby
+    # and therefore retained as-is — we only default when status is nil or
+    # absent.
     def apply_defaults(device)
       device.merge(status: device[:status] || "active")
     end

--- a/lib/rpms_rpc/api/device.rb
+++ b/lib/rpms_rpc/api/device.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module RpmsRpc
+  module Device
+    extend self
+
+    def for_patient(dfn)
+      return [] if blank?(dfn)
+
+      DataMapper.device_list.fetch_many(dfn.to_s).map { |device| apply_defaults(device) }
+    end
+
+    def find(ien)
+      return nil if blank?(ien)
+
+      device = DataMapper.device_detail.fetch_one(ien.to_s, extras: { ien: ien.to_s })
+      apply_defaults(device) if device
+    end
+
+    private
+
+    def apply_defaults(device)
+      device.merge(status: device[:status] || "active")
+    end
+
+    def blank?(value)
+      value.nil? || value.to_s.strip.empty?
+    end
+  end
+end

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -363,14 +363,23 @@ module RpmsRpc
     end
 
     # ORWPCE IMPLANT LIST — implanted device list (multi-line)
-    # Format: IEN^DEVICE_NAME^IMPLANT_DATE^STATUS^UDI
+    # Format: IEN^UDI^DEVICE_ID^STATUS^DEVICE_NAME^MANUFACTURER^MODEL^SERIAL^LOT^MFG_DATE^EXP_DATE^TYPE_CODE^TYPE_DISPLAY^DISTINCT_ID
     DataMapper.define(:device_list) do |m|
       m.rpc "ORWPCE IMPLANT LIST"
       m.field 0, :ien
-      m.field 1, :device_name
-      m.field 2, :implant_date, :fileman_date
+      m.field 1, :udi
+      m.field 2, :device_identifier
       m.field 3, :status
-      m.field 4, :udi
+      m.field 4, :name
+      m.field 5, :manufacturer
+      m.field 6, :model_number
+      m.field 7, :serial_number
+      m.field 8, :lot_number
+      m.field 9, :manufacture_date, :fileman_date
+      m.field 10, :expiration_date, :fileman_date
+      m.field 11, :snomed_code
+      m.field 12, :device_type
+      m.field 13, :distinct_id
     end
 
     # ========================================================================
@@ -713,14 +722,23 @@ module RpmsRpc
     end
 
     # ORWPCE IMPLANT GET — single implanted device
+    # Format: UDI^DEVICE_ID^STATUS^DEVICE_NAME^MANUFACTURER^MODEL^SERIAL^LOT^MFG_DATE^EXP_DATE^TYPE_CODE^TYPE_DISPLAY^DISTINCT_ID^PATIENT_DFN
     DataMapper.define(:device_detail) do |m|
       m.rpc "ORWPCE IMPLANT GET"
-      m.field 0, :ien
-      m.field 1, :device_name
-      m.field 2, :implant_date, :fileman_date
-      m.field 3, :status
-      m.field 4, :udi
-      m.field 5, :manufacturer
+      m.field 0, :udi
+      m.field 1, :device_identifier
+      m.field 2, :status
+      m.field 3, :name
+      m.field 4, :manufacturer
+      m.field 5, :model_number
+      m.field 6, :serial_number
+      m.field 7, :lot_number
+      m.field 8, :manufacture_date, :fileman_date
+      m.field 9, :expiration_date, :fileman_date
+      m.field 10, :snomed_code
+      m.field 11, :device_type
+      m.field 12, :distinct_id
+      m.field 13, :patient_dfn
     end
 
     # ========================================================================

--- a/test/rpms_rpc/api/device_test.rb
+++ b/test/rpms_rpc/api/device_test.rb
@@ -127,13 +127,9 @@ class DeviceTest < Minitest::Test
   end
 
   def test_find_uses_first_line_from_multi_line_detail_response
-    rpc_name = RpmsRpc::DataMapper.device_detail.rpc_name
-    keyed_collections = RpmsRpc.client.instance_variable_get(:@keyed_collections)
-    keyed_collections[rpc_name] ||= {}
-    keyed_collections[rpc_name]["201"] = [
-      "UDI-201^DEV-201^^Neurostimulator^Acme Medical^^^^^^^^^^^^1",
-      "ignored continuation line"
-    ]
+    RpmsRpc.client.seed_text(:device_detail, "201",
+      "UDI-201^DEV-201^^Neurostimulator^Acme Medical^^^^^^^^^^^^1\n" \
+      "ignored continuation line")
 
     device = RpmsRpc::Device.find("201")
 

--- a/test/rpms_rpc/api/device_test.rb
+++ b/test/rpms_rpc/api/device_test.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "date"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/device"
+
+class DeviceTest < Minitest::Test
+  def setup
+    RpmsRpc.mock! do |m|
+      m.seed_keyed_collection(:device_list, "1", [
+        {
+          ien: "101",
+          udi: "UDI-101",
+          device_identifier: "DEV-101",
+          status: "inactive",
+          name: "Pacemaker",
+          manufacturer: "Acme Medical",
+          model_number: "PM-100",
+          serial_number: "SN101",
+          lot_number: "LOT101",
+          manufacture_date: Date.new(2021, 2, 3),
+          expiration_date: Date.new(2031, 2, 3),
+          snomed_code: "14106009",
+          device_type: "Cardiac pacemaker",
+          distinct_id: "DIST-101"
+        },
+        {
+          ien: "102",
+          udi: "UDI-102",
+          device_identifier: "DEV-102",
+          status: nil,
+          name: "Implantable defibrillator"
+        }
+      ])
+
+      m.seed(:device_detail, "101", {
+        udi: "UDI-101",
+        device_identifier: "DEV-101",
+        status: "inactive",
+        name: "Pacemaker",
+        manufacturer: "Acme Medical",
+        model_number: "PM-100",
+        serial_number: "SN101",
+        lot_number: "LOT101",
+        manufacture_date: Date.new(2021, 2, 3),
+        expiration_date: Date.new(2031, 2, 3),
+        snomed_code: "14106009",
+        device_type: "Cardiac pacemaker",
+        distinct_id: "DIST-101",
+        patient_dfn: "1"
+      })
+      m.seed(:device_detail, "102", {
+        udi: "UDI-102",
+        device_identifier: "DEV-102",
+        status: nil,
+        name: "Implantable defibrillator",
+        patient_dfn: "1"
+      })
+    end
+  end
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  def test_for_patient_returns_devices
+    results = RpmsRpc::Device.for_patient("1")
+
+    assert_equal 2, results.length
+    device = results.first
+    assert_equal "101", device[:ien]
+    assert_equal "UDI-101", device[:udi]
+    assert_equal "DEV-101", device[:device_identifier]
+    assert_equal "Pacemaker", device[:name]
+    assert_equal "Acme Medical", device[:manufacturer]
+    assert_equal "PM-100", device[:model_number]
+    assert_equal "SN101", device[:serial_number]
+    assert_equal "LOT101", device[:lot_number]
+    assert_equal Date.new(2021, 2, 3), device[:manufacture_date]
+    assert_equal Date.new(2031, 2, 3), device[:expiration_date]
+    assert_equal "14106009", device[:snomed_code]
+    assert_equal "Cardiac pacemaker", device[:device_type]
+    assert_equal "DIST-101", device[:distinct_id]
+  end
+
+  def test_for_patient_defaults_blank_status_to_active
+    results = RpmsRpc::Device.for_patient("1")
+
+    assert_equal "active", results.last[:status]
+  end
+
+  def test_for_patient_returns_empty_for_invalid_dfn
+    assert_equal [], RpmsRpc::Device.for_patient(nil)
+    assert_equal [], RpmsRpc::Device.for_patient("")
+  end
+
+  def test_for_patient_returns_empty_for_unknown_dfn
+    assert_equal [], RpmsRpc::Device.for_patient("99999")
+  end
+
+  def test_find_returns_device_detail_with_ien_from_param
+    device = RpmsRpc::Device.find("101")
+
+    refute_nil device
+    assert_equal "101", device[:ien]
+    assert_equal "UDI-101", device[:udi]
+    assert_equal "DEV-101", device[:device_identifier]
+    assert_equal "inactive", device[:status]
+    assert_equal "Pacemaker", device[:name]
+    assert_equal "1", device[:patient_dfn]
+  end
+
+  def test_find_defaults_blank_status_to_active
+    device = RpmsRpc::Device.find("102")
+
+    assert_equal "active", device[:status]
+  end
+
+  def test_find_returns_nil_for_invalid_ien
+    assert_nil RpmsRpc::Device.find(nil)
+    assert_nil RpmsRpc::Device.find("")
+  end
+
+  def test_find_returns_nil_for_unknown_ien
+    assert_nil RpmsRpc::Device.find("99999")
+  end
+
+  def test_find_uses_first_line_from_multi_line_detail_response
+    rpc_name = RpmsRpc::DataMapper.device_detail.rpc_name
+    keyed_collections = RpmsRpc.client.instance_variable_get(:@keyed_collections)
+    keyed_collections[rpc_name] ||= {}
+    keyed_collections[rpc_name]["201"] = [
+      "UDI-201^DEV-201^^Neurostimulator^Acme Medical^^^^^^^^^^^^1",
+      "ignored continuation line"
+    ]
+
+    device = RpmsRpc::Device.find("201")
+
+    assert_equal "201", device[:ien]
+    assert_equal "UDI-201", device[:udi]
+    assert_equal "Neurostimulator", device[:name]
+    assert_equal "active", device[:status]
+  end
+end


### PR DESCRIPTION
## Summary
- Part of #80.
- Adds `RpmsRpc::Device.for_patient(dfn)` and `RpmsRpc::Device.find(ien)` for `ORWPCE IMPLANT LIST` and `ORWPCE IMPLANT GET`.
- Re-derived implant list/detail mappings from the rpms_redux gateway, fixing stale field-position assumptions: list now maps UDI/device identifier/name/manufacturer/model/serial/lot/manufacture and expiration dates/type fields, and detail no longer treats field 0 as IEN because IEN is supplied from the RPC parameter.

## Test plan
- `bundle exec ruby -Ilib -Itest test/rpms_rpc/api/device_test.rb`
- `bundle exec rake test`
- `bundle exec rubocop lib/rpms_rpc/mappings.rb lib/rpms_rpc/api/device.rb test/rpms_rpc/api/device_test.rb`

Made with [Cursor](https://cursor.com)