### PR TITLE
PHR module: port from rpms_redux (Part of #80)

### DIFF
--- a/lib/rpms_rpc/api/phr.rb
+++ b/lib/rpms_rpc/api/phr.rb
@@ -13,10 +13,25 @@ module RpmsRpc
     def enrollment_status(dfn)
       return disabled_status("Invalid patient") if invalid_id?(dfn)
 
-      row = DataMapper.phr_access.fetch_one(dfn.to_s)
-      return disabled_status("No response") if row.nil?
+      # BEHOCCD PHR is line-based, not caret-delimited:
+      #   line 0: "1" (has access) or "0" (no access)
+      #   line 1: optional human-readable message
+      # fetch_one normalizes to first line only, which would drop the
+      # message and would fail to coerce "1Some text" forms — so the
+      # parsing is done here against the raw response.
+      response = RpmsRpc.client.call_rpc(DataMapper.phr_access.rpc_name, dfn.to_s)
+      return disabled_status("No response") if blank_response?(response)
 
-      decorate_status(row)
+      lines = response.is_a?(Array) ? response : response.to_s.split(/\r?\n/)
+      status = lines.first.to_s.strip
+      message = lines[1].to_s.strip
+      has_access = status == "1"
+
+      {
+        enrolled: has_access,
+        has_access: has_access,
+        message: message.empty? ? default_status_message(has_access) : message
+      }
     end
 
     def has_access?(dfn)
@@ -78,15 +93,6 @@ module RpmsRpc
 
     private
 
-    def decorate_status(row)
-      has_access = row[:has_access] == true
-      {
-        enrolled: has_access,
-        has_access: has_access,
-        message: blank?(row[:message]) ? default_status_message(has_access) : row[:message]
-      }
-    end
-
     def decorate_ccd(row)
       row.merge(
         title: blank?(row[:title]) ? DEFAULT_CCD_TITLE : row[:title],
@@ -137,7 +143,11 @@ module RpmsRpc
     end
 
     def blank?(value)
-      value.nil? || value.to_s.empty?
+      value.nil? || value.to_s.strip.empty?
+    end
+
+    def blank_response?(response)
+      response.nil? || (response.respond_to?(:empty?) && response.empty?)
     end
   end
 end

--- a/lib/rpms_rpc/api/phr.rb
+++ b/lib/rpms_rpc/api/phr.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require "date"
+
+module RpmsRpc
+  # Symbolic API for Personal Health Record and CCD gateway RPCs.
+  module Phr
+    extend self
+
+    DEFAULT_CCD_TITLE = "Clinical Document"
+    DEFAULT_CCD_TYPE = "CCD"
+
+    def enrollment_status(dfn)
+      return disabled_status("Invalid patient") if invalid_id?(dfn)
+
+      row = DataMapper.phr_access.fetch_one(dfn.to_s)
+      return disabled_status("No response") if row.nil?
+
+      decorate_status(row)
+    end
+
+    def has_access?(dfn)
+      enrollment_status(dfn)[:has_access]
+    end
+
+    def for_patient(dfn, start_date: Date.today - 365, end_date: Date.today)
+      return [] if invalid_id?(dfn)
+
+      key = "#{dfn}^#{format_date(start_date)}^#{format_date(end_date)}"
+      Array(DataMapper.ccd_document.fetch_many(key)).map { |row| decorate_ccd(row) }
+    end
+
+    def find(ien)
+      return nil if invalid_id?(ien)
+
+      content = DataMapper.immunization_text.fetch_text(ien.to_s)
+      return nil if blank?(content)
+
+      { content: content, format: detect_format(content) }
+    end
+
+    def counts(dfn)
+      return zero_counts if invalid_id?(dfn)
+
+      row = DataMapper.immunization_count.fetch_one(dfn.to_s)
+      return zero_counts if row.nil?
+
+      total = row[:total].to_i
+      reconciled = row[:reconciled].to_i
+      { total: total, reconciled: reconciled, pending: total - reconciled }
+    end
+
+    def referrals_for_visits(visit_iens)
+      ids = Array(visit_iens).reject { |ien| invalid_id?(ien) }
+      return [] if ids.empty?
+
+      DataMapper.ccd_referral.fetch_many(ids.join("^"))
+    end
+
+    def patient_direct_address(dfn)
+      direct_address(:phr_patient_direct, dfn)
+    end
+
+    def provider_direct_address(duz)
+      direct_address(:phr_provider_direct, duz)
+    end
+
+    def facility_direct_domain(location_ien)
+      direct_address(:phr_facility_direct, location_ien)
+    end
+
+    def record_access(dfn, access_type: "VIEW", date: Date.today)
+      return nil if invalid_id?(dfn)
+
+      param = "#{dfn}^#{access_type}^#{format_date(date)}"
+      DataMapper.phr_record_access.fetch_scalar(param)
+    end
+
+    private
+
+    def decorate_status(row)
+      has_access = row[:has_access] == true
+      {
+        enrolled: has_access,
+        has_access: has_access,
+        message: blank?(row[:message]) ? default_status_message(has_access) : row[:message]
+      }
+    end
+
+    def decorate_ccd(row)
+      row.merge(
+        title: blank?(row[:title]) ? DEFAULT_CCD_TITLE : row[:title],
+        type: blank?(row[:type]) ? DEFAULT_CCD_TYPE : row[:type]
+      )
+    end
+
+    def direct_address(mapping_name, id)
+      return nil if invalid_id?(id)
+
+      row = DataMapper[mapping_name].fetch_one(id.to_s)
+      return nil if row.nil?
+
+      address = row[:direct_address].to_s.strip
+      return nil if address.empty? || address.start_with?("-1")
+
+      address
+    end
+
+    def detect_format(content)
+      if content.include?("<?xml") || content.include?("<ClinicalDocument")
+        "xml"
+      elsif content.include?("<html") || content.include?("<HTML")
+        "html"
+      else
+        "text"
+      end
+    end
+
+    def zero_counts
+      { total: 0, reconciled: 0, pending: 0 }
+    end
+
+    def disabled_status(message)
+      { enrolled: false, has_access: false, message: message }
+    end
+
+    def default_status_message(has_access)
+      has_access ? "PHR access enabled" : "PHR not enrolled"
+    end
+
+    def format_date(date)
+      date.strftime("%m/%d/%Y")
+    end
+
+    def invalid_id?(value)
+      blank?(value) || value.to_i <= 0
+    end
+
+    def blank?(value)
+      value.nil? || value.to_s.empty?
+    end
+  end
+end

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -1138,28 +1138,41 @@ module RpmsRpc
     # PHR / CCD (BEHOCCD*, BPHR*, BEHOCIR*)
     # ========================================================================
 
-    # BEHOCCD PHR — CCD document (text blob)
+    # BEHOCIR1 GETCCDS — CCD documents for patient
+    # Format per line: IEN^DATE^SOURCE^TITLE^TYPE
     DataMapper.define(:ccd_document) do |m|
-      m.rpc "BEHOCCD PHR"
-      m.text_blob :ccd_xml
+      m.rpc "BEHOCIR1 GETCCDS"
+      m.field 0, :ien, :integer
+      m.field 1, :date, :fileman_date
+      m.field 2, :source
+      m.field 3, :title
+      m.field 4, :type
     end
 
-    # BEHOCCD GETREF — referral CCD (text blob)
+    # BEHOCCD GETREF — referrals with CCD status
+    # Format per line: REFERRAL_IEN^VISIT_IEN^HAS_CCD^CCD_SENT_DATE^PROVIDER^FACILITY
     DataMapper.define(:ccd_referral) do |m|
       m.rpc "BEHOCCD GETREF"
-      m.text_blob :ccd_xml
+      m.field 0, :referral_ien, :integer
+      m.field 1, :visit_ien, :integer
+      m.field 2, :has_ccd, :boolean
+      m.field 3, :ccd_sent_date, :fileman_date
+      m.field 4, :provider_name
+      m.field 5, :facility
     end
 
-    # BEHOCIR GETTXT — immunization text
+    # BEHOCIR GETTXT — CCD document content
     DataMapper.define(:immunization_text) do |m|
       m.rpc "BEHOCIR GETTXT"
-      m.text_blob :immunization_text
+      m.text_blob :content
     end
 
-    # BEHOCIR GETNUM — immunization count
+    # BEHOCIR GETNUM — CCD count and reconciliation status
+    # Format: TOTAL^RECONCILED
     DataMapper.define(:immunization_count) do |m|
       m.rpc "BEHOCIR GETNUM"
-      m.scalar :count, :integer
+      m.field 0, :total, :integer
+      m.field 1, :reconciled, :integer
     end
 
     # BYIMRT VXU — send patient immunizations to state IIS
@@ -1208,10 +1221,17 @@ module RpmsRpc
       m.field 1, :message
     end
 
-    # BPHR RECORD ACCESS — PHR access check
+    # BEHOCCD PHR — PHR enrollment/access check
     DataMapper.define(:phr_access) do |m|
+      m.rpc "BEHOCCD PHR"
+      m.field 0, :has_access, :boolean
+      m.field 1, :message
+    end
+
+    # BPHR RECORD ACCESS — records PHR access for reporting
+    DataMapper.define(:phr_record_access) do |m|
       m.rpc "BPHR RECORD ACCESS"
-      m.scalar :has_access, :boolean
+      m.scalar :success, :boolean
     end
 
     # BPHR PATIENT DIRECT — patient direct messaging
@@ -1234,6 +1254,7 @@ module RpmsRpc
       m.field 0, :direct_address
       m.field 1, :status
     end
+
     # ========================================================================
     # VFC ELIGIBILITY (BIPC*)
     # ========================================================================

--- a/test/rpms_rpc/api/phr_test.rb
+++ b/test/rpms_rpc/api/phr_test.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "date"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/phr"
+
+class PhrTest < Minitest::Test
+  DFN = 8791
+  INVALID_IDS = [ nil, "", 0, -5, "abc" ].freeze
+
+  def setup
+    @start_date = Date.new(2025, 5, 26)
+    @end_date = Date.new(2026, 5, 26)
+    ccd_key = "#{DFN}^05/26/2025^05/26/2026"
+
+    RpmsRpc.mock! do |m|
+      m.seed(:phr_access, DFN.to_s, { has_access: true, message: "Patient portal enabled" })
+      m.seed(:phr_access, "123", { has_access: false, message: nil })
+
+      m.seed_keyed_collection(:ccd_document, ccd_key, [
+        {
+          ien: 501, date: Date.new(2026, 5, 1), source: "External Clinic",
+          title: "Visit CCD", type: "CCD"
+        },
+        {
+          ien: 502, date: Date.new(2026, 5, 2), source: "Hospital",
+          title: nil, type: nil
+        }
+      ])
+
+      m.seed_text(:immunization_text, "501",
+        "<?xml version=\"1.0\"?>\n" \
+        "<ClinicalDocument>\n" \
+        "  <title>Continuity of Care Document</title>\n" \
+        "</ClinicalDocument>")
+      m.seed_text(:immunization_text, "502",
+        "<html>\n" \
+        "<body>CCD preview</body>\n" \
+        "</html>")
+
+      m.seed(:immunization_count, DFN.to_s, { total: 5, reconciled: 2 })
+
+      m.seed_keyed_collection(:ccd_referral, "9001^9002", [
+        {
+          referral_ien: 7001, visit_ien: 9001, has_ccd: true,
+          ccd_sent_date: Date.new(2026, 5, 10), provider_name: "PROVIDER,TEST",
+          facility: "Test Facility"
+        },
+        {
+          referral_ien: 7002, visit_ien: 9002, has_ccd: false,
+          ccd_sent_date: nil, provider_name: "PROVIDER,TWO", facility: nil
+        }
+      ])
+
+      m.seed(:phr_patient_direct, DFN.to_s, { direct_address: "patient@example.direct", status: "active" })
+      m.seed(:phr_patient_direct, "123", { direct_address: "-1^No address", status: nil })
+      m.seed(:phr_provider_direct, "301", { direct_address: "provider@example.direct", status: "active" })
+      m.seed(:phr_facility_direct, "55", { direct_address: "clinic.example.direct", status: "active" })
+    end
+  end
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  def test_enrollment_status_returns_access_hash
+    status = RpmsRpc::Phr.enrollment_status(DFN)
+
+    assert_equal true, status[:enrolled]
+    assert_equal true, status[:has_access]
+    assert_equal "Patient portal enabled", status[:message]
+  end
+
+  def test_enrollment_status_defaults_blank_message
+    status = RpmsRpc::Phr.enrollment_status(123)
+
+    assert_equal false, status[:enrolled]
+    assert_equal false, status[:has_access]
+    assert_equal "PHR not enrolled", status[:message]
+  end
+
+  def test_enrollment_status_rejects_blank_zero_negative_and_nonnumeric_dfn
+    INVALID_IDS.each do |dfn|
+      assert_equal false, RpmsRpc::Phr.enrollment_status(dfn)[:has_access]
+      assert_equal false, RpmsRpc::Phr.has_access?(dfn)
+    end
+  end
+
+  def test_enrollment_status_returns_disabled_for_unknown_dfn
+    status = RpmsRpc::Phr.enrollment_status(999_999)
+
+    assert_equal false, status[:has_access]
+    assert_equal "No response", status[:message]
+  end
+
+  def test_for_patient_sends_caret_delimited_date_range
+    RpmsRpc::Phr.for_patient(DFN, start_date: @start_date, end_date: @end_date)
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BEHOCIR1 GETCCDS" }
+    refute_nil call
+    assert_equal [ "#{DFN}^05/26/2025^05/26/2026" ], call[:params]
+  end
+
+  def test_for_patient_returns_ccd_documents_with_defaults
+    documents = RpmsRpc::Phr.for_patient(DFN, start_date: @start_date, end_date: @end_date)
+
+    assert_equal 2, documents.length
+    first = documents.first
+    assert_equal 501, first[:ien]
+    assert_equal Date.new(2026, 5, 1), first[:date]
+    assert_equal "External Clinic", first[:source]
+    assert_equal "Visit CCD", first[:title]
+
+    second = documents.last
+    assert_equal "Clinical Document", second[:title]
+    assert_equal "CCD", second[:type]
+  end
+
+  def test_for_patient_returns_empty_for_invalid_or_unknown_dfn
+    INVALID_IDS.each do |dfn|
+      assert_equal [], RpmsRpc::Phr.for_patient(dfn, start_date: @start_date, end_date: @end_date)
+    end
+
+    assert_equal [], RpmsRpc::Phr.for_patient(999_999, start_date: @start_date, end_date: @end_date)
+  end
+
+  def test_find_returns_multiline_ccd_content_and_detects_xml
+    document = RpmsRpc::Phr.find(501)
+
+    refute_nil document
+    assert_equal "xml", document[:format]
+    assert_includes document[:content], "<ClinicalDocument>"
+    assert_includes document[:content], "\n"
+  end
+
+  def test_find_detects_html_content
+    assert_equal "html", RpmsRpc::Phr.find(502)[:format]
+  end
+
+  def test_find_returns_nil_for_invalid_or_unknown_ien
+    INVALID_IDS.each do |ien|
+      assert_nil RpmsRpc::Phr.find(ien)
+    end
+
+    assert_nil RpmsRpc::Phr.find(999_999)
+  end
+
+  def test_counts_returns_total_reconciled_and_pending
+    counts = RpmsRpc::Phr.counts(DFN)
+
+    assert_equal 5, counts[:total]
+    assert_equal 2, counts[:reconciled]
+    assert_equal 3, counts[:pending]
+  end
+
+  def test_counts_returns_zeroes_for_invalid_or_unknown_dfn
+    (INVALID_IDS + [ 999_999 ]).each do |dfn|
+      assert_equal({ total: 0, reconciled: 0, pending: 0 }, RpmsRpc::Phr.counts(dfn))
+    end
+  end
+
+  def test_referrals_for_visits_returns_ccd_status
+    referrals = RpmsRpc::Phr.referrals_for_visits([ 9001, 9002 ])
+
+    assert_equal 2, referrals.length
+    assert_equal 7001, referrals.first[:referral_ien]
+    assert_equal 9001, referrals.first[:visit_ien]
+    assert_equal true, referrals.first[:has_ccd]
+    assert_equal Date.new(2026, 5, 10), referrals.first[:ccd_sent_date]
+  end
+
+  def test_referrals_for_visits_rejects_invalid_ids
+    assert_equal [], RpmsRpc::Phr.referrals_for_visits(INVALID_IDS)
+  end
+
+  def test_direct_address_methods_return_addresses
+    assert_equal "patient@example.direct", RpmsRpc::Phr.patient_direct_address(DFN)
+    assert_equal "provider@example.direct", RpmsRpc::Phr.provider_direct_address(301)
+    assert_equal "clinic.example.direct", RpmsRpc::Phr.facility_direct_domain(55)
+  end
+
+  def test_direct_address_methods_return_nil_for_errors_and_invalid_ids
+    assert_nil RpmsRpc::Phr.patient_direct_address(123)
+    assert_nil RpmsRpc::Phr.patient_direct_address(0)
+  end
+
+  def test_record_access_sends_bphr_record_access_payload
+    RpmsRpc::Phr.record_access(DFN, access_type: "DOWNLOAD", date: Date.new(2026, 5, 26))
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BPHR RECORD ACCESS" }
+    refute_nil call
+    assert_equal [ "#{DFN}^DOWNLOAD^05/26/2026" ], call[:params]
+  end
+end

--- a/test/rpms_rpc/api/phr_test.rb
+++ b/test/rpms_rpc/api/phr_test.rb
@@ -15,8 +15,11 @@ class PhrTest < Minitest::Test
     ccd_key = "#{DFN}^05/26/2025^05/26/2026"
 
     RpmsRpc.mock! do |m|
-      m.seed(:phr_access, DFN.to_s, { has_access: true, message: "Patient portal enabled" })
-      m.seed(:phr_access, "123", { has_access: false, message: nil })
+      # BEHOCCD PHR is line-based: line 0 = "1"/"0", line 1 = optional message.
+      # seed_text models the multi-line wire shape; fetch_one would only see
+      # the first line.
+      m.seed_text(:phr_access, DFN.to_s, "1\nPatient portal enabled")
+      m.seed_text(:phr_access, "123", "0")
 
       m.seed_keyed_collection(:ccd_document, ccd_key, [
         {

--- a/test/rpms_rpc/mappings_test.rb
+++ b/test/rpms_rpc/mappings_test.rb
@@ -332,7 +332,10 @@ class RpmsRpc::MappingsTest < Minitest::Test
   # -- PHR RPCs --------------------------------------------------------------
 
   def test_immunization_count
-    assert_equal 5, RpmsRpc::DataMapper[:immunization_count].parse_scalar("5")
+    result = RpmsRpc::DataMapper[:immunization_count].parse_one("5^2")
+
+    assert_equal 5, result[:total]
+    assert_equal 2, result[:reconciled]
   end
 
   def test_vaccine_lot_list
@@ -427,7 +430,10 @@ class RpmsRpc::MappingsTest < Minitest::Test
   end
 
   def test_phr_access
-    assert_equal true, RpmsRpc::DataMapper[:phr_access].parse_scalar("1")
+    result = RpmsRpc::DataMapper[:phr_access].parse_one("1^Patient portal enabled")
+
+    assert_equal true, result[:has_access]
+    assert_equal "Patient portal enabled", result[:message]
   end
 
   # -- Registry completeness -------------------------------------------------
@@ -459,7 +465,7 @@ class RpmsRpc::MappingsTest < Minitest::Test
       immunization_exchange_vxu immunization_exchange_vxq
       immunization_exchange_rsp immunization_exchange_process_result
       immunization_exchange_status
-      phr_access phr_patient_direct phr_provider_direct phr_facility_direct
+      phr_access phr_record_access phr_patient_direct phr_provider_direct phr_facility_direct
       vfc_eligibility vfc_eligibility_list vaccine_lot_list vaccine_lot_detail
       vendor_list vendor_detail preferred_vendor_list vendor_service_list
       vendor_contract_list vendor_rate_list


### PR DESCRIPTION
## Summary
- Add symbolic PHR API for enrollment/access checks, CCD lists, CCD content, counts, referral CCD status, DIRECT addresses, and access recording.
- Re-derive the existing PHR/CCD mappings from the rpms_redux gateway parser shapes.
- Add focused PHR API coverage and update mapping registry expectations.

## Test plan
- bundle exec ruby -Ilib -Itest test/rpms_rpc/api/phr_test.rb
- bundle exec ruby -Ilib -Itest test/rpms_rpc/mappings_test.rb
- bundle exec rake test
- bundle exec rubocop lib/rpms_rpc/api/phr.rb lib/rpms_rpc/mappings.rb test/rpms_rpc/api/phr_test.rb test/rpms_rpc/mappings_test.rb

Made with [Cursor](https://cursor.com)