### PR TITLE
RcisSiteParams module: port from rpms_redux (Part of #80)

### DIFF
--- a/lib/rpms_rpc/api/rcis_site_params.rb
+++ b/lib/rpms_rpc/api/rcis_site_params.rb
@@ -21,6 +21,11 @@ module RpmsRpc
       return nil if rows.empty?
 
       params = rows.each_with_object({}) do |row, result|
+        # Gateway parses with default split("^") which drops trailing empties,
+        # then skips rows where fields.length < 2. So a "KEY^" line with a
+        # blank value is omitted entirely, not assigned a default.
+        next if blank?(row[:value])
+
         key = normalize_key(row[:key])
         result[key] = parse_param_value(row[:key], row[:value]) unless key.nil?
       end
@@ -50,7 +55,7 @@ module RpmsRpc
     end
 
     def blank?(val)
-      val.nil? || val.to_s.empty?
+      val.nil? || val.to_s.strip.empty?
     end
   end
 end

--- a/lib/rpms_rpc/api/rcis_site_params.rb
+++ b/lib/rpms_rpc/api/rcis_site_params.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module RpmsRpc
+  # Symbolic API for RCIS site parameters.
+  # Underlying RPC: BMCRPC GTSITPRM.
+  module RcisSiteParams
+    extend self
+
+    FIELD_MAP = {
+      "COMMTHRESH" => :committee_threshold,
+      "NOTIFYHR"   => :notification_grace_period,
+      "PRISYS"     => :priority_system,
+      "FACILITY"   => :facility_name,
+      "FACILCODE"  => :facility_code
+    }.freeze
+
+    def for_facility(facility_ien)
+      return nil if blank?(facility_ien) || facility_ien.to_i <= 0
+
+      rows = DataMapper.site_params.fetch_many(facility_ien.to_s)
+      return nil if rows.empty?
+
+      params = rows.each_with_object({}) do |row, result|
+        key = normalize_key(row[:key])
+        result[key] = parse_param_value(row[:key], row[:value]) unless key.nil?
+      end
+
+      params.empty? ? nil : params
+    end
+
+    private
+
+    def normalize_key(raw_key)
+      mapped = FIELD_MAP[raw_key.to_s]
+      return mapped if mapped
+
+      normalized = raw_key.to_s.downcase.gsub(/\s+/, "_").gsub(/[^a-z0-9_]/, "")
+      normalized.empty? ? nil : normalized.to_sym
+    end
+
+    def parse_param_value(key, value)
+      case key.to_s.upcase
+      when "COMMTHRESH", "NOTIFYHR"
+        value.to_i
+      when "PRISYS"
+        value == "I" ? "ihs_2024" : "traditional"
+      else
+        value
+      end
+    end
+
+    def blank?(val)
+      val.nil? || val.to_s.empty?
+    end
+  end
+end

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -465,11 +465,11 @@ module RpmsRpc
     end
 
     # BMCRPC GTSITPRM — RCIS site parameters
+    # Format per line: KEY^VALUE
     DataMapper.define(:site_params) do |m|
       m.rpc "BMCRPC GTSITPRM"
-      m.field 0, :site_name
-      m.field 1, :station_number
-      m.field 2, :service_area
+      m.field 0, :key
+      m.field 1, :value
     end
 
     # ========================================================================

--- a/test/rpms_rpc/api/rcis_site_params_test.rb
+++ b/test/rpms_rpc/api/rcis_site_params_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/rcis_site_params"
+
+class RcisSiteParamsTest < Minitest::Test
+  FACILITY_IEN = 55
+
+  def setup
+    RpmsRpc.mock! do |m|
+      # BMCRPC GTSITPRM — keyed by facility IEN, multi-line KEY^VALUE response.
+      m.seed_keyed_collection(:site_params, FACILITY_IEN.to_s, [
+        { key: "COMMTHRESH", value: "50000" },
+        { key: "NOTIFYHR", value: "72" },
+        { key: "PRISYS", value: "I" },
+        { key: "FACILITY", value: "General Hospital" },
+        { key: "FACILCODE", value: "GH01" },
+        { key: "CUSTOM PARAM", value: "enabled" }
+      ])
+
+      m.seed_keyed_collection(:site_params, "56", [
+        { key: "COMMTHRESH", value: "" },
+        { key: "NOTIFYHR", value: nil },
+        { key: "PRISYS", value: "" },
+        { key: "FACILITY", value: "" }
+      ])
+    end
+  end
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  def test_for_facility_returns_site_parameters
+    params = RpmsRpc::RcisSiteParams.for_facility(FACILITY_IEN)
+
+    refute_nil params
+    assert_equal 50_000, params[:committee_threshold]
+    assert_equal 72, params[:notification_grace_period]
+    assert_equal "ihs_2024", params[:priority_system]
+    assert_equal "General Hospital", params[:facility_name]
+    assert_equal "GH01", params[:facility_code]
+    assert_equal "enabled", params[:custom_param]
+  end
+
+  def test_for_facility_sends_facility_ien_to_site_params_rpc
+    RpmsRpc::RcisSiteParams.for_facility(FACILITY_IEN)
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BMCRPC GTSITPRM" }
+    refute_nil call
+    assert_equal [ FACILITY_IEN.to_s ], call[:params]
+  end
+
+  def test_for_facility_returns_nil_for_blank_zero_or_negative_facility_ien
+    assert_nil RpmsRpc::RcisSiteParams.for_facility(nil)
+    assert_nil RpmsRpc::RcisSiteParams.for_facility("")
+    assert_nil RpmsRpc::RcisSiteParams.for_facility(0)
+    assert_nil RpmsRpc::RcisSiteParams.for_facility(-5)
+  end
+
+  def test_for_facility_returns_nil_for_unknown_facility
+    assert_nil RpmsRpc::RcisSiteParams.for_facility(999_999)
+  end
+
+  def test_for_facility_applies_blank_field_defaults_from_gateway
+    params = RpmsRpc::RcisSiteParams.for_facility(56)
+
+    refute_nil params
+    assert_equal 0, params[:committee_threshold]
+    assert_equal 0, params[:notification_grace_period]
+    assert_equal "traditional", params[:priority_system]
+    assert_nil params[:facility_name]
+  end
+
+  def test_module_exposes_documented_methods
+    assert RpmsRpc::RcisSiteParams.respond_to?(:for_facility)
+  end
+end

--- a/test/rpms_rpc/api/rcis_site_params_test.rb
+++ b/test/rpms_rpc/api/rcis_site_params_test.rb
@@ -25,6 +25,15 @@ class RcisSiteParamsTest < Minitest::Test
         { key: "PRISYS", value: "" },
         { key: "FACILITY", value: "" }
       ])
+
+      # Partial-blank facility: blank-valued rows should be omitted entirely
+      # (matching gateway's `parse_line` + length-< 2 skip), populated rows kept.
+      m.seed_keyed_collection(:site_params, "57", [
+        { key: "COMMTHRESH", value: "" },
+        { key: "NOTIFYHR",   value: "48" },
+        { key: "PRISYS",     value: "" },
+        { key: "FACILITY",   value: "Test Clinic" }
+      ])
     end
   end
 
@@ -63,14 +72,22 @@ class RcisSiteParamsTest < Minitest::Test
     assert_nil RpmsRpc::RcisSiteParams.for_facility(999_999)
   end
 
-  def test_for_facility_applies_blank_field_defaults_from_gateway
-    params = RpmsRpc::RcisSiteParams.for_facility(56)
+  def test_for_facility_returns_nil_when_all_values_blank
+    # Gateway parses with default split("^") which drops trailing empties,
+    # then skips rows whose split length is < 2. So a facility whose response
+    # is all "KEY^" lines (blank values) yields an empty params hash, which
+    # the gateway returns as nil (`params.presence`).
+    assert_nil RpmsRpc::RcisSiteParams.for_facility(56)
+  end
+
+  def test_for_facility_skips_blank_valued_rows_keeping_populated_ones
+    params = RpmsRpc::RcisSiteParams.for_facility(57)
 
     refute_nil params
-    assert_equal 0, params[:committee_threshold]
-    assert_equal 0, params[:notification_grace_period]
-    assert_equal "traditional", params[:priority_system]
-    assert_nil params[:facility_name]
+    refute params.key?(:committee_threshold), "blank-valued row should be omitted"
+    refute params.key?(:priority_system),     "blank-valued row should be omitted"
+    assert_equal 48,            params[:notification_grace_period]
+    assert_equal "Test Clinic", params[:facility_name]
   end
 
   def test_module_exposes_documented_methods

--- a/test/rpms_rpc/mappings_test.rb
+++ b/test/rpms_rpc/mappings_test.rb
@@ -221,6 +221,12 @@ class RpmsRpc::MappingsTest < Minitest::Test
     assert_equal "AK", result[:state]
   end
 
+  def test_site_params
+    result = RpmsRpc::DataMapper[:site_params].parse_one("COMMTHRESH^50000")
+    assert_equal "COMMTHRESH", result[:key]
+    assert_equal "50000", result[:value]
+  end
+
   # -- XUS GET USER INFO -----------------------------------------------------
 
   def test_user_info


### PR DESCRIPTION
## Summary
- Port RCIS site parameter access via `RpmsRpc::RcisSiteParams.for_facility`.
- Correct `BMCRPC GTSITPRM` mapping to parse `KEY^VALUE` response lines and normalize known parameters.
- Add focused API and mapping coverage for parameter conversion, invalid facility IDs, unknown facilities, and blank values.

## Test plan
- `bundle exec ruby -Ilib -Itest test/rpms_rpc/api/rcis_site_params_test.rb`
- `bundle exec rake test`
- `bundle exec rubocop lib/rpms_rpc/mappings.rb lib/rpms_rpc/api/rcis_site_params.rb test/rpms_rpc/api/rcis_site_params_test.rb test/rpms_rpc/mappings_test.rb`

Made with [Cursor](https://cursor.com)