### PR TITLE
Vendor module: port from rpms_redux (Part of #80)

### DIFF
--- a/lib/rpms_rpc/api/vendor.rb
+++ b/lib/rpms_rpc/api/vendor.rb
@@ -163,12 +163,15 @@ module RpmsRpc
       row[:service].to_s.downcase.include?(needle) || row[:specialty].to_s.downcase.include?(needle)
     end
 
+    # Vendor and contract IDs are opaque tokens (e.g. "VENDOR-001",
+    # "CONTRACT-001"), not numeric IENs — so the `to_i <= 0` guard used
+    # elsewhere would reject legitimate identifiers. Just check for blank.
     def invalid_ien?(ien)
-      blank?(ien) || ien.to_i <= 0
+      blank?(ien)
     end
 
     def blank?(val)
-      val.nil? || val.to_s.empty?
+      val.nil? || val.to_s.strip.empty?
     end
   end
 end

--- a/lib/rpms_rpc/api/vendor.rb
+++ b/lib/rpms_rpc/api/vendor.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require "bigdecimal"
+require "date"
+
+module RpmsRpc
+  # Symbolic API for CHS vendor/provider lookup.
+  # Underlying RPCs (BMCRPC family): SRCHVEND, GTVEND, GTPREFVEND,
+  # GTCONTRACT, GTRATES.
+  module Vendor
+    extend self
+
+    VENDOR_TYPES = %w[FACILITY INDIVIDUAL GROUP].freeze
+    DETAIL_RAW_KEYS = %i[
+      specialties_raw
+      phone
+      fax
+      email
+      contact_name
+      street
+      city
+      state
+      zip
+      contracted_services_raw
+    ].freeze
+
+    def search(name: nil, specialty: nil, type: nil)
+      rows = DataMapper.vendor_list.fetch_many(name.to_s, specialty.to_s, type.to_s)
+      Array(rows).select do |row|
+        matches_name?(row, name) && matches_specialty?(row, specialty) && matches_type?(row, type)
+      end
+    end
+
+    def find(ien)
+      return nil if invalid_ien?(ien)
+
+      row = DataMapper.vendor_detail.fetch_one(ien.to_s)
+      return nil if row.nil?
+
+      decorate_detail(row)
+    end
+
+    def preferred(specialty: nil)
+      rows = DataMapper.preferred_vendor_list.fetch_many(specialty.to_s)
+      Array(rows).select { |row| row[:preferred] && matches_specialty?(row, specialty) }
+    end
+
+    def for_service(service)
+      return [] if blank?(service)
+
+      rows = DataMapper.vendor_service_list.fetch_many(service.to_s)
+      Array(rows).select { |row| matches_service?(row, service) }.map { |row| decorate_rate_vendor(row) }
+    end
+
+    def contracts(ien)
+      return [] if invalid_ien?(ien)
+
+      Array(DataMapper.vendor_contract_list.fetch_many(ien.to_s)).map { |row| decorate_contract(row) }
+    end
+
+    def active_contract(ien)
+      contracts(ien).find { |contract| contract[:active] || contract[:status] == "ACTIVE" }
+    end
+
+    def rates(ien)
+      return [] if invalid_ien?(ien)
+
+      Array(DataMapper.vendor_rate_list.fetch_many(ien.to_s)).map { |row| decorate_rate(row) }
+    end
+
+    def active?(ien)
+      contract = active_contract(ien)
+      return false if contract.nil?
+
+      end_date = contract[:end_date]
+      end_date.nil? || end_date >= Date.today
+    end
+
+    private
+
+    def decorate_detail(row)
+      row.merge(
+        specialties: parse_csv(row[:specialties_raw]),
+        contact_info: {
+          phone: row[:phone],
+          fax: row[:fax],
+          email: row[:email],
+          contact_name: row[:contact_name]
+        },
+        address: {
+          street: row[:street],
+          city: row[:city],
+          state: row[:state],
+          zip: row[:zip]
+        },
+        contracted_services: parse_csv(row[:contracted_services_raw])
+      ).tap do |detail|
+        DETAIL_RAW_KEYS.each { |key| detail.delete(key) }
+      end
+    end
+
+    def decorate_rate_vendor(row)
+      row.merge(
+        rate: parse_decimal(row[:rate]),
+        contracted_rate: parse_decimal(row[:rate])
+      )
+    end
+
+    def decorate_contract(row)
+      active = row[:end_date].nil? || row[:end_date] >= Date.today
+      row.merge(
+        status: active ? "ACTIVE" : "EXPIRED",
+        active: active,
+        services: parse_csv(row[:services_raw])
+      ).tap { |contract| contract.delete(:services_raw) }
+    end
+
+    def decorate_rate(row)
+      amount = parse_decimal(row[:rate])
+      row.merge(
+        service_type: row[:service],
+        rate: amount,
+        amount: amount
+      )
+    end
+
+    def parse_csv(value)
+      return [] if blank?(value)
+
+      value.to_s.split(",").map(&:strip).reject(&:empty?)
+    end
+
+    def parse_decimal(value)
+      return nil if blank?(value)
+
+      BigDecimal(value.to_s)
+    rescue ArgumentError
+      nil
+    end
+
+    def matches_name?(row, name)
+      return true if blank?(name)
+
+      row[:name].to_s.downcase.include?(name.to_s.downcase)
+    end
+
+    def matches_specialty?(row, specialty)
+      return true if blank?(specialty)
+
+      needle = specialty.to_s.downcase
+      specialty_text = row[:specialty].to_s.downcase
+      specialties = row[:specialties] || parse_csv(row[:specialties_raw])
+      specialty_text.include?(needle) ||
+        specialties.any? { |entry| entry.to_s.downcase.include?(needle) }
+    end
+
+    def matches_type?(row, type)
+      blank?(type) || row[:type] == type
+    end
+
+    def matches_service?(row, service)
+      needle = service.to_s.downcase
+      row[:service].to_s.downcase.include?(needle) || row[:specialty].to_s.downcase.include?(needle)
+    end
+
+    def invalid_ien?(ien)
+      blank?(ien) || ien.to_i <= 0
+    end
+
+    def blank?(val)
+      val.nil? || val.to_s.empty?
+    end
+  end
+end

--- a/lib/rpms_rpc/api/vendor.rb
+++ b/lib/rpms_rpc/api/vendor.rb
@@ -10,7 +10,6 @@ module RpmsRpc
   module Vendor
     extend self
 
-    VENDOR_TYPES = %w[FACILITY INDIVIDUAL GROUP].freeze
     DETAIL_RAW_KEYS = %i[
       specialties_raw
       phone
@@ -72,8 +71,7 @@ module RpmsRpc
       contract = active_contract(ien)
       return false if contract.nil?
 
-      end_date = contract[:end_date]
-      end_date.nil? || end_date >= Date.today
+      contract_active?(contract[:start_date], contract[:end_date])
     end
 
     private
@@ -107,12 +105,21 @@ module RpmsRpc
     end
 
     def decorate_contract(row)
-      active = row[:end_date].nil? || row[:end_date] >= Date.today
+      active = contract_active?(row[:start_date], row[:end_date])
       row.merge(
         status: active ? "ACTIVE" : "EXPIRED",
         active: active,
         services: parse_csv(row[:services_raw])
       ).tap { |contract| contract.delete(:services_raw) }
+    end
+
+    # A contract is active when today falls between its start (or open-ended)
+    # and its end (or open-ended). Both bounds are optional.
+    def contract_active?(start_date, end_date)
+      today = Date.today
+      started = start_date.nil? || start_date <= today
+      not_ended = end_date.nil? || end_date >= today
+      started && not_ended
     end
 
     def decorate_rate(row)
@@ -160,7 +167,7 @@ module RpmsRpc
 
     def matches_service?(row, service)
       needle = service.to_s.downcase
-      row[:service].to_s.downcase.include?(needle) || row[:specialty].to_s.downcase.include?(needle)
+      row[:service].to_s.downcase.include?(needle)
     end
 
     # Vendor and contract IDs are opaque tokens (e.g. "VENDOR-001",

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -485,7 +485,10 @@ module RpmsRpc
     # Format: IEN^NAME^TYPE^SPECIALTY^PREFERRED^PHONE^CITY^STATE
     DataMapper.define(:vendor_list) do |m|
       m.rpc "BMCRPC SRCHVEND"
-      m.field 0, :ien, :integer
+      # :ien is left as a string — RCIS vendor identifiers are opaque
+      # tokens like "VENDOR-001", not numeric IENs (matches the gateway's
+      # pick_string of "IEN" / "Id" / "VendorIEN").
+      m.field 0, :ien
       m.field 1, :name
       m.field 2, :type
       m.field 3, :specialty
@@ -500,7 +503,7 @@ module RpmsRpc
     #         STREET^CITY^STATE^ZIP^CONTRACTED_SERVICES^CONTRACT_START^CONTRACT_END^ACTIVE
     DataMapper.define(:vendor_detail) do |m|
       m.rpc "BMCRPC GTVEND"
-      m.field 0,  :ien, :integer
+      m.field 0,  :ien
       m.field 1,  :name
       m.field 2,  :type
       m.field 3,  :specialties_raw
@@ -523,7 +526,7 @@ module RpmsRpc
     # Same response shape as BMCRPC SRCHVEND.
     DataMapper.define(:preferred_vendor_list) do |m|
       m.rpc "BMCRPC GTPREFVEND"
-      m.field 0, :ien, :integer
+      m.field 0, :ien
       m.field 1, :name
       m.field 2, :type
       m.field 3, :specialty
@@ -537,7 +540,7 @@ module RpmsRpc
     # Format: IEN^NAME^SERVICE^SPECIALTY^RATE^PREFERRED
     DataMapper.define(:vendor_service_list) do |m|
       m.rpc "BMCRPC SRCHVEND"
-      m.field 0, :ien, :integer
+      m.field 0, :ien
       m.field 1, :name
       m.field 2, :service
       m.field 3, :specialty
@@ -549,8 +552,10 @@ module RpmsRpc
     # Format: ID^VENDOR_IEN^START_DATE^END_DATE^SERVICES^NOTES
     DataMapper.define(:vendor_contract_list) do |m|
       m.rpc "BMCRPC GTCONTRACT"
-      m.field 0, :id, :integer
-      m.field 1, :vendor_ien, :integer
+      # Contract :id and :vendor_ien are opaque string identifiers
+      # (e.g. "CONTRACT-001", "VENDOR-001"); gateway uses pick_string.
+      m.field 0, :id
+      m.field 1, :vendor_ien
       m.field 2, :start_date, :fileman_date
       m.field 3, :end_date, :fileman_date
       m.field 4, :services_raw

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -481,6 +481,92 @@ module RpmsRpc
       m.field 1, :value
     end
 
+    # BMCRPC SRCHVEND — CHS vendor search (multi-line)
+    # Format: IEN^NAME^TYPE^SPECIALTY^PREFERRED^PHONE^CITY^STATE
+    DataMapper.define(:vendor_list) do |m|
+      m.rpc "BMCRPC SRCHVEND"
+      m.field 0, :ien, :integer
+      m.field 1, :name
+      m.field 2, :type
+      m.field 3, :specialty
+      m.field 4, :preferred, :boolean
+      m.field 5, :phone
+      m.field 6, :city
+      m.field 7, :state
+    end
+
+    # BMCRPC GTVEND — single CHS vendor detail
+    # Format: IEN^NAME^TYPE^SPECIALTIES^PREFERRED^PHONE^FAX^EMAIL^CONTACT_NAME^
+    #         STREET^CITY^STATE^ZIP^CONTRACTED_SERVICES^CONTRACT_START^CONTRACT_END^ACTIVE
+    DataMapper.define(:vendor_detail) do |m|
+      m.rpc "BMCRPC GTVEND"
+      m.field 0,  :ien, :integer
+      m.field 1,  :name
+      m.field 2,  :type
+      m.field 3,  :specialties_raw
+      m.field 4,  :preferred, :boolean
+      m.field 5,  :phone
+      m.field 6,  :fax
+      m.field 7,  :email
+      m.field 8,  :contact_name
+      m.field 9,  :street
+      m.field 10, :city
+      m.field 11, :state
+      m.field 12, :zip
+      m.field 13, :contracted_services_raw
+      m.field 14, :contract_start_date, :fileman_date
+      m.field 15, :contract_end_date, :fileman_date
+      m.field 16, :active, :boolean
+    end
+
+    # BMCRPC GTPREFVEND — preferred CHS vendors (multi-line)
+    # Same response shape as BMCRPC SRCHVEND.
+    DataMapper.define(:preferred_vendor_list) do |m|
+      m.rpc "BMCRPC GTPREFVEND"
+      m.field 0, :ien, :integer
+      m.field 1, :name
+      m.field 2, :type
+      m.field 3, :specialty
+      m.field 4, :preferred, :boolean
+      m.field 5, :phone
+      m.field 6, :city
+      m.field 7, :state
+    end
+
+    # BMCRPC SRCHVEND — CHS vendors offering a service, with rates
+    # Format: IEN^NAME^SERVICE^SPECIALTY^RATE^PREFERRED
+    DataMapper.define(:vendor_service_list) do |m|
+      m.rpc "BMCRPC SRCHVEND"
+      m.field 0, :ien, :integer
+      m.field 1, :name
+      m.field 2, :service
+      m.field 3, :specialty
+      m.field 4, :rate
+      m.field 5, :preferred, :boolean
+    end
+
+    # BMCRPC GTCONTRACT — CHS vendor contracts (multi-line)
+    # Format: ID^VENDOR_IEN^START_DATE^END_DATE^SERVICES^NOTES
+    DataMapper.define(:vendor_contract_list) do |m|
+      m.rpc "BMCRPC GTCONTRACT"
+      m.field 0, :id, :integer
+      m.field 1, :vendor_ien, :integer
+      m.field 2, :start_date, :fileman_date
+      m.field 3, :end_date, :fileman_date
+      m.field 4, :services_raw
+      m.field 5, :notes
+    end
+
+    # BMCRPC GTRATES — CHS vendor contracted rates (multi-line)
+    # Format: SERVICE^RATE^UNIT^EFFECTIVE_DATE
+    DataMapper.define(:vendor_rate_list) do |m|
+      m.rpc "BMCRPC GTRATES"
+      m.field 0, :service
+      m.field 1, :rate
+      m.field 2, :unit
+      m.field 3, :effective_date, :fileman_date
+    end
+
     # ========================================================================
     # AUTHENTICATION (XUS*)
     # ========================================================================

--- a/test/rpms_rpc/api/vendor_test.rb
+++ b/test/rpms_rpc/api/vendor_test.rb
@@ -109,7 +109,7 @@ class VendorTest < Minitest::Test
     vendors = RpmsRpc::Vendor.search(name: "Metro", specialty: "Cardiology", type: "FACILITY")
 
     assert_equal 1, vendors.length
-    assert_equal 101, vendors.first[:ien]
+    assert_equal "101", vendors.first[:ien]
     assert_equal "Metro Health Center", vendors.first[:name]
     assert_equal true, vendors.first[:preferred]
   end
@@ -130,7 +130,7 @@ class VendorTest < Minitest::Test
     vendor = RpmsRpc::Vendor.find(101)
 
     refute_nil vendor
-    assert_equal 101, vendor[:ien]
+    assert_equal "101", vendor[:ien]
     assert_equal "Metro Health Center", vendor[:name]
     assert_equal [ "Cardiology", "Internal Medicine" ], vendor[:specialties]
     assert_equal [ "MRI", "CT Scan", "Cardiology Consult" ], vendor[:contracted_services]
@@ -147,29 +147,44 @@ class VendorTest < Minitest::Test
     assert_equal [], vendor[:contracted_services]
   end
 
-  def test_find_rejects_blank_zero_negative_and_non_numeric_ien
+  def test_find_rejects_only_blank_ien
+    # Vendor IDs are opaque tokens (e.g. "VENDOR-001"), not numeric IENs,
+    # so the only invalid input is truly blank — non-numeric strings like
+    # "VENDOR-001" or "abc" must be allowed through to the RPC.
     assert_nil RpmsRpc::Vendor.find(nil)
     assert_nil RpmsRpc::Vendor.find("")
-    assert_nil RpmsRpc::Vendor.find(0)
-    assert_nil RpmsRpc::Vendor.find(-1)
-    assert_nil RpmsRpc::Vendor.find("abc")
+    assert_nil RpmsRpc::Vendor.find("   ")
   end
 
   def test_find_returns_nil_for_unknown_ien
     assert_nil RpmsRpc::Vendor.find(999_999)
   end
 
+  def test_find_accepts_non_numeric_vendor_id
+    RpmsRpc.client.seed(:vendor_detail, "VENDOR-001", {
+      ien: "VENDOR-001",
+      name: "Northwest Specialists",
+      type: "GROUP",
+      preferred: true,
+      active: true
+    })
+
+    vendor = RpmsRpc::Vendor.find("VENDOR-001")
+    refute_nil vendor, "non-numeric vendor IDs must reach the RPC"
+    assert_equal "VENDOR-001", vendor[:ien]
+  end
+
   def test_preferred_returns_preferred_vendors
     vendors = RpmsRpc::Vendor.preferred
 
-    assert_equal [ 101, 103 ], vendors.map { |v| v[:ien] }
+    assert_equal [ "101", "103" ], vendors.map { |v| v[:ien] }
     assert vendors.all? { |v| v[:preferred] }
   end
 
   def test_preferred_filters_by_specialty
     vendors = RpmsRpc::Vendor.preferred(specialty: "Radio")
 
-    assert_equal [ 103 ], vendors.map { |v| v[:ien] }
+    assert_equal [ "103" ], vendors.map { |v| v[:ien] }
   end
 
   def test_for_service_returns_vendors_with_rates
@@ -190,8 +205,8 @@ class VendorTest < Minitest::Test
 
     assert_equal 1, contracts.length
     contract = contracts.first
-    assert_equal 201, contract[:id]
-    assert_equal 101, contract[:vendor_ien]
+    assert_equal "201", contract[:id]
+    assert_equal "101", contract[:vendor_ien]
     assert_equal [ "MRI", "CT Scan", "Cardiology Consult" ], contract[:services]
     assert_equal "ACTIVE", contract[:status]
     assert_equal true, contract[:active]
@@ -213,7 +228,7 @@ class VendorTest < Minitest::Test
     contract = RpmsRpc::Vendor.active_contract(101)
 
     refute_nil contract
-    assert_equal 201, contract[:id]
+    assert_equal "201", contract[:id]
   end
 
   def test_active_predicate_is_false_for_expired_or_unknown_vendor

--- a/test/rpms_rpc/api/vendor_test.rb
+++ b/test/rpms_rpc/api/vendor_test.rb
@@ -6,6 +6,14 @@ require "rpms_rpc/mock_client"
 require "rpms_rpc/api/vendor"
 
 class VendorTest < Minitest::Test
+  # Relative dates so the suite stays time-independent. Active contracts use a
+  # 30-day window centered on today; expired contracts end before today.
+  ACTIVE_START      = Date.today - 365
+  ACTIVE_END        = Date.today + 365
+  EXPIRED_START     = Date.today - 730
+  EXPIRED_END       = Date.today - 365
+  RATE_EFFECTIVE_AT = Date.today - 90
+
   def setup
     RpmsRpc.mock! do |m|
       m.seed_collection(:vendor_list, [
@@ -49,8 +57,8 @@ class VendorTest < Minitest::Test
         state: "OR",
         zip: "97201",
         contracted_services_raw: "MRI, CT Scan, Cardiology Consult",
-        contract_start_date: Date.new(2024, 1, 1),
-        contract_end_date: Date.new(2027, 12, 31),
+        contract_start_date: ACTIVE_START,
+        contract_end_date: ACTIVE_END,
         active: true
       })
 
@@ -76,8 +84,8 @@ class VendorTest < Minitest::Test
         {
           id: 201,
           vendor_ien: 101,
-          start_date: Date.new(2024, 1, 1),
-          end_date: Date.new(2027, 12, 31),
+          start_date: ACTIVE_START,
+          end_date: ACTIVE_END,
           services_raw: "MRI, CT Scan, Cardiology Consult",
           notes: "Multi-year contract with preferred rates"
         }
@@ -87,16 +95,16 @@ class VendorTest < Minitest::Test
         {
           id: 204,
           vendor_ien: 104,
-          start_date: Date.new(2022, 1, 1),
-          end_date: Date.new(2023, 12, 31),
+          start_date: EXPIRED_START,
+          end_date: EXPIRED_END,
           services_raw: "General Consult",
           notes: "Expired contract"
         }
       ])
 
       m.seed_keyed_collection(:vendor_rate_list, "101", [
-        { service: "MRI", rate: "1500.00", unit: "procedure", effective_date: Date.new(2024, 1, 1) },
-        { service: "Cardiology Consult", rate: "350.00", unit: "visit", effective_date: Date.new(2024, 1, 1) }
+        { service: "MRI", rate: "1500.00", unit: "procedure", effective_date: RATE_EFFECTIVE_AT },
+        { service: "Cardiology Consult", rate: "350.00", unit: "visit", effective_date: RATE_EFFECTIVE_AT }
       ])
     end
   end
@@ -136,7 +144,7 @@ class VendorTest < Minitest::Test
     assert_equal [ "MRI", "CT Scan", "Cardiology Consult" ], vendor[:contracted_services]
     assert_equal "555-0100", vendor[:contact_info][:phone]
     assert_equal "123 Example Way", vendor[:address][:street]
-    assert_equal Date.new(2024, 1, 1), vendor[:contract_start_date]
+    assert_equal ACTIVE_START, vendor[:contract_start_date]
   end
 
   def test_find_defaults_blank_multi_value_fields_to_empty_arrays
@@ -236,6 +244,24 @@ class VendorTest < Minitest::Test
     assert_equal false, RpmsRpc::Vendor.active?(999_999)
   end
 
+  def test_active_predicate_is_false_for_future_start_contracts
+    RpmsRpc.client.seed_keyed_collection(:vendor_contract_list, "FUTURE-VEND", [
+      {
+        id: "FUTURE-001",
+        vendor_ien: "FUTURE-VEND",
+        start_date: Date.today + 30,
+        end_date: Date.today + 365,
+        services_raw: "MRI",
+        notes: "Not yet started"
+      }
+    ])
+
+    contracts = RpmsRpc::Vendor.contracts("FUTURE-VEND")
+    assert_equal "EXPIRED", contracts.first[:status],
+      "future-start contracts should NOT be marked ACTIVE"
+    assert_equal false, RpmsRpc::Vendor.active?("FUTURE-VEND")
+  end
+
   def test_rates_returns_contracted_rates
     rates = RpmsRpc::Vendor.rates(101)
 
@@ -244,7 +270,7 @@ class VendorTest < Minitest::Test
     assert_equal "MRI", rates.first[:service_type]
     assert_equal BigDecimal("1500.00"), rates.first[:amount]
     assert_equal "procedure", rates.first[:unit]
-    assert_equal Date.new(2024, 1, 1), rates.first[:effective_date]
+    assert_equal RATE_EFFECTIVE_AT, rates.first[:effective_date]
   end
 
   def test_rates_reject_invalid_ien

--- a/test/rpms_rpc/api/vendor_test.rb
+++ b/test/rpms_rpc/api/vendor_test.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "date"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/vendor"
+
+class VendorTest < Minitest::Test
+  def setup
+    RpmsRpc.mock! do |m|
+      m.seed_collection(:vendor_list, [
+        {
+          ien: 101, name: "Metro Health Center", type: "FACILITY", specialty: "Cardiology",
+          preferred: true, phone: "555-0100", city: "Portland", state: "OR"
+        },
+        {
+          ien: 102, name: "Northwest Specialists", type: "GROUP", specialty: "Orthopedics",
+          preferred: false, phone: "555-0200", city: "Seattle", state: "WA"
+        },
+        {
+          ien: 103, name: "River City Clinic", type: "FACILITY", specialty: "Radiology",
+          preferred: true, phone: "555-0300", city: "Portland", state: "OR"
+        }
+      ])
+
+      m.seed_collection(:preferred_vendor_list, [
+        {
+          ien: 101, name: "Metro Health Center", type: "FACILITY", specialty: "Cardiology",
+          preferred: true, phone: "555-0100", city: "Portland", state: "OR"
+        },
+        {
+          ien: 103, name: "River City Clinic", type: "FACILITY", specialty: "Radiology",
+          preferred: true, phone: "555-0300", city: "Portland", state: "OR"
+        }
+      ])
+
+      m.seed(:vendor_detail, "101", {
+        ien: 101,
+        name: "Metro Health Center",
+        type: "FACILITY",
+        specialties_raw: "Cardiology, Internal Medicine",
+        preferred: true,
+        phone: "555-0100",
+        fax: "555-0101",
+        email: "contact@example.invalid",
+        contact_name: "Primary Contact",
+        street: "123 Example Way",
+        city: "Portland",
+        state: "OR",
+        zip: "97201",
+        contracted_services_raw: "MRI, CT Scan, Cardiology Consult",
+        contract_start_date: Date.new(2024, 1, 1),
+        contract_end_date: Date.new(2027, 12, 31),
+        active: true
+      })
+
+      m.seed(:vendor_detail, "102", {
+        ien: 102,
+        name: "Northwest Specialists",
+        type: "GROUP",
+        specialties_raw: "",
+        preferred: false,
+        phone: "555-0200",
+        city: "Seattle",
+        state: "WA",
+        contracted_services_raw: "",
+        active: true
+      })
+
+      m.seed_keyed_collection(:vendor_service_list, "MRI", [
+        { ien: 101, name: "Metro Health Center", service: "MRI", specialty: "Radiology", rate: "1500.00", preferred: true },
+        { ien: 103, name: "River City Clinic", service: "MRI", specialty: "Radiology", rate: "1800.00", preferred: false }
+      ])
+
+      m.seed_keyed_collection(:vendor_contract_list, "101", [
+        {
+          id: 201,
+          vendor_ien: 101,
+          start_date: Date.new(2024, 1, 1),
+          end_date: Date.new(2027, 12, 31),
+          services_raw: "MRI, CT Scan, Cardiology Consult",
+          notes: "Multi-year contract with preferred rates"
+        }
+      ])
+
+      m.seed_keyed_collection(:vendor_contract_list, "104", [
+        {
+          id: 204,
+          vendor_ien: 104,
+          start_date: Date.new(2022, 1, 1),
+          end_date: Date.new(2023, 12, 31),
+          services_raw: "General Consult",
+          notes: "Expired contract"
+        }
+      ])
+
+      m.seed_keyed_collection(:vendor_rate_list, "101", [
+        { service: "MRI", rate: "1500.00", unit: "procedure", effective_date: Date.new(2024, 1, 1) },
+        { service: "Cardiology Consult", rate: "350.00", unit: "visit", effective_date: Date.new(2024, 1, 1) }
+      ])
+    end
+  end
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  def test_search_returns_matching_vendors
+    vendors = RpmsRpc::Vendor.search(name: "Metro", specialty: "Cardiology", type: "FACILITY")
+
+    assert_equal 1, vendors.length
+    assert_equal 101, vendors.first[:ien]
+    assert_equal "Metro Health Center", vendors.first[:name]
+    assert_equal true, vendors.first[:preferred]
+  end
+
+  def test_search_uses_mapping_rpc_name
+    RpmsRpc::Vendor.search(name: "Metro")
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BMCRPC SRCHVEND" }
+    refute_nil call
+    assert_equal [ "Metro", "", "" ], call[:params]
+  end
+
+  def test_search_returns_empty_for_unknown_name
+    assert_equal [], RpmsRpc::Vendor.search(name: "Unknown Vendor")
+  end
+
+  def test_find_returns_vendor_detail
+    vendor = RpmsRpc::Vendor.find(101)
+
+    refute_nil vendor
+    assert_equal 101, vendor[:ien]
+    assert_equal "Metro Health Center", vendor[:name]
+    assert_equal [ "Cardiology", "Internal Medicine" ], vendor[:specialties]
+    assert_equal [ "MRI", "CT Scan", "Cardiology Consult" ], vendor[:contracted_services]
+    assert_equal "555-0100", vendor[:contact_info][:phone]
+    assert_equal "123 Example Way", vendor[:address][:street]
+    assert_equal Date.new(2024, 1, 1), vendor[:contract_start_date]
+  end
+
+  def test_find_defaults_blank_multi_value_fields_to_empty_arrays
+    vendor = RpmsRpc::Vendor.find(102)
+
+    refute_nil vendor
+    assert_equal [], vendor[:specialties]
+    assert_equal [], vendor[:contracted_services]
+  end
+
+  def test_find_rejects_blank_zero_negative_and_non_numeric_ien
+    assert_nil RpmsRpc::Vendor.find(nil)
+    assert_nil RpmsRpc::Vendor.find("")
+    assert_nil RpmsRpc::Vendor.find(0)
+    assert_nil RpmsRpc::Vendor.find(-1)
+    assert_nil RpmsRpc::Vendor.find("abc")
+  end
+
+  def test_find_returns_nil_for_unknown_ien
+    assert_nil RpmsRpc::Vendor.find(999_999)
+  end
+
+  def test_preferred_returns_preferred_vendors
+    vendors = RpmsRpc::Vendor.preferred
+
+    assert_equal [ 101, 103 ], vendors.map { |v| v[:ien] }
+    assert vendors.all? { |v| v[:preferred] }
+  end
+
+  def test_preferred_filters_by_specialty
+    vendors = RpmsRpc::Vendor.preferred(specialty: "Radio")
+
+    assert_equal [ 103 ], vendors.map { |v| v[:ien] }
+  end
+
+  def test_for_service_returns_vendors_with_rates
+    vendors = RpmsRpc::Vendor.for_service("MRI")
+
+    assert_equal 2, vendors.length
+    assert_equal BigDecimal("1500.00"), vendors.first[:rate]
+    assert_equal BigDecimal("1500.00"), vendors.first[:contracted_rate]
+  end
+
+  def test_for_service_returns_empty_for_blank_service
+    assert_equal [], RpmsRpc::Vendor.for_service(nil)
+    assert_equal [], RpmsRpc::Vendor.for_service("")
+  end
+
+  def test_contracts_returns_vendor_contracts_with_status
+    contracts = RpmsRpc::Vendor.contracts(101)
+
+    assert_equal 1, contracts.length
+    contract = contracts.first
+    assert_equal 201, contract[:id]
+    assert_equal 101, contract[:vendor_ien]
+    assert_equal [ "MRI", "CT Scan", "Cardiology Consult" ], contract[:services]
+    assert_equal "ACTIVE", contract[:status]
+    assert_equal true, contract[:active]
+  end
+
+  def test_contracts_reject_invalid_ien
+    assert_equal [], RpmsRpc::Vendor.contracts(nil)
+    assert_equal [], RpmsRpc::Vendor.contracts("")
+    assert_equal [], RpmsRpc::Vendor.contracts(0)
+    assert_equal [], RpmsRpc::Vendor.contracts(-1)
+    assert_equal [], RpmsRpc::Vendor.contracts("abc")
+  end
+
+  def test_contracts_returns_empty_for_unknown_ien
+    assert_equal [], RpmsRpc::Vendor.contracts(999_999)
+  end
+
+  def test_active_contract_returns_current_contract
+    contract = RpmsRpc::Vendor.active_contract(101)
+
+    refute_nil contract
+    assert_equal 201, contract[:id]
+  end
+
+  def test_active_predicate_is_false_for_expired_or_unknown_vendor
+    assert_equal false, RpmsRpc::Vendor.active?(104)
+    assert_equal false, RpmsRpc::Vendor.active?(999_999)
+  end
+
+  def test_rates_returns_contracted_rates
+    rates = RpmsRpc::Vendor.rates(101)
+
+    assert_equal 2, rates.length
+    assert_equal "MRI", rates.first[:service]
+    assert_equal "MRI", rates.first[:service_type]
+    assert_equal BigDecimal("1500.00"), rates.first[:amount]
+    assert_equal "procedure", rates.first[:unit]
+    assert_equal Date.new(2024, 1, 1), rates.first[:effective_date]
+  end
+
+  def test_rates_reject_invalid_ien
+    assert_equal [], RpmsRpc::Vendor.rates(nil)
+    assert_equal [], RpmsRpc::Vendor.rates("")
+    assert_equal [], RpmsRpc::Vendor.rates(0)
+    assert_equal [], RpmsRpc::Vendor.rates(-1)
+    assert_equal [], RpmsRpc::Vendor.rates("abc")
+  end
+end

--- a/test/rpms_rpc/mappings_test.rb
+++ b/test/rpms_rpc/mappings_test.rb
@@ -365,6 +365,67 @@ class RpmsRpc::MappingsTest < Minitest::Test
     assert_equal "55", result[:facility_ien]
   end
 
+  def test_vendor_list
+    result = RpmsRpc::DataMapper[:vendor_list].parse_many(
+      [ "101^Metro Health Center^FACILITY^Cardiology^1^555-0100^Portland^OR" ]
+    ).first
+
+    assert_equal 101, result[:ien]
+    assert_equal "Metro Health Center", result[:name]
+    assert_equal "FACILITY", result[:type]
+    assert_equal "Cardiology", result[:specialty]
+    assert_equal true, result[:preferred]
+    assert_equal "OR", result[:state]
+  end
+
+  def test_vendor_detail
+    result = RpmsRpc::DataMapper[:vendor_detail].parse_one(
+      "101^Metro Health Center^FACILITY^Cardiology, Internal Medicine^1^555-0100^555-0101^contact@example.invalid^Primary Contact^123 Example Way^Portland^OR^97201^MRI, CT Scan^3240101^3271231^1"
+    )
+
+    assert_equal 101, result[:ien]
+    assert_equal "Cardiology, Internal Medicine", result[:specialties_raw]
+    assert_equal true, result[:preferred]
+    assert_equal Date.new(2024, 1, 1), result[:contract_start_date]
+    assert_equal Date.new(2027, 12, 31), result[:contract_end_date]
+    assert_equal true, result[:active]
+  end
+
+  def test_vendor_service_list
+    result = RpmsRpc::DataMapper[:vendor_service_list].parse_many(
+      [ "101^Metro Health Center^MRI^Radiology^1500.00^1" ]
+    ).first
+
+    assert_equal 101, result[:ien]
+    assert_equal "MRI", result[:service]
+    assert_equal "Radiology", result[:specialty]
+    assert_equal "1500.00", result[:rate]
+    assert_equal true, result[:preferred]
+  end
+
+  def test_vendor_contract_list
+    result = RpmsRpc::DataMapper[:vendor_contract_list].parse_many(
+      [ "201^101^3240101^3271231^MRI, CT Scan^Multi-year contract" ]
+    ).first
+
+    assert_equal 201, result[:id]
+    assert_equal 101, result[:vendor_ien]
+    assert_equal Date.new(2024, 1, 1), result[:start_date]
+    assert_equal Date.new(2027, 12, 31), result[:end_date]
+    assert_equal "MRI, CT Scan", result[:services_raw]
+  end
+
+  def test_vendor_rate_list
+    result = RpmsRpc::DataMapper[:vendor_rate_list].parse_many(
+      [ "MRI^1500.00^procedure^3240101" ]
+    ).first
+
+    assert_equal "MRI", result[:service]
+    assert_equal "1500.00", result[:rate]
+    assert_equal "procedure", result[:unit]
+    assert_equal Date.new(2024, 1, 1), result[:effective_date]
+  end
+
   def test_phr_access
     assert_equal true, RpmsRpc::DataMapper[:phr_access].parse_scalar("1")
   end
@@ -400,6 +461,8 @@ class RpmsRpc::MappingsTest < Minitest::Test
       immunization_exchange_status
       phr_access phr_patient_direct phr_provider_direct phr_facility_direct
       vfc_eligibility vfc_eligibility_list vaccine_lot_list vaccine_lot_detail
+      vendor_list vendor_detail preferred_vendor_list vendor_service_list
+      vendor_contract_list vendor_rate_list
     ]
 
     expected.each do |name|

--- a/test/rpms_rpc/mappings_test.rb
+++ b/test/rpms_rpc/mappings_test.rb
@@ -370,7 +370,7 @@ class RpmsRpc::MappingsTest < Minitest::Test
       [ "101^Metro Health Center^FACILITY^Cardiology^1^555-0100^Portland^OR" ]
     ).first
 
-    assert_equal 101, result[:ien]
+    assert_equal "101", result[:ien]
     assert_equal "Metro Health Center", result[:name]
     assert_equal "FACILITY", result[:type]
     assert_equal "Cardiology", result[:specialty]
@@ -383,7 +383,7 @@ class RpmsRpc::MappingsTest < Minitest::Test
       "101^Metro Health Center^FACILITY^Cardiology, Internal Medicine^1^555-0100^555-0101^contact@example.invalid^Primary Contact^123 Example Way^Portland^OR^97201^MRI, CT Scan^3240101^3271231^1"
     )
 
-    assert_equal 101, result[:ien]
+    assert_equal "101", result[:ien]
     assert_equal "Cardiology, Internal Medicine", result[:specialties_raw]
     assert_equal true, result[:preferred]
     assert_equal Date.new(2024, 1, 1), result[:contract_start_date]
@@ -396,7 +396,7 @@ class RpmsRpc::MappingsTest < Minitest::Test
       [ "101^Metro Health Center^MRI^Radiology^1500.00^1" ]
     ).first
 
-    assert_equal 101, result[:ien]
+    assert_equal "101", result[:ien]
     assert_equal "MRI", result[:service]
     assert_equal "Radiology", result[:specialty]
     assert_equal "1500.00", result[:rate]
@@ -408,8 +408,8 @@ class RpmsRpc::MappingsTest < Minitest::Test
       [ "201^101^3240101^3271231^MRI, CT Scan^Multi-year contract" ]
     ).first
 
-    assert_equal 201, result[:id]
-    assert_equal 101, result[:vendor_ien]
+    assert_equal "201", result[:id]
+    assert_equal "101", result[:vendor_ien]
     assert_equal Date.new(2024, 1, 1), result[:start_date]
     assert_equal Date.new(2027, 12, 31), result[:end_date]
     assert_equal "MRI, CT Scan", result[:services_raw]


### PR DESCRIPTION
## Summary
- Add CHS vendor symbolic API for search, preferred vendors, service rates, vendor details, contracts, and active contract checks.
- Register BMCRPC vendor mappings for vendor lists, details, preferred vendors, service-rate rows, contracts, and rates.
- Add vendor API and mapping tests covering happy paths, invalid IDs, blank defaults, unknown IDs, and multi-row responses.

## Test plan
- bundle exec ruby -Ilib -Itest test/rpms_rpc/api/vendor_test.rb
- bundle exec rake test
- bundle exec rubocop lib/rpms_rpc/api/vendor.rb lib/rpms_rpc/mappings.rb test/rpms_rpc/api/vendor_test.rb test/rpms_rpc/mappings_test.rb

Made with [Cursor](https://cursor.com)