### PR TITLE
Communication module: port from rpms_redux (Part of #80)

### DIFF
--- a/lib/rpms_rpc/api/communication.rb
+++ b/lib/rpms_rpc/api/communication.rb
@@ -80,6 +80,7 @@ module RpmsRpc
     def for_user(duz, basket: "IN")
       return [] if invalid_id?(duz)
 
+      basket = "IN" if blank?(basket)
       key = "#{duz}^#{basket}"
       Array(DataMapper.mailman_inbox.fetch_many(key)).map { |message| apply_message_defaults(message) }
     end
@@ -157,7 +158,11 @@ module RpmsRpc
     def validate_send_params!(params)
       raise ArgumentError, "Subject required" if blank?(params[:subject])
       raise ArgumentError, "Body required" if blank?(params[:body])
-      raise ArgumentError, "Recipients required" if Array(params[:recipients]).empty?
+
+      recipients = Array(params[:recipients]).reject { |r| blank?(r) }.map { |r| r.to_s.strip }
+      raise ArgumentError, "Recipients required" if recipients.empty?
+
+      params[:recipients] = recipients
     end
 
     def escape_multiline(value)

--- a/lib/rpms_rpc/api/communication.rb
+++ b/lib/rpms_rpc/api/communication.rb
@@ -169,7 +169,7 @@ module RpmsRpc
     end
 
     def blank?(value)
-      value.nil? || value.to_s.empty?
+      value.nil? || value.to_s.strip.empty?
     end
   end
 end

--- a/lib/rpms_rpc/api/communication.rb
+++ b/lib/rpms_rpc/api/communication.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+module RpmsRpc
+  # Symbolic API for FHIR Communication-style MailMan messages and XQAL alerts.
+  # Underlying RPCs (XM/XQAL family): message reads, message writes, inbox,
+  # threads, alerts, and alert write acknowledgements.
+  module Communication
+    extend self
+
+    DEFAULT_MESSAGE_STATUS = "NEW"
+    DEFAULT_PRIORITY = "routine"
+    DEFAULT_ALERT_STATUS = "NEW"
+
+    def find(ien)
+      return nil if invalid_id?(ien)
+
+      message = DataMapper.mailman_message.fetch_one(ien.to_s)
+      return nil if message.nil?
+
+      apply_message_defaults(message)
+    end
+
+    def for_patient(dfn)
+      return [] if invalid_id?(dfn)
+
+      Array(DataMapper.mailman_messages_for_patient.fetch_many(dfn.to_s)).map do |message|
+        apply_message_defaults(message)
+      end
+    end
+
+    def search(criteria = {})
+      messages = criteria[:patient_dfn] ? for_patient(criteria[:patient_dfn]) : []
+
+      %i[status priority category].each do |field|
+        messages = messages.select { |m| m[field] == criteria[field] } if criteria[field]
+      end
+
+      messages
+    end
+
+    def send_message(params = {})
+      validate_send_params!(params)
+
+      parsed = DataMapper.mailman_send.fetch_one(build_send_payload(params))
+
+      {
+        success: parsed && parsed[:success] == true,
+        message_id: parsed&.fetch(:message_ien, nil),
+        error: parsed&.fetch(:error, nil)
+      }
+    end
+
+    def reply_to_message(parent_ien, params = {})
+      return { success: false, error: "Parent message IEN required" } if invalid_id?(parent_ien)
+      return { success: false, error: "Reply body required" } if blank?(params[:body])
+
+      parent = find(parent_ien)
+      return { success: false, error: "Parent message not found" } unless parent
+
+      parsed = DataMapper.mailman_reply.fetch_one(build_reply_payload(parent_ien, params))
+
+      {
+        success: parsed && parsed[:success] == true,
+        message_id: parsed&.fetch(:message_ien, nil),
+        thread_id: parsed&.fetch(:thread_id, nil) || parent[:thread_id] || parent_ien.to_s,
+        parent_id: parent_ien.to_i,
+        error: parsed&.fetch(:error, nil)
+      }
+    end
+
+    def get_thread(thread_id)
+      return [] if blank?(thread_id)
+
+      messages = Array(DataMapper.mailman_thread.fetch_many(thread_id.to_s)).map do |message|
+        apply_message_defaults(message)
+      end
+      messages.sort_by { |message| message[:sent_at] || Time.at(0) }
+    end
+
+    def for_user(duz, basket: "IN")
+      return [] if invalid_id?(duz)
+
+      key = "#{duz}^#{basket}"
+      Array(DataMapper.mailman_inbox.fetch_many(key)).map { |message| apply_message_defaults(message) }
+    end
+
+    def get_alerts(duz)
+      return [] if invalid_id?(duz)
+
+      Array(DataMapper.xqal_alert.fetch_many(duz.to_s)).map { |alert| apply_alert_defaults(alert) }
+    end
+
+    def alert_count(duz)
+      get_alerts(duz).size
+    end
+
+    def mark_alert_read(alert_ien, duz)
+      return { success: false, error: "Alert IEN required" } if invalid_id?(alert_ien)
+      return { success: false, error: "User DUZ required" } if invalid_id?(duz)
+
+      parsed = DataMapper.xqal_mark_read.fetch_one("#{alert_ien}^#{duz}")
+
+      {
+        success: parsed && parsed[:success] == true,
+        error: parsed&.fetch(:error, nil)
+      }
+    end
+
+    def forward_alert(alert_ien, from_duz:, to_duz:, comment: nil)
+      return { success: false, error: "Alert IEN required" } if invalid_id?(alert_ien)
+      return { success: false, error: "From DUZ required" } if invalid_id?(from_duz)
+      return { success: false, error: "To DUZ required" } if invalid_id?(to_duz)
+
+      parsed = DataMapper.xqal_forward.fetch_one(
+        [ alert_ien, from_duz, to_duz, escape_multiline(comment) ].join("^")
+      )
+
+      {
+        success: parsed && parsed[:success] == true,
+        new_alert_ien: parsed&.fetch(:new_alert_ien, nil),
+        error: parsed&.fetch(:error, nil)
+      }
+    end
+
+    private
+
+    def build_send_payload(params)
+      [
+        params[:subject],
+        escape_multiline(params[:body]),
+        Array(params[:recipients]).join(","),
+        params[:patient_dfn],
+        params[:priority] || DEFAULT_PRIORITY,
+        params[:category]
+      ].join("^")
+    end
+
+    def build_reply_payload(parent_ien, params)
+      [
+        parent_ien,
+        escape_multiline(params[:body]),
+        params[:reply_all] ? "1" : "0"
+      ].join("^")
+    end
+
+    def apply_message_defaults(message)
+      message.merge(
+        status: blank?(message[:status]) ? DEFAULT_MESSAGE_STATUS : message[:status],
+        priority: blank?(message[:priority]) ? DEFAULT_PRIORITY : message[:priority]
+      )
+    end
+
+    def apply_alert_defaults(alert)
+      alert.merge(status: blank?(alert[:status]) ? DEFAULT_ALERT_STATUS : alert[:status])
+    end
+
+    def validate_send_params!(params)
+      raise ArgumentError, "Subject required" if blank?(params[:subject])
+      raise ArgumentError, "Body required" if blank?(params[:body])
+      raise ArgumentError, "Recipients required" if Array(params[:recipients]).empty?
+    end
+
+    def escape_multiline(value)
+      value.to_s.gsub(/\r?\n/, "\\n")
+    end
+
+    def invalid_id?(value)
+      blank?(value) || value.to_i <= 0
+    end
+
+    def blank?(value)
+      value.nil? || value.to_s.empty?
+    end
+  end
+end

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -497,6 +497,141 @@ module RpmsRpc
     end
 
     # ========================================================================
+    # COMMUNICATION (MailMan XM*, XQAL*)
+    # ========================================================================
+
+    # XM GET MESSAGE / XM GET MESSAGES — MailMan message.
+    # Format: IEN^PATIENT_DFN^SENDER_DUZ^SENDER_NAME^RECIPIENT_DUZ^RECIPIENT_NAME^
+    #         SUBJECT^BODY^SENT_AT^READ_AT^STATUS^PRIORITY^CATEGORY^PARENT_ID^THREAD_ID^BASKET
+    DataMapper.define(:mailman_message) do |m|
+      m.rpc "XM GET MESSAGE"
+      m.field 0,  :ien, :integer
+      m.field 1,  :patient_dfn, :integer
+      m.field 2,  :sender_duz, :integer
+      m.field 3,  :sender_name
+      m.field 4,  :recipient_duz, :integer
+      m.field 5,  :recipient_name
+      m.field 6,  :subject
+      m.field 7,  :body
+      m.field 8,  :sent_at, :fileman_datetime
+      m.field 9,  :read_at, :fileman_datetime
+      m.field 10, :status
+      m.field 11, :priority
+      m.field 12, :category
+      m.field 13, :parent_id, :integer
+      m.field 14, :thread_id
+      m.field 15, :basket
+    end
+
+    # XM GET MESSAGES — patient-scoped MailMan messages (same wire shape as GET).
+    DataMapper.define(:mailman_messages_for_patient) do |m|
+      m.rpc "XM GET MESSAGES"
+      m.field 0,  :ien, :integer
+      m.field 1,  :patient_dfn, :integer
+      m.field 2,  :sender_duz, :integer
+      m.field 3,  :sender_name
+      m.field 4,  :recipient_duz, :integer
+      m.field 5,  :recipient_name
+      m.field 6,  :subject
+      m.field 7,  :body
+      m.field 8,  :sent_at, :fileman_datetime
+      m.field 9,  :read_at, :fileman_datetime
+      m.field 10, :status
+      m.field 11, :priority
+      m.field 12, :category
+      m.field 13, :parent_id, :integer
+      m.field 14, :thread_id
+      m.field 15, :basket
+    end
+
+    # XM SEND MESSAGE — write result: SUCCESS^MESSAGE_IEN^ERROR
+    DataMapper.define(:mailman_send) do |m|
+      m.rpc "XM SEND MESSAGE"
+      m.field 0, :success, :boolean
+      m.field 1, :message_ien, :integer
+      m.field 2, :error
+    end
+
+    # XM REPLY MESSAGE — write result: SUCCESS^MESSAGE_IEN^THREAD_ID^ERROR
+    DataMapper.define(:mailman_reply) do |m|
+      m.rpc "XM REPLY MESSAGE"
+      m.field 0, :success, :boolean
+      m.field 1, :message_ien, :integer
+      m.field 2, :thread_id
+      m.field 3, :error
+    end
+
+    # XM GET THREAD — MailMan thread messages (same wire shape as GET).
+    DataMapper.define(:mailman_thread) do |m|
+      m.rpc "XM GET THREAD"
+      m.field 0,  :ien, :integer
+      m.field 1,  :patient_dfn, :integer
+      m.field 2,  :sender_duz, :integer
+      m.field 3,  :sender_name
+      m.field 4,  :recipient_duz, :integer
+      m.field 5,  :recipient_name
+      m.field 6,  :subject
+      m.field 7,  :body
+      m.field 8,  :sent_at, :fileman_datetime
+      m.field 9,  :read_at, :fileman_datetime
+      m.field 10, :status
+      m.field 11, :priority
+      m.field 12, :category
+      m.field 13, :parent_id, :integer
+      m.field 14, :thread_id
+      m.field 15, :basket
+    end
+
+    # XM GET INBOX — MailMan inbox messages (same wire shape as GET).
+    DataMapper.define(:mailman_inbox) do |m|
+      m.rpc "XM GET INBOX"
+      m.field 0,  :ien, :integer
+      m.field 1,  :patient_dfn, :integer
+      m.field 2,  :sender_duz, :integer
+      m.field 3,  :sender_name
+      m.field 4,  :recipient_duz, :integer
+      m.field 5,  :recipient_name
+      m.field 6,  :subject
+      m.field 7,  :body
+      m.field 8,  :sent_at, :fileman_datetime
+      m.field 9,  :read_at, :fileman_datetime
+      m.field 10, :status
+      m.field 11, :priority
+      m.field 12, :category
+      m.field 13, :parent_id, :integer
+      m.field 14, :thread_id
+      m.field 15, :basket
+    end
+
+    # XQAL NEW ALERTS — pending alert list.
+    # Format: ALERT_IEN^USER_DUZ^MESSAGE^CREATED_AT^PRIORITY^CATEGORY^STATUS
+    DataMapper.define(:xqal_alert) do |m|
+      m.rpc "XQAL NEW ALERTS"
+      m.field 0, :alert_ien, :integer
+      m.field 1, :user_duz, :integer
+      m.field 2, :message
+      m.field 3, :created_at, :fileman_datetime
+      m.field 4, :priority
+      m.field 5, :category
+      m.field 6, :status
+    end
+
+    # XQAL MARK READ — write result: SUCCESS^ERROR
+    DataMapper.define(:xqal_mark_read) do |m|
+      m.rpc "XQAL MARK READ"
+      m.field 0, :success, :boolean
+      m.field 1, :error
+    end
+
+    # XQAL FORWARD — write result: SUCCESS^NEW_ALERT_IEN^ERROR
+    DataMapper.define(:xqal_forward) do |m|
+      m.rpc "XQAL FORWARD"
+      m.field 0, :success, :boolean
+      m.field 1, :new_alert_ien, :integer
+      m.field 2, :error
+    end
+
+    # ========================================================================
     # HEALTH SUMMARY & REMINDERS (ORWRP*, GMTS*, ORQQPX*)
     # ========================================================================
 

--- a/test/rpms_rpc/api/communication_test.rb
+++ b/test/rpms_rpc/api/communication_test.rb
@@ -132,6 +132,12 @@ class CommunicationTest < Minitest::Test
     end
   end
 
+  def test_send_message_rejects_recipients_that_are_all_blank
+    assert_raises(ArgumentError) do
+      RpmsRpc::Communication.send_message(subject: "Subject", body: "Body", recipients: [ "", "  ", nil ])
+    end
+  end
+
   def test_reply_to_message_uses_parent_thread_context
     result = RpmsRpc::Communication.reply_to_message(2001, body: "Thanks\nAcknowledged", reply_all: true)
 
@@ -161,6 +167,18 @@ class CommunicationTest < Minitest::Test
     assert_equal 2004, messages.first[:ien]
     call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "XM GET INBOX" }
     assert_equal [ "#{DUZ}^IN" ], call[:params]
+  end
+
+  def test_for_user_coerces_blank_basket_to_default_in
+    RpmsRpc::Communication.for_user(DUZ, basket: "")
+    RpmsRpc::Communication.for_user(DUZ, basket: nil)
+    RpmsRpc::Communication.for_user(DUZ, basket: "   ")
+
+    calls = RpmsRpc.client.received_calls.select { |c| c[:rpc] == "XM GET INBOX" }
+    calls.each do |c|
+      assert_equal "#{DUZ}^IN", c[:params].first,
+        "blank basket should default to IN, not produce '#{DUZ}^' or '#{DUZ}^   '"
+    end
   end
 
   def test_get_alerts_and_count_default_blank_status

--- a/test/rpms_rpc/api/communication_test.rb
+++ b/test/rpms_rpc/api/communication_test.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "date"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/communication"
+
+class CommunicationTest < Minitest::Test
+  DFN = 8791
+  DUZ = 301
+
+  def setup
+    RpmsRpc.mock! do |m|
+      m.seed(:mailman_message, "2001", message_attrs(ien: 2001, status: "READ"))
+      m.seed_keyed_collection(:mailman_messages_for_patient, DFN.to_s, [
+        message_attrs(ien: 2001, status: "READ"),
+        message_attrs(ien: 2002, subject: "Follow-up", status: "", priority: "")
+      ])
+      m.seed_keyed_collection(:mailman_thread, "T2001", [
+        message_attrs(ien: 2001, thread_id: "T2001", sent_at: DateTime.new(2026, 1, 2, 10, 0, 0)),
+        message_attrs(ien: 2003, subject: "RE: Care update", thread_id: "T2001",
+          parent_id: 2001, sent_at: DateTime.new(2026, 1, 2, 11, 0, 0))
+      ])
+      m.seed_keyed_collection(:mailman_inbox, "#{DUZ}^IN", [
+        message_attrs(ien: 2004, recipient_duz: DUZ, basket: "IN")
+      ])
+      m.seed_keyed_collection(:xqal_alert, DUZ.to_s, [
+        {
+          alert_ien: 501,
+          user_duz: DUZ,
+          message: "Review critical lab",
+          created_at: DateTime.new(2026, 1, 3, 8, 30, 0),
+          priority: "urgent",
+          category: "alert",
+          status: ""
+        }
+      ])
+      m.seed(:mailman_send, "Care update^Please review\\nLine two^301,302^8791^routine^notification", {
+        success: true,
+        message_ien: 3001,
+        error: nil
+      })
+      m.seed(:mailman_reply, "2001^Thanks\\nAcknowledged^1", {
+        success: true,
+        message_ien: 3002,
+        thread_id: "T2001",
+        error: nil
+      })
+      m.seed(:xqal_mark_read, "501^301", { success: true, error: nil })
+      m.seed(:xqal_forward, "501^301^302^Please review", {
+        success: true,
+        new_alert_ien: 777,
+        error: nil
+      })
+    end
+  end
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  def test_find_returns_mailman_message
+    message = RpmsRpc::Communication.find(2001)
+
+    refute_nil message
+    assert_equal 2001, message[:ien]
+    assert_equal DFN, message[:patient_dfn]
+    assert_equal "Care update", message[:subject]
+    assert_equal "READ", message[:status]
+    assert_equal "routine", message[:priority]
+  end
+
+  def test_find_returns_nil_for_invalid_or_unknown_ien
+    assert_nil RpmsRpc::Communication.find(nil)
+    assert_nil RpmsRpc::Communication.find("")
+    assert_nil RpmsRpc::Communication.find(0)
+    assert_nil RpmsRpc::Communication.find(-1)
+    assert_nil RpmsRpc::Communication.find("abc")
+    assert_nil RpmsRpc::Communication.find(999_999)
+  end
+
+  def test_for_patient_returns_messages_and_defaults_blank_fields
+    messages = RpmsRpc::Communication.for_patient(DFN)
+
+    assert_equal 2, messages.length
+    follow_up = messages.find { |m| m[:subject] == "Follow-up" }
+    assert_equal "NEW", follow_up[:status]
+    assert_equal "routine", follow_up[:priority]
+  end
+
+  def test_for_patient_rejects_blank_zero_negative_and_non_numeric_dfn
+    assert_equal [], RpmsRpc::Communication.for_patient(nil)
+    assert_equal [], RpmsRpc::Communication.for_patient("")
+    assert_equal [], RpmsRpc::Communication.for_patient(0)
+    assert_equal [], RpmsRpc::Communication.for_patient(-1)
+    assert_equal [], RpmsRpc::Communication.for_patient("abc")
+  end
+
+  def test_search_filters_patient_messages
+    results = RpmsRpc::Communication.search(patient_dfn: DFN, status: "READ")
+
+    assert_equal 1, results.length
+    assert_equal 2001, results.first[:ien]
+  end
+
+  def test_send_message_sends_write_payload_and_maps_result
+    result = RpmsRpc::Communication.send_message(
+      subject: "Care update",
+      body: "Please review\nLine two",
+      recipients: [ "301", "302" ],
+      patient_dfn: DFN,
+      category: "notification"
+    )
+
+    assert_equal({ success: true, message_id: 3001, error: nil }, result)
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "XM SEND MESSAGE" }
+    assert_equal [ "Care update^Please review\\nLine two^301,302^8791^routine^notification" ], call[:params]
+  end
+
+  def test_send_message_validates_required_fields
+    assert_raises(ArgumentError) { RpmsRpc::Communication.send_message(body: "Body", recipients: [ "301" ]) }
+    assert_raises(ArgumentError) { RpmsRpc::Communication.send_message(subject: "Subject", recipients: [ "301" ]) }
+    assert_raises(ArgumentError) { RpmsRpc::Communication.send_message(subject: "Subject", body: "Body") }
+  end
+
+  def test_reply_to_message_uses_parent_thread_context
+    result = RpmsRpc::Communication.reply_to_message(2001, body: "Thanks\nAcknowledged", reply_all: true)
+
+    assert_equal true, result[:success]
+    assert_equal 3002, result[:message_id]
+    assert_equal "T2001", result[:thread_id]
+    assert_equal 2001, result[:parent_id]
+  end
+
+  def test_reply_to_message_rejects_invalid_parent_or_body
+    assert_equal false, RpmsRpc::Communication.reply_to_message(nil, body: "Thanks")[:success]
+    assert_equal false, RpmsRpc::Communication.reply_to_message(2001, body: "")[:success]
+    assert_equal false, RpmsRpc::Communication.reply_to_message(999_999, body: "Thanks")[:success]
+  end
+
+  def test_get_thread_returns_messages_in_chronological_order
+    messages = RpmsRpc::Communication.get_thread("T2001")
+
+    assert_equal [ 2001, 2003 ], messages.map { |m| m[:ien] }
+  end
+
+  def test_for_user_uses_duz_and_basket_composite_key
+    messages = RpmsRpc::Communication.for_user(DUZ)
+
+    assert_equal 1, messages.length
+    assert_equal 2004, messages.first[:ien]
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "XM GET INBOX" }
+    assert_equal [ "#{DUZ}^IN" ], call[:params]
+  end
+
+  def test_get_alerts_and_count_default_blank_status
+    alerts = RpmsRpc::Communication.get_alerts(DUZ)
+
+    assert_equal 1, alerts.length
+    assert_equal 501, alerts.first[:alert_ien]
+    assert_equal "NEW", alerts.first[:status]
+    assert_equal 1, RpmsRpc::Communication.alert_count(DUZ)
+  end
+
+  def test_mark_alert_read_and_forward_alert_map_results
+    assert_equal({ success: true, error: nil }, RpmsRpc::Communication.mark_alert_read(501, DUZ))
+    assert_equal({ success: true, new_alert_ien: 777, error: nil },
+      RpmsRpc::Communication.forward_alert(501, from_duz: DUZ, to_duz: 302, comment: "Please review"))
+  end
+
+  def test_alert_write_paths_reject_invalid_ids
+    assert_equal false, RpmsRpc::Communication.mark_alert_read(0, DUZ)[:success]
+    assert_equal false, RpmsRpc::Communication.mark_alert_read(501, 0)[:success]
+    assert_equal false, RpmsRpc::Communication.forward_alert(0, from_duz: DUZ, to_duz: 302)[:success]
+    assert_equal false, RpmsRpc::Communication.forward_alert(501, from_duz: 0, to_duz: 302)[:success]
+    assert_equal false, RpmsRpc::Communication.forward_alert(501, from_duz: DUZ, to_duz: 0)[:success]
+  end
+
+  private
+
+  def message_attrs(overrides = {})
+    {
+      ien: 2001,
+      patient_dfn: DFN,
+      sender_duz: 201,
+      sender_name: "PROVIDER,SENDER",
+      recipient_duz: DUZ,
+      recipient_name: "PROVIDER,RECIPIENT",
+      subject: "Care update",
+      body: "Please review\nLine two",
+      sent_at: DateTime.new(2026, 1, 2, 10, 0, 0),
+      read_at: nil,
+      status: "NEW",
+      priority: "routine",
+      category: "notification",
+      parent_id: nil,
+      thread_id: "T2001",
+      basket: "IN"
+    }.merge(overrides)
+  end
+end

--- a/test/rpms_rpc/api/communication_test.rb
+++ b/test/rpms_rpc/api/communication_test.rb
@@ -123,6 +123,15 @@ class CommunicationTest < Minitest::Test
     assert_raises(ArgumentError) { RpmsRpc::Communication.send_message(subject: "Subject", body: "Body") }
   end
 
+  def test_send_message_rejects_whitespace_only_subject_or_body
+    assert_raises(ArgumentError) do
+      RpmsRpc::Communication.send_message(subject: "   ", body: "Body", recipients: [ "301" ])
+    end
+    assert_raises(ArgumentError) do
+      RpmsRpc::Communication.send_message(subject: "Subject", body: "   ", recipients: [ "301" ])
+    end
+  end
+
   def test_reply_to_message_uses_parent_thread_context
     result = RpmsRpc::Communication.reply_to_message(2001, body: "Thanks\nAcknowledged", reply_all: true)
 
@@ -135,6 +144,7 @@ class CommunicationTest < Minitest::Test
   def test_reply_to_message_rejects_invalid_parent_or_body
     assert_equal false, RpmsRpc::Communication.reply_to_message(nil, body: "Thanks")[:success]
     assert_equal false, RpmsRpc::Communication.reply_to_message(2001, body: "")[:success]
+    assert_equal false, RpmsRpc::Communication.reply_to_message(2001, body: "   ")[:success]
     assert_equal false, RpmsRpc::Communication.reply_to_message(999_999, body: "Thanks")[:success]
   end
 

--- a/test/rpms_rpc/mappings_test.rb
+++ b/test/rpms_rpc/mappings_test.rb
@@ -381,7 +381,9 @@ class RpmsRpc::MappingsTest < Minitest::Test
       medication_list care_plan_list care_team_list goal_list
       procedure_list device_list lab_result_list radiology_list
       hospital_location institution referral_search site_params
-      user_info report_types reminders_list
+      user_info mailman_message mailman_messages_for_patient mailman_send
+      mailman_reply mailman_thread mailman_inbox xqal_alert xqal_mark_read
+      xqal_forward report_types reminders_list
       reminder_detail patient_deceased patient_sensitive user_has_key
       signon_setup av_code cvc_verify user_keys
       report_text report_type_components health_summary_report


### PR DESCRIPTION
## Summary
- Add Communication API for MailMan messages and XQAL alerts, including read, search, inbox/thread, send, reply, mark-read, and forward paths.
- Register XM/XQAL DataMapper mappings for message, alert, and write-result response shapes.
- Add focused API coverage for validation, defaults, unknown IDs, multi-line payloads, and write RPC calls.

## Test plan
- bundle exec ruby -Ilib -Itest test/rpms_rpc/api/communication_test.rb
- bundle exec rake test
- bundle exec rubocop lib/rpms_rpc/api/communication.rb lib/rpms_rpc/mappings.rb test/rpms_rpc/api/communication_test.rb test/rpms_rpc/mappings_test.rb

Made with [Cursor](https://cursor.com)