### PR TITLE
Authentication module: port from rpms_redux (Part of #80)

### DIFF
--- a/lib/rpms_rpc/api/authentication.rb
+++ b/lib/rpms_rpc/api/authentication.rb
@@ -69,7 +69,15 @@ module RpmsRpc
       ].join("^")
 
       parsed = DataMapper.cvc_verify.fetch_lines(cvc_param)
-      parsed&.dig(:result_code).to_i.zero? ? { success: true } : validation_error("Verify code change failed")
+      # `parsed&.dig(:result_code).to_i.zero?` was previously true for nil
+      # responses (`nil.to_i == 0`), masking timeouts / RPC drops as success.
+      # Require an explicit present `result_code` that equals `"0"`.
+      code = parsed && parsed[:result_code]
+      if code.to_s == "0"
+        { success: true }
+      else
+        validation_error("Verify code change failed")
+      end
     end
 
     def clear_cache!

--- a/lib/rpms_rpc/api/authentication.rb
+++ b/lib/rpms_rpc/api/authentication.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require_relative "../mappings"
+
+module RpmsRpc
+  # Symbolic API for VistA/RPMS authentication RPCs.
+  # Underlying RPCs: XUS SIGNON SETUP, XUS AV CODE, XUS CVC,
+  # XUS GET USER INFO, ORWU HASKEY, ORWU USERKEYS.
+  module Authentication
+    extend self
+
+    ERROR_MESSAGES = {
+      0 => nil,
+      1 => "Invalid access/verify code",
+      2 => "Logins inhibited",
+      3 => "Account locked",
+      4 => "Authentication failure",
+      5 => "Other error",
+      7 => "IP address locked (three-strike lockout)",
+      12 => "Verify code expired - must be changed"
+    }.freeze
+
+    USER_TYPES = {
+      3 => "provider",
+      4 => "nurse",
+      5 => "clerk"
+    }.freeze
+
+    def authenticate(access_code: nil, verify_code: nil)
+      return validation_error("Access code is required") if blank?(access_code&.to_s&.strip)
+      return validation_error("Verify code is required") if blank?(verify_code&.to_s&.strip)
+
+      signon_setup
+      av_code = "#{normalize_code(access_code)};#{normalize_code(verify_code)}"
+      parsed = DataMapper.av_code.fetch_lines(av_code)
+
+      parse_auth_response(parsed)
+    end
+
+    def user_info(duz)
+      return nil if invalid_id?(duz)
+
+      DataMapper.user_info.fetch_one(duz.to_s)
+    end
+
+    def has_security_key?(duz, key_name)
+      return false if invalid_id?(duz) || blank_after_strip?(key_name)
+
+      DataMapper.user_has_key.fetch_scalar(duz.to_s, key_name.to_s) == true
+    end
+
+    def user_security_keys(duz)
+      return [] if invalid_id?(duz)
+
+      Array(DataMapper.user_keys.fetch_many(duz.to_s)).filter_map { |row| presence(row[:key_name]) }
+    end
+
+    def change_verify_code(old_verify_code:, new_verify_code:, confirm_verify_code:, **_unused_keywords)
+      return validation_error("Old verify code is required") if blank?(old_verify_code&.to_s&.strip)
+      return validation_error("New verify code is required") if blank?(new_verify_code&.to_s&.strip)
+      if blank?(confirm_verify_code&.to_s&.strip)
+        return validation_error("Confirm verify code is required")
+      end
+
+      cvc_param = [
+        normalize_code(old_verify_code),
+        normalize_code(new_verify_code),
+        normalize_code(confirm_verify_code)
+      ].join("^")
+
+      parsed = DataMapper.cvc_verify.fetch_lines(cvc_param)
+      parsed&.dig(:result_code).to_i.zero? ? { success: true } : validation_error("Verify code change failed")
+    end
+
+    def clear_cache!
+      @signon_setup_cache = nil
+    end
+
+    private
+
+    def signon_setup
+      @signon_setup_cache ||= DataMapper.signon_setup.fetch_scalar
+    end
+
+    def parse_auth_response(parsed)
+      return validation_error("Invalid response") if parsed.nil? || parsed.empty?
+
+      duz = parsed[:duz].to_i
+      error_code = parsed[:error_code].to_i
+      verify_needs_change = parsed[:verify_needs_change].to_i == 1
+      message = parsed[:message].to_s
+
+      if duz.positive? && error_code.zero?
+        auth_success(duz, parsed[:user_class], message, verify_needs_change)
+      else
+        {
+          success: false,
+          duz: duz.positive? ? duz : nil,
+          error: ERROR_MESSAGES[error_code] || presence(message) || "Authentication failed",
+          error_code: error_code,
+          verify_needs_change: error_code == 12
+        }
+      end
+    end
+
+    def auth_success(duz, user_class, message, verify_needs_change)
+      result = {
+        success: true,
+        duz: duz,
+        provider_ien: duz,
+        message: message,
+        verify_needs_change: verify_needs_change,
+        user_type: USER_TYPES.fetch(user_class.to_i, "user")
+      }
+
+      info = user_info(duz)
+      result[:name] = info[:name] if info
+      result
+    end
+
+    def validation_error(message)
+      { success: false, error: message }
+    end
+
+    def normalize_code(code)
+      code.to_s.strip.upcase
+    end
+
+    def invalid_id?(value)
+      blank?(value) || value.to_i <= 0
+    end
+
+    def presence(value)
+      return nil if value.nil?
+
+      str = value.to_s
+      str.empty? ? nil : str
+    end
+
+    def blank?(value)
+      value.nil? || value.to_s.empty?
+    end
+
+    def blank_after_strip?(value)
+      value.nil? || value.to_s.strip.empty?
+    end
+  end
+end

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -486,15 +486,14 @@ module RpmsRpc
     # ========================================================================
 
     # XUS GET USER INFO — authenticated user info
-    # Format: DUZ^NAME^USERCL^CANSIGN^ISPROVIDER^ORDERROLE
+    # Format: DUZ^NAME^ACCESS_CODE^VERIFY_CODE_EXISTS^DIVISION
     DataMapper.define(:user_info) do |m|
       m.rpc "XUS GET USER INFO"
       m.field 0, :duz, :integer
       m.field 1, :name
-      m.field 2, :user_class
-      m.field 3, :can_sign,    :boolean
-      m.field 4, :is_provider, :boolean
-      m.field 5, :order_role
+      m.field 2, :access_code
+      m.field 3, :verify_code_exists, :boolean
+      m.field 4, :division
     end
 
     # ========================================================================
@@ -560,22 +559,24 @@ module RpmsRpc
 
     # XUS AV CODE — authentication result (line-based)
     # Line 0: DUZ (or 0 for failure)
-    # Line 1: 0
-    # Line 2: 0
-    # Line 3: greeting message
-    # Line 4: (blank)
-    # Line 5: number of tries remaining
+    # Line 1: error code
+    # Line 2: verify-code-change flag
+    # Line 3: message / greeting
+    # Line 4: unused
+    # Line 5: user class
     DataMapper.define(:av_code) do |m|
       m.rpc "XUS AV CODE"
       m.line_field 0, :duz, :integer
-      m.line_field 3, :greeting
-      m.line_field 5, :tries, :integer
+      m.line_field 1, :error_code, :integer
+      m.line_field 2, :verify_needs_change, :integer
+      m.line_field 3, :message
+      m.line_field 5, :user_class, :integer
     end
 
     # XUS CVC — CVC verification
     DataMapper.define(:cvc_verify) do |m|
       m.rpc "XUS CVC"
-      m.scalar :verified, :boolean
+      m.line_field 0, :result_code, :integer
     end
 
     # ORWU USERKEYS — user security keys (multi-line, one key per line)

--- a/lib/rpms_rpc/mock_client.rb
+++ b/lib/rpms_rpc/mock_client.rb
@@ -108,11 +108,25 @@ module RpmsRpc
       require_relative "security_keys"
       require_relative "user_roles"
 
+      user_class = UserRoles.class_for(role) || "0"
+
       # Credential response
-      seed_lines(:av_code, credentials, { duz: duz.to_i, greeting: "Welcome #{name}", tries: 3 })
+      seed_lines(:av_code, credentials.to_s.strip.upcase, {
+        duz: duz.to_i,
+        error_code: 0,
+        verify_needs_change: 0,
+        message: "Welcome #{name}",
+        user_class: user_class.to_i
+      })
 
       # User info
-      seed(:user_info, duz.to_s, UserRoles.mock_user_info(duz: duz, name: name, role: role))
+      seed(:user_info, duz.to_s, {
+        duz: duz.to_i,
+        name: name,
+        access_code: "",
+        verify_code_exists: true,
+        division: ""
+      })
 
       # Security keys (symbolic → RPMS strings)
       rpms_keys = security_keys.filter_map { |sym| SecurityKeys.rpms_name(sym) }

--- a/test/rpms_rpc/api/authentication_test.rb
+++ b/test/rpms_rpc/api/authentication_test.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/authentication"
+
+class AuthenticationTest < Minitest::Test
+  def setup
+    RpmsRpc::Authentication.clear_cache!
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:signon_setup, "", "OK")
+      m.seed_user("301",
+        credentials: "ACCESS123;VERIFY123",
+        name: "PROVIDER,TEST",
+        role: :provider,
+        security_keys: [ :cprs_gui_chart, :prc_supervisor ])
+      m.seed_lines(:av_code, "EXPIRED;VERIFY123", {
+        duz: 301,
+        error_code: 12,
+        verify_needs_change: 1,
+        message: "Verify code expired",
+        user_class: 3
+      })
+      m.seed_lines(:cvc_verify, "OLDVERIFY^NEWVERIFY^NEWVERIFY", { result_code: 0 })
+    end
+  end
+
+  def teardown
+    RpmsRpc::Authentication.clear_cache!
+    RpmsRpc.reset!
+  end
+
+  def test_authenticate_runs_signon_setup_then_av_code_and_user_info
+    result = RpmsRpc::Authentication.authenticate(access_code: " access123 ", verify_code: " verify123 ")
+
+    assert_equal true, result[:success]
+    assert_equal 301, result[:duz]
+    assert_equal 301, result[:provider_ien]
+    assert_equal "provider", result[:user_type]
+    assert_equal "PROVIDER,TEST", result[:name]
+
+    assert_equal [ "XUS SIGNON SETUP", "XUS AV CODE", "XUS GET USER INFO" ],
+      RpmsRpc.client.received_calls.first(3).map { |c| c[:rpc] }
+    assert_equal [ "ACCESS123;VERIFY123" ],
+      RpmsRpc.client.received_calls.find { |c| c[:rpc] == "XUS AV CODE" }[:params]
+  end
+
+  def test_authenticate_rejects_blank_access_or_verify_code
+    assert_equal({ success: false, error: "Access code is required" },
+      RpmsRpc::Authentication.authenticate(access_code: "", verify_code: "VERIFY123"))
+    assert_equal({ success: false, error: "Verify code is required" },
+      RpmsRpc::Authentication.authenticate(access_code: "ACCESS123", verify_code: " "))
+  end
+
+  def test_authenticate_returns_failure_for_unknown_credentials
+    result = RpmsRpc::Authentication.authenticate(access_code: "BAD", verify_code: "CODES")
+
+    assert_equal false, result[:success]
+    assert_equal "Invalid response", result[:error]
+  end
+
+  def test_authenticate_maps_verify_code_expired_response
+    result = RpmsRpc::Authentication.authenticate(access_code: "EXPIRED", verify_code: "VERIFY123")
+
+    assert_equal false, result[:success]
+    assert_equal 301, result[:duz]
+    assert_equal "Verify code expired - must be changed", result[:error]
+    assert_equal 12, result[:error_code]
+    assert_equal true, result[:verify_needs_change]
+  end
+
+  def test_user_info_returns_user_details
+    info = RpmsRpc::Authentication.user_info(301)
+
+    assert_equal 301, info[:duz]
+    assert_equal "PROVIDER,TEST", info[:name]
+    assert_nil info[:access_code]
+    assert_equal true, info[:verify_code_exists]
+  end
+
+  def test_user_info_rejects_blank_zero_negative_and_non_numeric_duz
+    assert_nil RpmsRpc::Authentication.user_info(nil)
+    assert_nil RpmsRpc::Authentication.user_info("")
+    assert_nil RpmsRpc::Authentication.user_info(0)
+    assert_nil RpmsRpc::Authentication.user_info(-1)
+    assert_nil RpmsRpc::Authentication.user_info("abc")
+  end
+
+  def test_user_info_returns_nil_for_unknown_duz
+    assert_nil RpmsRpc::Authentication.user_info(999_999)
+  end
+
+  def test_user_security_keys_returns_seeded_keys
+    keys = RpmsRpc::Authentication.user_security_keys(301)
+
+    assert_equal [ "OR CPRS GUI CHART", "PRCFA SUPERVISOR" ], keys
+  end
+
+  def test_user_security_keys_rejects_invalid_duz
+    assert_equal [], RpmsRpc::Authentication.user_security_keys(nil)
+    assert_equal [], RpmsRpc::Authentication.user_security_keys(0)
+    assert_equal [], RpmsRpc::Authentication.user_security_keys(-1)
+  end
+
+  def test_has_security_key_uses_duz_and_key_name
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:user_has_key, "301", true)
+    end
+
+    assert_equal true, RpmsRpc::Authentication.has_security_key?(301, "OR CPRS GUI CHART")
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWU HASKEY" }
+    assert_equal [ "301", "OR CPRS GUI CHART" ], call[:params]
+  end
+
+  def test_has_security_key_rejects_invalid_arguments
+    assert_equal false, RpmsRpc::Authentication.has_security_key?(nil, "OR CPRS GUI CHART")
+    assert_equal false, RpmsRpc::Authentication.has_security_key?(0, "OR CPRS GUI CHART")
+    assert_equal false, RpmsRpc::Authentication.has_security_key?(301, "")
+  end
+
+  def test_change_verify_code_sends_caret_delimited_uppercase_payload
+    result = RpmsRpc::Authentication.change_verify_code(
+      old_verify_code: " oldverify ",
+      new_verify_code: " newverify ",
+      confirm_verify_code: " newverify "
+    )
+
+    assert_equal({ success: true }, result)
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "XUS CVC" }
+    assert_equal [ "OLDVERIFY^NEWVERIFY^NEWVERIFY" ], call[:params]
+  end
+
+  def test_change_verify_code_rejects_blank_fields
+    result = RpmsRpc::Authentication.change_verify_code(
+      old_verify_code: "OLDVERIFY",
+      new_verify_code: "",
+      confirm_verify_code: "NEWVERIFY"
+    )
+
+    assert_equal false, result[:success]
+    assert_equal "New verify code is required", result[:error]
+  end
+end

--- a/test/rpms_rpc/api/authentication_test.rb
+++ b/test/rpms_rpc/api/authentication_test.rb
@@ -140,4 +140,18 @@ class AuthenticationTest < Minitest::Test
     assert_equal false, result[:success]
     assert_equal "New verify code is required", result[:error]
   end
+
+  def test_change_verify_code_treats_unseeded_response_as_failure
+    # Unseeded payload → MockClient returns "" → fetch_lines returns nil.
+    # Without an explicit result-code check, the previous code would treat
+    # this as success because `nil.to_i == 0`.
+    result = RpmsRpc::Authentication.change_verify_code(
+      old_verify_code: "WRONGOLD",
+      new_verify_code: "NEWVERIFY",
+      confirm_verify_code: "NEWVERIFY"
+    )
+
+    assert_equal false, result[:success]
+    assert_equal "Verify code change failed", result[:error]
+  end
 end

--- a/test/rpms_rpc/mappings_test.rb
+++ b/test/rpms_rpc/mappings_test.rb
@@ -237,10 +237,12 @@ class RpmsRpc::MappingsTest < Minitest::Test
   # -- XUS GET USER INFO -----------------------------------------------------
 
   def test_user_info
-    result = RpmsRpc::DataMapper[:user_info].parse_one("101^MARTINEZ,SARAH^PROVIDER^1^1^PHYSICIAN")
+    result = RpmsRpc::DataMapper[:user_info].parse_one("101^PROVIDER,TEST^ACCESS123^1^PRIMARY")
     assert_equal 101, result[:duz]
-    assert_equal true, result[:can_sign]
-    assert_equal true, result[:is_provider]
+    assert_equal "PROVIDER,TEST", result[:name]
+    assert_equal "ACCESS123", result[:access_code]
+    assert_equal true, result[:verify_code_exists]
+    assert_equal "PRIMARY", result[:division]
   end
 
   # -- Scalar RPCs -----------------------------------------------------------
@@ -268,15 +270,24 @@ class RpmsRpc::MappingsTest < Minitest::Test
     m = RpmsRpc::DataMapper[:av_code]
     result = m.parse_lines([ "101", "0", "0", "Welcome to RPMS", "", "3" ])
     assert_equal 101, result[:duz]
-    assert_equal "Welcome to RPMS", result[:greeting]
-    assert_equal 3, result[:tries]
+    assert_equal 0, result[:error_code]
+    assert_equal 0, result[:verify_needs_change]
+    assert_equal "Welcome to RPMS", result[:message]
+    assert_equal 3, result[:user_class]
   end
 
   def test_av_code_failure
     m = RpmsRpc::DataMapper[:av_code]
-    result = m.parse_lines([ "0", "0", "0", "Not a valid ACCESS CODE/VERIFY CODE pair.", "", "2" ])
+    result = m.parse_lines([ "0", "1", "0", "Not a valid ACCESS CODE/VERIFY CODE pair.", "", "" ])
     assert_equal 0, result[:duz]
-    assert_equal 2, result[:tries]
+    assert_equal 1, result[:error_code]
+    assert_equal "Not a valid ACCESS CODE/VERIFY CODE pair.", result[:message]
+  end
+
+  def test_cvc_verify_line_based
+    m = RpmsRpc::DataMapper[:cvc_verify]
+    result = m.parse_lines([ "0" ])
+    assert_equal 0, result[:result_code]
   end
 
   # -- Text blob RPCs --------------------------------------------------------


### PR DESCRIPTION
## Summary
- Ported the authentication API for sign-on setup, access/verify authentication, user info, security keys, and verify-code changes.
- Corrected XUS authentication mappings to match the rpms_redux gateway response positions.
- Added focused tests using the mock client's `seed_user` helper.

## Test plan
- `bundle exec ruby -Ilib -Itest test/rpms_rpc/api/authentication_test.rb`
- `bundle exec ruby -Ilib -Itest test/rpms_rpc/mappings_test.rb`
- `bundle exec rake test`
- `bundle exec rubocop lib/rpms_rpc/api/authentication.rb lib/rpms_rpc/mappings.rb lib/rpms_rpc/mock_client.rb test/rpms_rpc/api/authentication_test.rb test/rpms_rpc/mappings_test.rb`

Made with [Cursor](https://cursor.com)