### PR TITLE
UserManagement module: port from rpms_redux (Part of #80)

### DIFF
--- a/lib/rpms_rpc/api/user_management.rb
+++ b/lib/rpms_rpc/api/user_management.rb
@@ -52,15 +52,19 @@ module RpmsRpc
       key_name = key_name.to_s.strip
       return { success: false, error: "Key name required" } if key_name.empty?
 
-      mapping = DataMapper[mapping_name]
-      response = RpmsRpc.client.call_rpc(mapping.rpc_name, duz.to_s, key_name)
+      rpc_name = DataMapper[mapping_name].rpc_name
+      response = RpmsRpc.client.call_rpc(rpc_name, duz.to_s, key_name)
       first_line = response.is_a?(Array) ? response.first.to_s : response.to_s
-      parsed = mapping.parse_one(first_line)
 
-      if parsed&.fetch(:success, false)
+      # Gateway behavior: success when the first line starts with "1" (handles
+      # both "1", "1^message", and "1Some text" forms). Failure path strips a
+      # leading "0" or "0^" prefix to surface the actual error text from RPMS
+      # — e.g. "0No such key" → "No such key" — rather than masking it with
+      # the generic fallback.
+      if first_line.start_with?("1")
         { success: true, message: "Key #{key_name} #{verb} #{preposition} DUZ #{duz}" }
       else
-        error = presence(parsed && parsed[:message]) || fallback
+        error = presence(first_line.sub(/\A0\^?/, "")) || fallback
         { success: false, error: error }
       end
     end

--- a/lib/rpms_rpc/api/user_management.rb
+++ b/lib/rpms_rpc/api/user_management.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module RpmsRpc
+  # Symbolic API for New Person / user-management operations.
+  # Underlying RPCs: ORWU NEWPERS, XUS GET USER INFO, ORWU USERKEYS, XU KEY*.
+  module UserManagement
+    extend self
+
+    def search(name_pattern)
+      pattern = name_pattern.to_s.strip
+      return [] if pattern.empty?
+
+      DataMapper.user_management_user_list.fetch_many(pattern, "1")
+    end
+
+    def find(duz)
+      duz = normalize_duz(duz)
+      return nil if duz.nil?
+
+      user_info = DataMapper.user_info.fetch_one(duz.to_s)
+      return nil if user_info.nil?
+
+      {
+        user_info: user_info,
+        practitioner: DataMapper.practitioner_info.fetch_one(duz.to_s, extras: { ien: duz }),
+        security_keys: security_keys(duz).sort
+      }
+    end
+
+    def grant_key(duz, key_name)
+      change_key(:key_grant, duz, key_name, "granted", "to", "Grant failed")
+    end
+
+    def revoke_key(duz, key_name)
+      change_key(:key_revoke, duz, key_name, "revoked", "from", "Revoke failed")
+    end
+
+    def list_all_keys
+      DataMapper.key_list.fetch_many
+    end
+
+    private
+
+    def security_keys(duz)
+      DataMapper.user_keys.fetch_many(duz.to_s).filter_map { |row| presence(row[:key_name]) }
+    end
+
+    def change_key(mapping_name, duz, key_name, verb, preposition, fallback)
+      duz = normalize_duz(duz)
+      return { success: false, error: "Invalid DUZ" } if duz.nil?
+
+      key_name = key_name.to_s.strip
+      return { success: false, error: "Key name required" } if key_name.empty?
+
+      mapping = DataMapper[mapping_name]
+      response = RpmsRpc.client.call_rpc(mapping.rpc_name, duz.to_s, key_name)
+      first_line = response.is_a?(Array) ? response.first.to_s : response.to_s
+      parsed = mapping.parse_one(first_line)
+
+      if parsed&.fetch(:success, false)
+        { success: true, message: "Key #{key_name} #{verb} #{preposition} DUZ #{duz}" }
+      else
+        error = presence(parsed && parsed[:message]) || fallback
+        { success: false, error: error }
+      end
+    end
+
+    def normalize_duz(duz)
+      return nil if duz.nil?
+
+      str = duz.to_s.strip
+      return nil unless str.match?(/\A[1-9]\d*\z/)
+
+      str.to_i
+    end
+
+    def presence(val)
+      return nil if val.nil?
+
+      str = val.to_s.strip
+      str.empty? ? nil : str
+    end
+  end
+end

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -275,6 +275,15 @@ module RpmsRpc
       m.field 2, :title
     end
 
+    # ORWU NEWPERS — user management search results (multi-line)
+    # Format per line: DUZ^NAME^TITLE
+    DataMapper.define(:user_management_user_list) do |m|
+      m.rpc "ORWU NEWPERS"
+      m.field 0, :duz, :integer
+      m.field 1, :name
+      m.field 2, :title
+    end
+
     # ========================================================================
     # CLINICAL DATA (ORQQPS*, ORQQCP*, ORQQCT*, ORQQGO*, ORWPCE*)
     # ========================================================================
@@ -852,10 +861,11 @@ module RpmsRpc
     # ========================================================================
 
     # XU KEY LIST — key list (multi-line)
+    # Format per line: IEN^NAME
     DataMapper.define(:key_list) do |m|
       m.rpc "XU KEY LIST"
-      m.field 0, :key_name
-      m.field 1, :key_ien, :integer
+      m.field 0, :ien, :integer
+      m.field 1, :name
     end
 
     # XU KEY GRANT — grant result

--- a/test/rpms_rpc/api/user_management_test.rb
+++ b/test/rpms_rpc/api/user_management_test.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/user_management"
+
+class UserManagementTest < Minitest::Test
+  DUZ = 301
+
+  def setup
+    RpmsRpc.mock! do |m|
+      # ORWU NEWPERS — same RPC as practitioner search, but File 200 user shape.
+      # Format per line: DUZ^NAME^TITLE
+      m.seed_collection(:user_management_user_list, [
+        { duz: DUZ, name: "PROVIDER,TEST", title: "MD" },
+        { duz: 405, name: "NURSE,TEST", title: "RN" }
+      ], filter_field: :name)
+
+      m.seed(:user_info, DUZ.to_s, {
+        duz: DUZ,
+        name: "PROVIDER,TEST",
+        user_class: "PROVIDER",
+        can_sign: true,
+        is_provider: true,
+        order_role: "PHYSICIAN"
+      })
+
+      m.seed(:practitioner_info, DUZ.to_s, {
+        name: "PROVIDER,TEST",
+        title: "MD",
+        service_section: "Primary Care",
+        specialty: "Family Medicine",
+        npi: "1234567890",
+        dea_number: "AB1234567",
+        phone: "907-555-0100",
+        provider_class: "Physician"
+      })
+
+      m.seed_keyed_collection(:user_keys, DUZ.to_s, [
+        { key_name: "XUPROGMODE" },
+        { key_name: "PROVIDER" },
+        { key_name: "" }
+      ])
+
+      m.seed_collection(:key_list, [
+        { ien: 1, name: "XUPROGMODE" },
+        { ien: 2, name: "PROVIDER" }
+      ])
+
+      m.seed(:key_grant, DUZ.to_s, { success: true, message: "Key granted" })
+      m.seed(:key_revoke, DUZ.to_s, { success: true, message: "Key revoked" })
+      m.seed(:key_grant, "999", { success: false, message: "No such user" })
+      m.seed(:key_revoke, "999", { success: false, message: "" })
+    end
+  end
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  def test_search_returns_matching_users
+    users = RpmsRpc::UserManagement.search("PRO")
+
+    assert_equal 1, users.length
+    assert_equal DUZ, users.first[:duz]
+    assert_equal "PROVIDER,TEST", users.first[:name]
+    assert_equal "MD", users.first[:title]
+  end
+
+  def test_search_returns_empty_for_blank_pattern
+    assert_equal [], RpmsRpc::UserManagement.search(nil)
+    assert_equal [], RpmsRpc::UserManagement.search("")
+    assert_equal [], RpmsRpc::UserManagement.search("   ")
+  end
+
+  def test_find_returns_access_summary
+    summary = RpmsRpc::UserManagement.find(DUZ)
+
+    refute_nil summary
+    assert_equal DUZ, summary[:user_info][:duz]
+    assert_equal "PROVIDER,TEST", summary[:practitioner][:name]
+    assert_equal %w[PROVIDER XUPROGMODE], summary[:security_keys]
+  end
+
+  def test_find_rejects_blank_zero_negative_and_nonnumeric_duz
+    assert_nil RpmsRpc::UserManagement.find(nil)
+    assert_nil RpmsRpc::UserManagement.find("")
+    assert_nil RpmsRpc::UserManagement.find(0)
+    assert_nil RpmsRpc::UserManagement.find(-1)
+    assert_nil RpmsRpc::UserManagement.find("abc")
+    assert_nil RpmsRpc::UserManagement.find("123abc")
+  end
+
+  def test_find_returns_nil_for_unknown_duz
+    assert_nil RpmsRpc::UserManagement.find(999_998)
+  end
+
+  def test_grant_key_calls_rpc_and_returns_success_message
+    result = RpmsRpc::UserManagement.grant_key(DUZ, "PROVIDER")
+
+    assert_equal true, result[:success]
+    assert_equal "Key PROVIDER granted to DUZ #{DUZ}", result[:message]
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "XU KEY GRANT" }
+    assert_equal [ DUZ.to_s, "PROVIDER" ], call[:params]
+  end
+
+  def test_revoke_key_calls_rpc_and_returns_success_message
+    result = RpmsRpc::UserManagement.revoke_key(DUZ, "PROVIDER")
+
+    assert_equal true, result[:success]
+    assert_equal "Key PROVIDER revoked from DUZ #{DUZ}", result[:message]
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "XU KEY REVOKE" }
+    assert_equal [ DUZ.to_s, "PROVIDER" ], call[:params]
+  end
+
+  def test_key_changes_reject_invalid_duz_and_blank_key
+    assert_equal({ success: false, error: "Invalid DUZ" }, RpmsRpc::UserManagement.grant_key(0, "PROVIDER"))
+    assert_equal({ success: false, error: "Invalid DUZ" }, RpmsRpc::UserManagement.revoke_key(-1, "PROVIDER"))
+    assert_equal({ success: false, error: "Invalid DUZ" }, RpmsRpc::UserManagement.grant_key("123abc", "PROVIDER"))
+    assert_equal({ success: false, error: "Key name required" }, RpmsRpc::UserManagement.grant_key(DUZ, " "))
+  end
+
+  def test_key_changes_return_rpc_errors_or_defaults
+    assert_equal({ success: false, error: "No such user" }, RpmsRpc::UserManagement.grant_key(999, "PROVIDER"))
+    assert_equal({ success: false, error: "Revoke failed" }, RpmsRpc::UserManagement.revoke_key(999, "PROVIDER"))
+  end
+
+  def test_list_all_keys_returns_file_19_1_entries
+    keys = RpmsRpc::UserManagement.list_all_keys
+
+    assert_equal 2, keys.length
+    assert_equal({ ien: 1, name: "XUPROGMODE" }, keys.first)
+    assert_equal({ ien: 2, name: "PROVIDER" }, keys.last)
+  end
+end

--- a/test/rpms_rpc/api/user_management_test.rb
+++ b/test/rpms_rpc/api/user_management_test.rb
@@ -51,6 +51,15 @@ class UserManagementTest < Minitest::Test
       m.seed(:key_revoke, DUZ.to_s, { success: true, message: "Key revoked" })
       m.seed(:key_grant, "999", { success: false, message: "No such user" })
       m.seed(:key_revoke, "999", { success: false, message: "" })
+
+      # Non-caret error response — gateway strips a leading "0" to surface
+      # the raw error text. Seeded as raw text so it bypasses the field-based
+      # format and exercises the first-line parsing path.
+      m.seed_text(:key_grant,  "1234", "0No such key")
+      m.seed_text(:key_revoke, "5678", "0Permission denied")
+      # Non-caret success response — gateway treats any line starting with "1"
+      # as success regardless of trailing text or caret.
+      m.seed_text(:key_grant, "4321", "1OK")
     end
   end
 
@@ -123,6 +132,22 @@ class UserManagementTest < Minitest::Test
   def test_key_changes_return_rpc_errors_or_defaults
     assert_equal({ success: false, error: "No such user" }, RpmsRpc::UserManagement.grant_key(999, "PROVIDER"))
     assert_equal({ success: false, error: "Revoke failed" }, RpmsRpc::UserManagement.revoke_key(999, "PROVIDER"))
+  end
+
+  def test_key_changes_strip_bare_zero_prefix_from_non_caret_error_responses
+    grant = RpmsRpc::UserManagement.grant_key(1234, "PROVIDER")
+    assert_equal false,          grant[:success]
+    assert_equal "No such key",  grant[:error]
+
+    revoke = RpmsRpc::UserManagement.revoke_key(5678, "PROVIDER")
+    assert_equal false,                revoke[:success]
+    assert_equal "Permission denied",  revoke[:error]
+  end
+
+  def test_key_changes_accept_non_caret_success_responses
+    result = RpmsRpc::UserManagement.grant_key(4321, "PROVIDER")
+    assert_equal true, result[:success]
+    assert_match(/granted/, result[:message])
   end
 
   def test_list_all_keys_returns_file_19_1_entries

--- a/test/rpms_rpc/mappings_test.rb
+++ b/test/rpms_rpc/mappings_test.rb
@@ -194,6 +194,13 @@ class RpmsRpc::MappingsTest < Minitest::Test
     assert_equal "DO", results[1][:title]
   end
 
+  def test_user_management_user_list
+    results = RpmsRpc::DataMapper[:user_management_user_list].parse_many([ "101^MARTINEZ,SARAH^MD", "102^CHEN,JAMES^DO" ])
+    assert_equal 2, results.size
+    assert_equal 101, results[0][:duz]
+    assert_equal "DO", results[1][:title]
+  end
+
   # -- ORQQPS LIST -----------------------------------------------------------
 
   def test_medication_list
@@ -299,6 +306,12 @@ class RpmsRpc::MappingsTest < Minitest::Test
     assert_equal true, result[:success]
   end
 
+  def test_key_list
+    result = RpmsRpc::DataMapper[:key_list].parse_many([ "1^XUPROGMODE", "2^PROVIDER" ]).first
+    assert_equal 1, result[:ien]
+    assert_equal "XUPROGMODE", result[:name]
+  end
+
   def test_prescription_new
     result = RpmsRpc::DataMapper[:prescription_new].parse_one("1^12345")
     assert_equal true, result[:success]
@@ -353,7 +366,7 @@ class RpmsRpc::MappingsTest < Minitest::Test
       patient_appointments allergy_list problem_list vitals
       tribal_enrollment tribal_validation tribe_info enrollment_eligibility
       service_unit patient_register patient_update encounter_create
-      practitioner_info practitioner_list
+      practitioner_info practitioner_list user_management_user_list
       medication_list care_plan_list care_team_list goal_list
       procedure_list device_list lab_result_list radiology_list
       hospital_location institution referral_search site_params


### PR DESCRIPTION
## Summary
- Ported the user management API for New Person lookup, access summaries, security key grant/revoke, and key listing.
- Added ORWU NEWPERS user search mapping and corrected XU KEY LIST parsing to the gateway's IEN/name shape.
- Covered user lookup, invalid IDs, blank inputs, unknown records, key changes, and mapping registration.

## Test plan
- bundle exec ruby -Ilib -Itest test/rpms_rpc/api/user_management_test.rb
- bundle exec ruby -Ilib -Itest test/rpms_rpc/mappings_test.rb
- bundle exec rake test
- bundle exec rubocop lib/rpms_rpc/api/user_management.rb lib/rpms_rpc/mappings.rb test/rpms_rpc/api/user_management_test.rb test/rpms_rpc/mappings_test.rb

Made with [Cursor](https://cursor.com)