### PR TITLE
ImmunizationExchange module: port from rpms_redux (Part of #80)

### DIFF
--- a/lib/rpms_rpc/api/immunization_exchange.rb
+++ b/lib/rpms_rpc/api/immunization_exchange.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module RpmsRpc
+  # Symbolic API for state IIS immunization exchange.
+  # Underlying RPCs (BYIMRT family): VXU, VXQ, RSP, STATUS.
+  module ImmunizationExchange
+    extend self
+
+    DEFAULT_STATUS = "completed"
+
+    def send_immunizations(dfn)
+      return invalid_patient_response unless positive_integer?(dfn)
+
+      response = RpmsRpc.client.call_rpc(DataMapper.immunization_exchange_vxu.rpc_name, dfn.to_s)
+      parse_status_line(DataMapper.immunization_exchange_vxu, response, default_error: "VXU send failed")
+    end
+
+    def submit_query(dfn)
+      return invalid_patient_response unless positive_integer?(dfn)
+
+      response = RpmsRpc.client.call_rpc(DataMapper.immunization_exchange_vxq.rpc_name, dfn.to_s)
+      parse_status_line(DataMapper.immunization_exchange_vxq, response, default_error: "VXQ query failed")
+    end
+
+    def for_patient(dfn)
+      return [] unless positive_integer?(dfn)
+
+      retrieve_response(dfn)
+    end
+
+    def retrieve_response(dfn = nil)
+      return [] if !dfn.nil? && !positive_integer?(dfn)
+
+      params = dfn.nil? ? [] : [ dfn.to_s ]
+      rows = DataMapper.immunization_exchange_rsp.fetch_many(*params)
+      Array(rows).map { |row| apply_defaults(row) }
+    end
+
+    def process_responses
+      response = RpmsRpc.client.call_rpc(DataMapper.immunization_exchange_rsp.rpc_name)
+      return { success: true, count: 0 } if empty_response?(response)
+
+      parsed = parse_status_line(DataMapper.immunization_exchange_process_result, response,
+        default_error: "Response processing failed")
+      return parsed unless parsed[:success]
+
+      { success: true, count: parsed[:message].to_s.scan(/\d+/).first.to_i }
+    end
+
+    def check_status
+      response = RpmsRpc.client.call_rpc(DataMapper.immunization_exchange_status.rpc_name)
+      status = parse_status_line(DataMapper.immunization_exchange_status, response,
+        default_error: "IIS status check failed")
+
+      status[:success] ? { available: true } : { available: false, error: status[:message] }
+    rescue StandardError => e
+      { available: false, error: e.message.to_s }
+    end
+
+    private
+
+    def parse_status_line(mapping, response, default_error:)
+      return { success: false, message: "Empty response from RPMS" } if empty_response?(response)
+
+      row = mapping.parse_one(response)
+      status_code = row[:status_code].to_i
+      message = row[:message]
+
+      if status_code.positive?
+        { success: true, message: message }
+      else
+        { success: false, message: blank?(message) ? default_error : message }
+      end
+    end
+
+    def apply_defaults(row)
+      row.merge(status: blank?(row[:status]) ? DEFAULT_STATUS : row[:status])
+    end
+
+    def invalid_patient_response
+      { success: false, message: "Invalid patient DFN" }
+    end
+
+    def empty_response?(response)
+      response.nil? || (response.respond_to?(:empty?) && response.empty?)
+    end
+
+    def blank?(val)
+      val.nil? || val.to_s.empty?
+    end
+
+    def positive_integer?(val)
+      !blank?(val) && val.to_s.match?(/\A\d+\z/) && val.to_i.positive?
+    end
+  end
+end

--- a/lib/rpms_rpc/api/immunization_exchange.rb
+++ b/lib/rpms_rpc/api/immunization_exchange.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "date"
+
 module RpmsRpc
   # Symbolic API for state IIS immunization exchange.
   # Underlying RPCs (BYIMRT family): VXU, VXQ, RSP, STATUS.
@@ -44,7 +46,11 @@ module RpmsRpc
         default_error: "Response processing failed")
       return parsed unless parsed[:success]
 
-      { success: true, count: parsed[:message].to_s.scan(/\d+/).first.to_i }
+      # Gateway: `fields[1].to_s.scan(/\d+/).first&.to_i || 0` — `.first` returns
+      # nil when the message contains no digits, so the safe-nav + `|| 0` are
+      # both required to avoid NoMethodError on success-without-count responses.
+      count = parsed[:message].to_s.scan(/\d+/).first&.to_i || 0
+      { success: true, count: count }
     end
 
     def check_status
@@ -74,7 +80,18 @@ module RpmsRpc
     end
 
     def apply_defaults(row)
-      row.merge(status: blank?(row[:status]) ? DEFAULT_STATUS : row[:status])
+      row.merge(
+        status:          blank?(row[:status]) ? DEFAULT_STATUS : row[:status],
+        occurrence_date: parse_iso_date(row[:occurrence_date])
+      )
+    end
+
+    def parse_iso_date(value)
+      return nil if blank?(value)
+
+      Date.parse(value.to_s)
+    rescue Date::Error
+      nil
     end
 
     def invalid_patient_response
@@ -86,7 +103,7 @@ module RpmsRpc
     end
 
     def blank?(val)
-      val.nil? || val.to_s.empty?
+      val.nil? || val.to_s.strip.empty?
     end
 
     def positive_integer?(val)

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -935,6 +935,49 @@ module RpmsRpc
       m.scalar :count, :integer
     end
 
+    # BYIMRT VXU — send patient immunizations to state IIS
+    # Format: STATUS^MESSAGE
+    DataMapper.define(:immunization_exchange_vxu) do |m|
+      m.rpc "BYIMRT VXU"
+      m.field 0, :status_code, :integer
+      m.field 1, :message
+    end
+
+    # BYIMRT VXQ — submit patient immunization query to state IIS
+    # Format: STATUS^MESSAGE
+    DataMapper.define(:immunization_exchange_vxq) do |m|
+      m.rpc "BYIMRT VXQ"
+      m.field 0, :status_code, :integer
+      m.field 1, :message
+    end
+
+    # BYIMRT RSP — inbound immunization response lines
+    # Format: VACCINE_CODE^VACCINE_DISPLAY^OCCURRENCE_DATE^NDC_CODE^STATUS
+    DataMapper.define(:immunization_exchange_rsp) do |m|
+      m.rpc "BYIMRT RSP"
+      m.field 0, :vaccine_code
+      m.field 1, :vaccine_display
+      m.field 2, :occurrence_date, :fileman_date
+      m.field 3, :ndc_code
+      m.field 4, :status
+    end
+
+    # BYIMRT RSP — batch process result when called without patient context
+    # Format: STATUS^MESSAGE
+    DataMapper.define(:immunization_exchange_process_result) do |m|
+      m.rpc "BYIMRT RSP"
+      m.field 0, :status_code, :integer
+      m.field 1, :message
+    end
+
+    # BYIMRT STATUS — IIS exchange connectivity check
+    # Format: STATUS^MESSAGE
+    DataMapper.define(:immunization_exchange_status) do |m|
+      m.rpc "BYIMRT STATUS"
+      m.field 0, :status_code, :integer
+      m.field 1, :message
+    end
+
     # BPHR RECORD ACCESS — PHR access check
     DataMapper.define(:phr_access) do |m|
       m.rpc "BPHR RECORD ACCESS"

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -953,11 +953,14 @@ module RpmsRpc
 
     # BYIMRT RSP — inbound immunization response lines
     # Format: VACCINE_CODE^VACCINE_DISPLAY^OCCURRENCE_DATE^NDC_CODE^STATUS
+    # :occurrence_date is left as a raw string; the API parses it with
+    # Date.parse (matches the gateway — values arrive ISO-formatted from
+    # the IIS bridge, not FileMan).
     DataMapper.define(:immunization_exchange_rsp) do |m|
       m.rpc "BYIMRT RSP"
       m.field 0, :vaccine_code
       m.field 1, :vaccine_display
-      m.field 2, :occurrence_date, :fileman_date
+      m.field 2, :occurrence_date
       m.field 3, :ndc_code
       m.field 4, :status
     end

--- a/test/rpms_rpc/api/immunization_exchange_test.rb
+++ b/test/rpms_rpc/api/immunization_exchange_test.rb
@@ -132,6 +132,39 @@ class ImmunizationExchangeTest < Minitest::Test
     assert_equal({ success: true, count: 3 }, RpmsRpc::ImmunizationExchange.process_responses)
   end
 
+  def test_process_responses_handles_success_without_count_in_message
+    RpmsRpc.reset!
+    RpmsRpc.mock! do |m|
+      m.seed(:immunization_exchange_process_result, "", {
+        status_code: 1,
+        message: "OK" # no digits — `.scan(/\d+/).first` returns nil
+      })
+    end
+
+    # Without nil-safety the call would raise NoMethodError on `nil.to_i`.
+    assert_equal({ success: true, count: 0 }, RpmsRpc::ImmunizationExchange.process_responses)
+  end
+
+  def test_for_patient_parses_iso_format_occurrence_date_from_iis_bridge
+    RpmsRpc.reset!
+    RpmsRpc.mock! do |m|
+      m.seed_keyed_collection(:immunization_exchange_rsp, DFN.to_s, [
+        {
+          vaccine_code: "207",
+          vaccine_display: "COVID-19 mRNA",
+          occurrence_date: "2026-05-01", # ISO format, not FileMan
+          ndc_code: "59267-1000-01",
+          status: "completed"
+        }
+      ])
+    end
+
+    immunizations = RpmsRpc::ImmunizationExchange.for_patient(DFN)
+    assert_equal 1, immunizations.length
+    assert_equal Date.new(2026, 5, 1), immunizations.first[:occurrence_date],
+      "ISO-format occurrence_date should parse via Date.parse, not FileMan"
+  end
+
   def test_check_status_returns_available
     assert_equal({ available: true }, RpmsRpc::ImmunizationExchange.check_status)
   end

--- a/test/rpms_rpc/api/immunization_exchange_test.rb
+++ b/test/rpms_rpc/api/immunization_exchange_test.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "date"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/immunization_exchange"
+
+class ImmunizationExchangeTest < Minitest::Test
+  DFN = 8791
+
+  def setup
+    RpmsRpc.mock! do |m|
+      m.seed(:immunization_exchange_vxu, DFN.to_s, {
+        status_code: 1,
+        message: "VXU accepted"
+      })
+
+      m.seed(:immunization_exchange_vxq, DFN.to_s, {
+        status_code: 1,
+        message: "VXQ submitted"
+      })
+
+      m.seed_keyed_collection(:immunization_exchange_rsp, DFN.to_s, [
+        {
+          vaccine_code: "207",
+          vaccine_display: "COVID-19 mRNA",
+          occurrence_date: Date.new(2026, 5, 1),
+          ndc_code: "59267-1000-01",
+          status: "completed"
+        },
+        {
+          vaccine_code: "140",
+          vaccine_display: "Influenza seasonal",
+          occurrence_date: Date.new(2025, 10, 15),
+          ndc_code: "49281-0425-10",
+          status: nil
+        }
+      ])
+
+      m.seed(:immunization_exchange_process_result, "", {
+        status_code: 1,
+        message: "3 responses processed"
+      })
+
+      m.seed(:immunization_exchange_status, "", {
+        status_code: 1,
+        message: "IIS available"
+      })
+    end
+  end
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  def test_send_immunizations_calls_vxu_for_patient
+    result = RpmsRpc::ImmunizationExchange.send_immunizations(DFN)
+
+    assert_equal({ success: true, message: "VXU accepted" }, result)
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BYIMRT VXU" }
+    refute_nil call
+    assert_equal [ DFN.to_s ], call[:params]
+  end
+
+  def test_submit_query_calls_vxq_for_patient
+    result = RpmsRpc::ImmunizationExchange.submit_query(DFN)
+
+    assert_equal({ success: true, message: "VXQ submitted" }, result)
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BYIMRT VXQ" }
+    refute_nil call
+    assert_equal [ DFN.to_s ], call[:params]
+  end
+
+  def test_write_paths_reject_blank_zero_and_negative_dfn
+    [ nil, "", 0, -1, "abc" ].each do |dfn|
+      assert_equal({ success: false, message: "Invalid patient DFN" },
+        RpmsRpc::ImmunizationExchange.send_immunizations(dfn))
+      assert_equal({ success: false, message: "Invalid patient DFN" },
+        RpmsRpc::ImmunizationExchange.submit_query(dfn))
+    end
+  end
+
+  def test_for_patient_returns_immunizations_from_rsp
+    immunizations = RpmsRpc::ImmunizationExchange.for_patient(DFN)
+
+    assert_equal 2, immunizations.length
+    covid = immunizations.first
+    assert_equal "207", covid[:vaccine_code]
+    assert_equal "COVID-19 mRNA", covid[:vaccine_display]
+    assert_equal Date.new(2026, 5, 1), covid[:occurrence_date]
+    assert_equal "59267-1000-01", covid[:ndc_code]
+    assert_equal "completed", covid[:status]
+  end
+
+  def test_for_patient_defaults_blank_status_to_completed
+    immunizations = RpmsRpc::ImmunizationExchange.for_patient(DFN)
+    flu = immunizations.find { |i| i[:vaccine_code] == "140" }
+
+    assert_equal "completed", flu[:status]
+  end
+
+  def test_for_patient_rejects_blank_zero_negative_and_unknown_dfn
+    assert_equal [], RpmsRpc::ImmunizationExchange.for_patient(nil)
+    assert_equal [], RpmsRpc::ImmunizationExchange.for_patient("")
+    assert_equal [], RpmsRpc::ImmunizationExchange.for_patient(0)
+    assert_equal [], RpmsRpc::ImmunizationExchange.for_patient(-1)
+    assert_equal [], RpmsRpc::ImmunizationExchange.for_patient("abc")
+    assert_equal [], RpmsRpc::ImmunizationExchange.for_patient(999_999)
+  end
+
+  def test_retrieve_response_without_dfn_processes_batch_rsp_lines
+    RpmsRpc.mock! do |m|
+      m.seed_keyed_collection(:immunization_exchange_rsp, "", [
+        {
+          vaccine_code: "207",
+          vaccine_display: "COVID-19 mRNA",
+          occurrence_date: Date.new(2026, 5, 1),
+          ndc_code: "59267-1000-01",
+          status: "completed"
+        }
+      ])
+    end
+
+    result = RpmsRpc::ImmunizationExchange.retrieve_response
+
+    assert_kind_of Array, result
+    assert_equal 1, result.length
+    assert_equal "COVID-19 mRNA", result.first[:vaccine_display]
+  end
+
+  def test_process_responses_extracts_processed_count
+    assert_equal({ success: true, count: 3 }, RpmsRpc::ImmunizationExchange.process_responses)
+  end
+
+  def test_check_status_returns_available
+    assert_equal({ available: true }, RpmsRpc::ImmunizationExchange.check_status)
+  end
+
+  def test_status_failures_include_message
+    RpmsRpc.mock! do |m|
+      m.seed(:immunization_exchange_status, "", { status_code: -1, message: "IIS unavailable" })
+    end
+
+    assert_equal({ available: false, error: "IIS unavailable" },
+      RpmsRpc::ImmunizationExchange.check_status)
+  end
+end

--- a/test/rpms_rpc/mappings_test.rb
+++ b/test/rpms_rpc/mappings_test.rb
@@ -382,6 +382,9 @@ class RpmsRpc::MappingsTest < Minitest::Test
       key_list key_grant key_revoke
       prescription_new erx_status prescription_cancel
       ccd_document ccd_referral immunization_text immunization_count
+      immunization_exchange_vxu immunization_exchange_vxq
+      immunization_exchange_rsp immunization_exchange_process_result
+      immunization_exchange_status
       phr_access phr_patient_direct phr_provider_direct phr_facility_direct
       vfc_eligibility vfc_eligibility_list vaccine_lot_list vaccine_lot_detail
     ]


### PR DESCRIPTION
## Summary
- Add BYIMRT immunization exchange mappings for VXU, VXQ, RSP, process result, and status calls.
- Add `RpmsRpc::ImmunizationExchange` API for send/query/retrieve/process/status workflows with gateway-compatible parsing and defaults.
- Cover patient validation, status handling, blank defaults, unknown IDs, and multi-line RSP responses.

## Test plan
- `bundle exec ruby -Ilib -Itest test/rpms_rpc/api/immunization_exchange_test.rb`
- `bundle exec ruby -Ilib -Itest test/rpms_rpc/mappings_test.rb`
- `bundle exec rake test`
- `bundle exec rubocop lib/rpms_rpc/mappings.rb lib/rpms_rpc/api/immunization_exchange.rb test/rpms_rpc/mappings_test.rb test/rpms_rpc/api/immunization_exchange_test.rb`

Made with [Cursor](https://cursor.com)