### PR TITLE
VaccineLot module: port from rpms_redux (Part of #80)

### DIFF
--- a/lib/rpms_rpc/api/vaccine_lot.rb
+++ b/lib/rpms_rpc/api/vaccine_lot.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "date"
+
+module RpmsRpc
+  module VaccineLot
+    extend self
+
+    def for_facility(facility_ien = nil)
+      params = facility_ien.nil? ? [] : [ facility_ien.to_s ]
+      lots = DataMapper.vaccine_lot_list.fetch_many(*params)
+      lots.map { |lot| normalize_lot(lot) }
+    end
+
+    def find(ien)
+      lot = DataMapper.vaccine_lot_detail.fetch_one(ien.to_s)
+      normalize_lot(lot) if lot
+    end
+
+    private
+
+    def normalize_lot(lot)
+      lot.merge(expiration_date: parse_lot_date(lot[:expiration_date]))
+    end
+
+    def parse_lot_date(date_str)
+      value = date_str.to_s
+      return nil if value.empty?
+
+      Date.parse(value)
+    rescue Date::Error
+      nil
+    end
+  end
+end

--- a/lib/rpms_rpc/api/vaccine_lot.rb
+++ b/lib/rpms_rpc/api/vaccine_lot.rb
@@ -8,11 +8,13 @@ module RpmsRpc
 
     def for_facility(facility_ien = nil)
       params = facility_ien.nil? ? [] : [ facility_ien.to_s ]
-      lots = DataMapper.vaccine_lot_list.fetch_many(*params)
+      lots = Array(DataMapper.vaccine_lot_list.fetch_many(*params))
       lots.map { |lot| normalize_lot(lot) }
     end
 
     def find(ien)
+      return nil if ien.nil? || ien.to_s.empty? || ien.to_i <= 0
+
       lot = DataMapper.vaccine_lot_detail.fetch_one(ien.to_s)
       normalize_lot(lot) if lot
     end

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -970,5 +970,40 @@ module RpmsRpc
       m.field 0, :code
       m.field 1, :label
     end
+
+    # BIPC LOTLIST — vaccine inventory lots, optionally filtered by facility
+    # Format per line: IEN^LOT^CVX^DISPLAY^MANUFACTURER^NDC^SOURCE^STATUS^EXP^START_COUNT^UNUSED^FACILITY
+    DataMapper.define(:vaccine_lot_list) do |m|
+      m.rpc "BIPC LOTLIST"
+      m.field 0,  :ien
+      m.field 1,  :lot_number
+      m.field 2,  :vaccine_code
+      m.field 3,  :vaccine_display
+      m.field 4,  :manufacturer
+      m.field 5,  :ndc_code
+      m.field 6,  :funding_source
+      m.field 7,  :status
+      m.field 8,  :expiration_date
+      m.field 9,  :doses_start, :integer
+      m.field 10, :doses_unused, :integer
+      m.field 11, :facility_ien
+    end
+
+    # BIPC LOTGET — single vaccine inventory lot
+    DataMapper.define(:vaccine_lot_detail) do |m|
+      m.rpc "BIPC LOTGET"
+      m.field 0,  :ien
+      m.field 1,  :lot_number
+      m.field 2,  :vaccine_code
+      m.field 3,  :vaccine_display
+      m.field 4,  :manufacturer
+      m.field 5,  :ndc_code
+      m.field 6,  :funding_source
+      m.field 7,  :status
+      m.field 8,  :expiration_date
+      m.field 9,  :doses_start, :integer
+      m.field 10, :doses_unused, :integer
+      m.field 11, :facility_ien
+    end
   end
 end

--- a/test/rpms_rpc/api/vaccine_lot_test.rb
+++ b/test/rpms_rpc/api/vaccine_lot_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "date"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/vaccine_lot"
+
+class VaccineLotTest < Minitest::Test
+  def setup
+    RpmsRpc.mock! do |m|
+      m.seed_collection(:vaccine_lot_list, [
+        lot_attrs(ien: "101", lot_number: "LOT-A", facility_ien: "55"),
+        lot_attrs(ien: "102", lot_number: "LOT-B", facility_ien: "66", expiration_date: "BAD")
+      ])
+      m.seed(:vaccine_lot_detail, "101", lot_attrs(ien: "101", lot_number: "LOT-A", facility_ien: "55"))
+    end
+  end
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  def test_for_facility_returns_lots_without_facility_filter
+    lots = RpmsRpc::VaccineLot.for_facility
+
+    assert_equal 2, lots.length
+    assert_equal "LOT-A", lots.first[:lot_number]
+    assert_equal Date.new(2026, 12, 31), lots.first[:expiration_date]
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BIPC LOTLIST" }
+    assert_equal [], call[:params]
+  end
+
+  def test_for_facility_passes_facility_filter
+    RpmsRpc::VaccineLot.for_facility(55)
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BIPC LOTLIST" }
+    assert_equal [ "55" ], call[:params]
+  end
+
+  def test_find_returns_lot_detail
+    lot = RpmsRpc::VaccineLot.find(101)
+
+    assert_equal "101", lot[:ien]
+    assert_equal "207", lot[:vaccine_code]
+    assert_equal "PFIZER", lot[:manufacturer]
+    assert_equal 120, lot[:doses_start]
+    assert_equal 45, lot[:doses_unused]
+  end
+
+  def test_find_returns_nil_for_missing_lot
+    assert_nil RpmsRpc::VaccineLot.find(999_999)
+  end
+
+  def test_invalid_values_are_handled_like_gateway
+    lots = RpmsRpc::VaccineLot.for_facility
+
+    assert_nil lots.last[:expiration_date]
+    assert_nil RpmsRpc::VaccineLot.find(nil)
+  end
+
+  private
+
+  def lot_attrs(overrides = {})
+    {
+      ien: "101",
+      lot_number: "LOT-A",
+      vaccine_code: "207",
+      vaccine_display: "COVID-19 mRNA",
+      manufacturer: "PFIZER",
+      ndc_code: "59267-1000-01",
+      funding_source: "VFC",
+      status: "ACTIVE",
+      expiration_date: "2026-12-31",
+      doses_start: 120,
+      doses_unused: 45,
+      facility_ien: "55"
+    }.merge(overrides)
+  end
+end

--- a/test/rpms_rpc/api/vaccine_lot_test.rb
+++ b/test/rpms_rpc/api/vaccine_lot_test.rb
@@ -56,7 +56,16 @@ class VaccineLotTest < Minitest::Test
     lots = RpmsRpc::VaccineLot.for_facility
 
     assert_nil lots.last[:expiration_date]
+  end
+
+  def test_find_returns_nil_for_blank_or_nonpositive_ien
     assert_nil RpmsRpc::VaccineLot.find(nil)
+    assert_nil RpmsRpc::VaccineLot.find("")
+    assert_nil RpmsRpc::VaccineLot.find(0)
+    assert_nil RpmsRpc::VaccineLot.find(-1)
+
+    refute RpmsRpc.client.received_calls.any? { |c| c[:rpc] == "BIPC LOTGET" },
+      "BIPC LOTGET should not fire for invalid IEN"
   end
 
   private

--- a/test/rpms_rpc/mappings_test.rb
+++ b/test/rpms_rpc/mappings_test.rb
@@ -305,6 +305,36 @@ class RpmsRpc::MappingsTest < Minitest::Test
     assert_equal 5, RpmsRpc::DataMapper[:immunization_count].parse_scalar("5")
   end
 
+  def test_vaccine_lot_list
+    result = RpmsRpc::DataMapper[:vaccine_lot_list].parse_many(
+      [ "101^LOT-A^207^COVID-19 mRNA^PFIZER^59267-1000-01^VFC^ACTIVE^2026-12-31^120^45^55" ]
+    ).first
+
+    assert_equal "101", result[:ien]
+    assert_equal "LOT-A", result[:lot_number]
+    assert_equal "207", result[:vaccine_code]
+    assert_equal "COVID-19 mRNA", result[:vaccine_display]
+    assert_equal "PFIZER", result[:manufacturer]
+    assert_equal "59267-1000-01", result[:ndc_code]
+    assert_equal "VFC", result[:funding_source]
+    assert_equal "ACTIVE", result[:status]
+    assert_equal "2026-12-31", result[:expiration_date]
+    assert_equal 120, result[:doses_start]
+    assert_equal 45, result[:doses_unused]
+    assert_equal "55", result[:facility_ien]
+  end
+
+  def test_vaccine_lot_detail
+    result = RpmsRpc::DataMapper[:vaccine_lot_detail].parse_one(
+      "101^LOT-A^207^COVID-19 mRNA^PFIZER^59267-1000-01^VFC^ACTIVE^2026-12-31^120^45^55"
+    )
+
+    assert_equal "101", result[:ien]
+    assert_equal "LOT-A", result[:lot_number]
+    assert_equal 45, result[:doses_unused]
+    assert_equal "55", result[:facility_ien]
+  end
+
   def test_phr_access
     assert_equal true, RpmsRpc::DataMapper[:phr_access].parse_scalar("1")
   end
@@ -334,7 +364,7 @@ class RpmsRpc::MappingsTest < Minitest::Test
       prescription_new erx_status prescription_cancel
       ccd_document ccd_referral immunization_text immunization_count
       phr_access phr_patient_direct phr_provider_direct phr_facility_direct
-      vfc_eligibility vfc_eligibility_list
+      vfc_eligibility vfc_eligibility_list vaccine_lot_list vaccine_lot_detail
     ]
 
     expected.each do |name|


### PR DESCRIPTION
## Summary
- Port VaccineLot list/detail access from rpms_redux using `BIPC LOTLIST` and `BIPC LOTGET`.
- Add `RpmsRpc::VaccineLot.for_facility` and `find` plus mapping coverage for the lot field shape.

Part of #80.

## Test plan
- `bundle exec ruby -Ilib -Itest test/rpms_rpc/api/vaccine_lot_test.rb`
- `bundle exec rake test`
- `bundle exec rubocop lib/rpms_rpc/mappings.rb lib/rpms_rpc/api/vaccine_lot.rb test/rpms_rpc/api/vaccine_lot_test.rb test/rpms_rpc/mappings_test.rb`

Made with [Cursor](https://cursor.com)