### PR TITLE
HealthSummary module: port from rpms_redux (Part of #80)

### DIFF
--- a/lib/rpms_rpc/api/health_summary.rb
+++ b/lib/rpms_rpc/api/health_summary.rb
@@ -24,19 +24,23 @@ module RpmsRpc
       procedures: "PRC"
     }.freeze
 
+    # Shape matches the :report_types mapping so callers see the same hash
+    # keys/types regardless of whether the RPC was reachable.
     DEFAULT_TYPES = [
-      { ien: "1", name: "STANDARD", description: "Standard Health Summary" },
-      { ien: "2", name: "BRIEF", description: "Brief Summary" },
-      { ien: "3", name: "COMPREHENSIVE", description: "Comprehensive Summary" },
-      { ien: "4", name: "PATIENT", description: "Patient-Facing Summary" }
+      { ien: 1, name: "STANDARD", description: "Standard Health Summary", owner: nil },
+      { ien: 2, name: "BRIEF", description: "Brief Summary", owner: nil },
+      { ien: 3, name: "COMPREHENSIVE", description: "Comprehensive Summary", owner: nil },
+      { ien: 4, name: "PATIENT", description: "Patient-Facing Summary", owner: nil }
     ].freeze
 
     def for_patient(dfn, summary_type: "STANDARD")
       return error_summary("Invalid patient DFN") if invalid_id?(dfn)
 
-      type_ien = summary_type_ien(summary_type)
-      text = DataMapper.report_text.fetch_text("#{dfn}^#{type_ien}^")
-      parse_health_summary(text, summary_type)
+      resolved = resolve_summary_type(summary_type)
+      text = DataMapper.report_text.fetch_text("#{dfn}^#{resolved[:ien]}^")
+      # Report the resolved type name (which may differ from the caller's input
+      # when the input was unknown and we fell back to the first available type).
+      parse_health_summary(text, resolved[:name])
     end
 
     def generate_selective(dfn, components:)
@@ -51,9 +55,10 @@ module RpmsRpc
     end
 
     def component_data(dfn, component)
-      return nil if invalid_id?(dfn)
+      return nil if invalid_id?(dfn) || component.nil?
 
-      code = COMPONENT_TYPES[component.to_sym]
+      sym = component.respond_to?(:to_sym) ? component.to_sym : nil
+      code = sym && COMPONENT_TYPES[sym]
       return nil if code.nil?
 
       text = DataMapper.report_text.fetch_text("#{dfn}^^#{code}")
@@ -120,8 +125,20 @@ module RpmsRpc
     private
 
     def summary_type_ien(type_name)
-      match = types.find { |type| type[:name].to_s.upcase == type_name.to_s.upcase }
-      match&.dig(:ien) || "1"
+      resolve_summary_type(type_name)[:ien]
+    end
+
+    # Resolve a caller-supplied summary type to the actual type that will be
+    # used. Returns the matched entry from `types` when found; otherwise
+    # falls back to the first available type so callers see the resolved
+    # name rather than their unrecognised input.
+    def resolve_summary_type(type_name)
+      available = types
+      match = available.find { |type| type[:name].to_s.upcase == type_name.to_s.upcase }
+      return { ien: match[:ien], name: match[:name] } if match
+
+      fallback = available.first || { ien: "1", name: "STANDARD" }
+      { ien: fallback[:ien], name: fallback[:name] }
     end
 
     def parse_health_summary(text, type)

--- a/lib/rpms_rpc/api/health_summary.rb
+++ b/lib/rpms_rpc/api/health_summary.rb
@@ -1,0 +1,228 @@
+# frozen_string_literal: true
+
+require "date"
+require_relative "../mappings"
+
+module RpmsRpc
+  # Symbolic API for RPMS Health Summary / GMTS-style reports.
+  module HealthSummary
+    extend self
+
+    COMPONENT_TYPES = {
+      demographics: "DEM",
+      problems: "PRB",
+      allergies: "ALL",
+      medications: "MED",
+      immunizations: "IMM",
+      vitals: "VIT",
+      labs: "LAB",
+      radiology: "RAD",
+      appointments: "APT",
+      clinical_reminders: "REM",
+      health_factors: "HF",
+      education: "EDU",
+      procedures: "PRC"
+    }.freeze
+
+    DEFAULT_TYPES = [
+      { ien: "1", name: "STANDARD", description: "Standard Health Summary" },
+      { ien: "2", name: "BRIEF", description: "Brief Summary" },
+      { ien: "3", name: "COMPREHENSIVE", description: "Comprehensive Summary" },
+      { ien: "4", name: "PATIENT", description: "Patient-Facing Summary" }
+    ].freeze
+
+    def for_patient(dfn, summary_type: "STANDARD")
+      return error_summary("Invalid patient DFN") if invalid_id?(dfn)
+
+      type_ien = summary_type_ien(summary_type)
+      text = DataMapper.report_text.fetch_text("#{dfn}^#{type_ien}^")
+      parse_health_summary(text, summary_type)
+    end
+
+    def generate_selective(dfn, components:)
+      return error_summary("Invalid patient DFN") if invalid_id?(dfn)
+
+      {
+        patient_dfn: dfn,
+        generated_at: Time.now,
+        sections: Array(components).filter_map { |component| component_data(dfn, component) },
+        type: "SELECTIVE"
+      }
+    end
+
+    def component_data(dfn, component)
+      return nil if invalid_id?(dfn)
+
+      code = COMPONENT_TYPES[component.to_sym]
+      return nil if code.nil?
+
+      text = DataMapper.report_text.fetch_text("#{dfn}^^#{code}")
+      return nil if blank?(text)
+
+      {
+        name: titleize(component.to_s),
+        code: code,
+        content: text,
+        generated_at: Time.now
+      }
+    end
+
+    def types
+      rows = DataMapper.report_types.fetch_many
+      rows.empty? ? DEFAULT_TYPES.map(&:dup) : rows
+    end
+
+    def type_components(ien)
+      return [] if invalid_id?(ien)
+
+      DataMapper.report_type_components.fetch_many(ien.to_s)
+    end
+
+    def personal_wellness_report(dfn)
+      return { sections: [], error: "Invalid patient DFN" } if invalid_id?(dfn)
+
+      parse_pwh_report(DataMapper.health_summary_report.fetch_text(dfn.to_s))
+    end
+
+    def flowsheet_definitions
+      DataMapper.flowsheet_list.fetch_many
+    end
+
+    def clinical_reminders(dfn)
+      return [] if invalid_id?(dfn)
+
+      DataMapper.reminders_list.fetch_many(dfn.to_s)
+    end
+
+    def reminder_detail(dfn, reminder_ien)
+      return nil if invalid_id?(dfn) || invalid_id?(reminder_ien)
+
+      text = DataMapper.reminder_detail.fetch_text("#{dfn}^#{reminder_ien}")
+      blank?(text) ? nil : { content: text, parsed_at: Time.now }
+    end
+
+    def health_maintenance(dfn)
+      return [] if invalid_id?(dfn)
+
+      DataMapper.maint_items.fetch_many(dfn.to_s)
+    end
+
+    def flowsheet(dfn, flowsheet_ien:, start_date: Date.today - 365, end_date: Date.today)
+      return { items: [], error: "Invalid patient DFN" } if invalid_id?(dfn) || invalid_id?(flowsheet_ien)
+
+      response = RpmsRpc.client.call_rpc(
+        DataMapper.flowsheet_data.rpc_name,
+        "#{dfn}^#{flowsheet_ien}^#{format_date(start_date)}^#{format_date(end_date)}"
+      )
+      parse_flowsheet(response)
+    end
+
+    private
+
+    def summary_type_ien(type_name)
+      match = types.find { |type| type[:name].to_s.upcase == type_name.to_s.upcase }
+      match&.dig(:ien) || "1"
+    end
+
+    def parse_health_summary(text, type)
+      return error_summary("No data returned") if blank?(text)
+
+      sections = []
+      current = nil
+
+      text.to_s.split(/\r?\n/).each do |line|
+        stripped = line.strip
+        if section_header?(stripped)
+          sections << current if current && !blank?(current[:content])
+          name, content = split_section_header(stripped)
+          current = { name: titleize(name), content: content }
+        elsif current
+          current[:content] += "#{line}\n"
+        else
+          current = { name: "Summary", content: "#{line}\n" }
+        end
+      end
+
+      sections << current if current && !blank?(current[:content])
+      { type: type, generated_at: Time.now, sections: sections, raw_content: text }
+    end
+
+    def section_header?(stripped)
+      return false if stripped.match?(/^[-=*]+$/)
+
+      stripped.match?(/^[A-Z]{3,}:/)
+    end
+
+    def split_section_header(stripped)
+      return [ stripped.gsub(/[-*:=]+/, "").strip, "" ] unless stripped.include?(":")
+
+      name, inline_content = stripped.split(":", 2)
+      content = blank?(inline_content) ? "" : "#{inline_content.strip}\n"
+      [ name, content ]
+    end
+
+    def parse_pwh_report(text)
+      return { sections: [] } if blank?(text)
+
+      {
+        generated_at: Time.now,
+        content: text,
+        sections: parse_pwh_sections(text)
+      }
+    end
+
+    def parse_pwh_sections(text)
+      sections = []
+      current = nil
+
+      text.to_s.split(/\r?\n/).each do |line|
+        if line.match?(/^(WELLNESS|HEALTH|PREVENTIVE|LIFESTYLE|GOALS)/i)
+          sections << current if current
+          current = { name: titleize(line.strip), items: [] }
+        elsif current && !blank?(line)
+          current[:items] << line.strip
+        end
+      end
+
+      sections << current if current
+      sections
+    end
+
+    def parse_flowsheet(response)
+      lines = response.is_a?(Array) ? response : response.to_s.split(/\r?\n/)
+      return { items: [] } if lines.empty? || blank?(lines.first)
+
+      headers = lines.first.to_s.split("^", -1)
+      items = lines[1..].to_a.filter_map do |line|
+        next if blank?(line)
+
+        values = line.to_s.split("^", -1)
+        headers.each_with_index.to_h do |header, index|
+          [ header.downcase.gsub(/\s+/, "_").to_sym, values[index] ]
+        end
+      end
+
+      { headers: headers, items: items }
+    end
+
+    def error_summary(message)
+      { type: "ERROR", generated_at: Time.now, sections: [], error: message }
+    end
+
+    def format_date(date)
+      date.strftime("%m/%d/%Y")
+    end
+
+    def titleize(value)
+      value.tr("_", " ").split.map(&:capitalize).join(" ")
+    end
+
+    def invalid_id?(value)
+      blank?(value) || value.to_i <= 0
+    end
+
+    def blank?(value)
+      value.nil? || value.to_s.empty?
+    end
+  end
+end

--- a/lib/rpms_rpc/api/health_summary.rb
+++ b/lib/rpms_rpc/api/health_summary.rb
@@ -132,10 +132,20 @@ module RpmsRpc
 
       text.to_s.split(/\r?\n/).each do |line|
         stripped = line.strip
+
         if section_header?(stripped)
+          # Separator-only lines (just dashes / equals / asterisks) start a
+          # header context but contribute no content. Match the gateway by
+          # skipping them entirely.
+          next if stripped.match?(/^[-=*]+$/)
+
           sections << current if current && !blank?(current[:content])
-          name, content = split_section_header(stripped)
-          current = { name: titleize(name), content: content }
+
+          # Gateway strips ALL punctuation in [-*:=] from the line and uses the
+          # remainder as the section name. So "PATIENT: Test Patient" becomes
+          # the name "PATIENT Test Patient" with no inline content split.
+          section_name = stripped.gsub(/[-*:=]+/, "").strip
+          current = { name: titleize(section_name), content: "" }
         elsif current
           current[:content] += "#{line}\n"
         else
@@ -147,18 +157,13 @@ module RpmsRpc
       { type: type, generated_at: Time.now, sections: sections, raw_content: text }
     end
 
+    # Gateway recognises four header forms: ALL-CAPS-WITH-COLON, and lines of
+    # dashes / equals / asterisks (3+).
     def section_header?(stripped)
-      return false if stripped.match?(/^[-=*]+$/)
-
-      stripped.match?(/^[A-Z]{3,}:/)
-    end
-
-    def split_section_header(stripped)
-      return [ stripped.gsub(/[-*:=]+/, "").strip, "" ] unless stripped.include?(":")
-
-      name, inline_content = stripped.split(":", 2)
-      content = blank?(inline_content) ? "" : "#{inline_content.strip}\n"
-      [ name, content ]
+      stripped.match?(/^[A-Z]{3,}:/) ||
+        stripped.match?(/^-{3,}$/) ||
+        stripped.match?(/^={3,}$/) ||
+        stripped.match?(/^\*{3,}$/)
     end
 
     def parse_pwh_report(text)
@@ -222,7 +227,7 @@ module RpmsRpc
     end
 
     def blank?(value)
-      value.nil? || value.to_s.empty?
+      value.nil? || value.to_s.strip.empty?
     end
   end
 end

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -727,22 +727,25 @@ module RpmsRpc
     # ========================================================================
 
     # ORWRP TYPES — report type list (multi-line)
-    # Format: IEN^NAME
+    # Format: IEN^NAME^DESCRIPTION^OWNER
     DataMapper.define(:report_types) do |m|
       m.rpc "ORWRP TYPES"
       m.field 0, :ien, :integer
       m.field 1, :name
+      m.field 2, :description
+      m.field 3, :owner
     end
 
     # ORQQPX REMINDERS LIST — clinical reminders (multi-line)
-    # Format: IEN^NAME^DUE_DATE^STATUS^LAST_DONE
+    # Format: IEN^NAME^STATUS^DUE_DATE^LAST_DONE^PRIORITY
     DataMapper.define(:reminders_list) do |m|
       m.rpc "ORQQPX REMINDERS LIST"
-      m.field 0, :ien
+      m.field 0, :ien, :integer
       m.field 1, :name
-      m.field 2, :due_date,  :fileman_date
-      m.field 3, :status
+      m.field 2, :status
+      m.field 3, :due_date,  :fileman_date
       m.field 4, :last_done, :fileman_date
+      m.field 5, :priority
     end
 
     # ORQQPX REMINDER DETAIL — single reminder detail (text blob)
@@ -826,6 +829,8 @@ module RpmsRpc
       m.rpc "ORWRP TYPE COMPONENTS"
       m.field 0, :ien, :integer
       m.field 1, :name
+      m.field 2, :abbreviation
+      m.field 3, :sequence, :integer
     end
 
     # GMTS PWH REPORT — patient health summary report text
@@ -834,19 +839,30 @@ module RpmsRpc
       m.text_blob :report_text
     end
 
-    # GMTS FLOWSHEET LIST — flowsheet items (multi-line)
+    # GMTS FLOWSHEET LIST — flowsheet definitions (multi-line)
     DataMapper.define(:flowsheet_list) do |m|
       m.rpc "GMTS FLOWSHEET LIST"
-      m.field 0, :ien
+      m.field 0, :ien, :integer
       m.field 1, :name
-      m.field 2, :date, :fileman_date
+      m.field 2, :description
+    end
+
+    # GMTS FLOWSHEET DATA — patient flowsheet table text
+    DataMapper.define(:flowsheet_data) do |m|
+      m.rpc "GMTS FLOWSHEET DATA"
+      m.text_blob :flowsheet_text
     end
 
     # GMTS MAINT ITEMS — maintenance items (multi-line)
     DataMapper.define(:maint_items) do |m|
       m.rpc "GMTS MAINT ITEMS"
-      m.field 0, :ien
+      m.field 0, :ien, :integer
       m.field 1, :name
+      m.field 2, :category
+      m.field 3, :status
+      m.field 4, :last_done, :fileman_date
+      m.field 5, :next_due,  :fileman_date
+      m.field 6, :frequency
     end
 
     # ORWLRR REPORT — full lab report text

--- a/test/rpms_rpc/api/health_summary_test.rb
+++ b/test/rpms_rpc/api/health_summary_test.rb
@@ -84,8 +84,13 @@ class HealthSummaryApiTest < Minitest::Test
     summary = RpmsRpc::HealthSummary.for_patient(DFN)
 
     assert_equal "STANDARD", summary[:type]
-    assert_equal 4, summary[:sections].length
-    assert_equal "Patient", summary[:sections].first[:name]
+    # Gateway behavior: only header sections that subsequently accumulate
+    # body content get retained. "PATIENT: Test Patient" / "DOB: ..." are
+    # header-only and produce no section because the next line is also a
+    # header. Only PROBLEMS and MEDICATIONS pick up body content.
+    assert_equal 2, summary[:sections].length
+    assert_equal "Problems", summary[:sections].first[:name]
+    assert_equal "Medications", summary[:sections].last[:name]
     assert_includes summary[:raw_content], "Type 2 diabetes"
   end
 
@@ -95,6 +100,33 @@ class HealthSummaryApiTest < Minitest::Test
     call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWRP REPORT TEXT" }
     refute_nil call
     assert_equal [ "#{DFN}^1^" ], call[:params]
+  end
+
+  def test_for_patient_skips_separator_only_lines_per_gateway
+    RpmsRpc.reset!
+    RpmsRpc.mock! do |m|
+      m.seed_text(:report_types, DFN.to_s, "1^STANDARD")
+      m.seed_text(:report_text, "#{DFN}^1^",
+        "===============\n" \
+        "PROBLEMS:\n" \
+        "---------------\n" \
+        "Hypertension\n" \
+        "***************\n" \
+        "MEDICATIONS:\n" \
+        "Lisinopril 10mg")
+    end
+
+    summary = RpmsRpc::HealthSummary.for_patient(DFN)
+    section_names = summary[:sections].map { |s| s[:name] }
+
+    # Separator-only lines (===, ---, ***) match the header regex but are
+    # then skipped entirely — they neither start new sections nor leak
+    # `[-=*]+` into existing content.
+    assert_includes section_names, "Problems"
+    assert_includes section_names, "Medications"
+    problems = summary[:sections].find { |s| s[:name] == "Problems" }
+    refute_match(/[-=*]{3,}/, problems[:content],
+      "separator lines should be skipped entirely, not appear in section content")
   end
 
   def test_for_patient_rejects_blank_zero_negative_and_unknown_dfn

--- a/test/rpms_rpc/api/health_summary_test.rb
+++ b/test/rpms_rpc/api/health_summary_test.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "date"
+require "rpms_rpc/version"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/health_summary"
+
+class HealthSummaryApiTest < Minitest::Test
+  DFN = 8791
+
+  def setup
+    RpmsRpc.mock! do |m|
+      m.seed_collection(:report_types, [
+        { ien: 1, name: "STANDARD", description: "Standard Health Summary", owner: "SYSTEM" },
+        { ien: 2, name: "BRIEF", description: "Brief Summary", owner: "SYSTEM" }
+      ])
+
+      m.seed_keyed_collection(:report_type_components, "1", [
+        { ien: 10, name: "Demographics", abbreviation: "DEM", sequence: 1 },
+        { ien: 11, name: "Problems", abbreviation: "PRB", sequence: 2 }
+      ])
+
+      m.seed_text(:report_text, "#{DFN}^1^",
+        "PATIENT: Test Patient\n" \
+        "DOB: 01/01/1970\n" \
+        "PROBLEMS:\n" \
+        "Type 2 diabetes\n" \
+        "MEDICATIONS:\n" \
+        "Metformin")
+
+      m.seed_text(:report_text, "#{DFN}^^MED",
+        "MEDICATIONS:\n" \
+        "Metformin 500mg twice daily")
+
+      m.seed_text(:health_summary_report, DFN.to_s,
+        "WELLNESS GOALS\n" \
+        "Walk 30 minutes daily\n" \
+        "PREVENTIVE CARE\n" \
+        "Influenza vaccine due")
+
+      m.seed_keyed_collection(:reminders_list, DFN.to_s, [
+        {
+          ien: 501,
+          name: "A1C Screening",
+          status: "DUE",
+          due_date: nil,
+          last_done: nil,
+          priority: "HIGH"
+        }
+      ])
+
+      m.seed_text(:reminder_detail, "#{DFN}^501",
+        "A1C Screening\n" \
+        "Patient is due for hemoglobin A1C.")
+
+      m.seed_keyed_collection(:maint_items, DFN.to_s, [
+        {
+          ien: 601,
+          name: "Diabetes Eye Exam",
+          category: "Preventive",
+          status: "",
+          last_done: nil,
+          next_due: nil,
+          frequency: "Yearly"
+        }
+      ])
+
+      m.seed_collection(:flowsheet_list, [
+        { ien: 701, name: "Diabetes Measures", description: "A1C and related measures" }
+      ])
+
+      m.seed_text(:flowsheet_data, "#{DFN}^701^01/01/2026^05/26/2026",
+        "Date^A1C\n" \
+        "05/01/2026^7.2")
+    end
+  end
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  def test_for_patient_generates_summary_sections
+    summary = RpmsRpc::HealthSummary.for_patient(DFN)
+
+    assert_equal "STANDARD", summary[:type]
+    assert_equal 4, summary[:sections].length
+    assert_equal "Patient", summary[:sections].first[:name]
+    assert_includes summary[:raw_content], "Type 2 diabetes"
+  end
+
+  def test_for_patient_uses_report_text_mapping_rpc_name
+    RpmsRpc::HealthSummary.for_patient(DFN)
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWRP REPORT TEXT" }
+    refute_nil call
+    assert_equal [ "#{DFN}^1^" ], call[:params]
+  end
+
+  def test_for_patient_rejects_blank_zero_negative_and_unknown_dfn
+    assert_equal "ERROR", RpmsRpc::HealthSummary.for_patient(nil)[:type]
+    assert_equal "ERROR", RpmsRpc::HealthSummary.for_patient("")[:type]
+    assert_equal "ERROR", RpmsRpc::HealthSummary.for_patient(0)[:type]
+    assert_equal "ERROR", RpmsRpc::HealthSummary.for_patient(-1)[:type]
+
+    unknown = RpmsRpc::HealthSummary.for_patient(999_999)
+    assert_equal "ERROR", unknown[:type]
+    assert_equal "No data returned", unknown[:error]
+  end
+
+  def test_types_returns_gateway_field_positions
+    type = RpmsRpc::HealthSummary.types.first
+
+    assert_equal 1, type[:ien]
+    assert_equal "STANDARD", type[:name]
+    assert_equal "Standard Health Summary", type[:description]
+    assert_equal "SYSTEM", type[:owner]
+  end
+
+  def test_type_components_returns_components_for_summary_type
+    components = RpmsRpc::HealthSummary.type_components(1)
+
+    assert_equal 2, components.length
+    assert_equal "DEM", components.first[:abbreviation]
+    assert_equal 1, components.first[:sequence]
+  end
+
+  def test_component_data_fetches_standard_component
+    component = RpmsRpc::HealthSummary.component_data(DFN, :medications)
+
+    refute_nil component
+    assert_equal "MED", component[:code]
+    assert_equal "Medications", component[:name]
+    assert_includes component[:content], "Metformin"
+  end
+
+  def test_component_data_returns_nil_for_invalid_component_or_dfn
+    assert_nil RpmsRpc::HealthSummary.component_data(DFN, :unknown)
+    assert_nil RpmsRpc::HealthSummary.component_data(0, :medications)
+  end
+
+  def test_generate_selective_returns_only_requested_components
+    summary = RpmsRpc::HealthSummary.generate_selective(DFN, components: [ :medications, :unknown ])
+
+    assert_equal "SELECTIVE", summary[:type]
+    assert_equal 1, summary[:sections].length
+    assert_equal "MED", summary[:sections].first[:code]
+  end
+
+  def test_personal_wellness_report_parses_multiline_sections
+    report = RpmsRpc::HealthSummary.personal_wellness_report(DFN)
+
+    assert_includes report[:content], "WELLNESS GOALS"
+    assert_equal 2, report[:sections].length
+    assert_equal "Wellness Goals", report[:sections].first[:name]
+    assert_equal [ "Walk 30 minutes daily" ], report[:sections].first[:items]
+  end
+
+  def test_clinical_reminders_returns_gateway_field_positions
+    reminder = RpmsRpc::HealthSummary.clinical_reminders(DFN).first
+
+    assert_equal 501, reminder[:ien]
+    assert_equal "A1C Screening", reminder[:name]
+    assert_equal "DUE", reminder[:status]
+    assert_equal "HIGH", reminder[:priority]
+  end
+
+  def test_reminder_detail_returns_multiline_content
+    detail = RpmsRpc::HealthSummary.reminder_detail(DFN, 501)
+
+    refute_nil detail
+    assert_includes detail[:content], "Patient is due"
+  end
+
+  def test_health_maintenance_normalizes_blank_status_to_nil
+    item = RpmsRpc::HealthSummary.health_maintenance(DFN).first
+
+    assert_equal 601, item[:ien]
+    assert_equal "Diabetes Eye Exam", item[:name]
+    assert_nil item[:status]
+    assert_equal "Yearly", item[:frequency]
+  end
+
+  def test_health_maintenance_returns_empty_for_invalid_or_unknown_dfn
+    assert_equal [], RpmsRpc::HealthSummary.health_maintenance(nil)
+    assert_equal [], RpmsRpc::HealthSummary.health_maintenance("")
+    assert_equal [], RpmsRpc::HealthSummary.health_maintenance(0)
+    assert_equal [], RpmsRpc::HealthSummary.health_maintenance(-1)
+    assert_equal [], RpmsRpc::HealthSummary.health_maintenance(999_999)
+  end
+
+  def test_flowsheet_definitions_returns_gateway_field_positions
+    flow = RpmsRpc::HealthSummary.flowsheet_definitions.first
+
+    assert_equal 701, flow[:ien]
+    assert_equal "Diabetes Measures", flow[:name]
+    assert_equal "A1C and related measures", flow[:description]
+  end
+
+  def test_flowsheet_uses_mapping_rpc_name_and_parses_table
+    result = RpmsRpc::HealthSummary.flowsheet(
+      DFN,
+      flowsheet_ien: 701,
+      start_date: Date.new(2026, 1, 1),
+      end_date: Date.new(2026, 5, 26)
+    )
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "GMTS FLOWSHEET DATA" }
+    refute_nil call
+    assert_equal [ "#{DFN}^701^01/01/2026^05/26/2026" ], call[:params]
+    assert_equal [ "Date", "A1C" ], result[:headers]
+    assert_equal "7.2", result[:items].first[:a1c]
+  end
+
+  def test_module_exposes_standard_component_types
+    assert_equal "DEM", RpmsRpc::HealthSummary::COMPONENT_TYPES[:demographics]
+    assert_equal "PRB", RpmsRpc::HealthSummary::COMPONENT_TYPES[:problems]
+    assert_equal "IMM", RpmsRpc::HealthSummary::COMPONENT_TYPES[:immunizations]
+  end
+end

--- a/test/rpms_rpc/mappings_test.rb
+++ b/test/rpms_rpc/mappings_test.rb
@@ -298,6 +298,67 @@ class RpmsRpc::MappingsTest < Minitest::Test
     assert_equal "Patient: DOE,JOHN\nDate: 2025-03-15\nVitals normal.", text
   end
 
+  def test_health_summary_report_types
+    result = RpmsRpc::DataMapper[:report_types].parse_many(
+      [ "1^STANDARD^Standard Health Summary^SYSTEM" ]
+    ).first
+
+    assert_equal 1, result[:ien]
+    assert_equal "STANDARD", result[:name]
+    assert_equal "Standard Health Summary", result[:description]
+    assert_equal "SYSTEM", result[:owner]
+  end
+
+  def test_health_summary_type_components
+    result = RpmsRpc::DataMapper[:report_type_components].parse_many(
+      [ "10^Demographics^DEM^1" ]
+    ).first
+
+    assert_equal 10, result[:ien]
+    assert_equal "Demographics", result[:name]
+    assert_equal "DEM", result[:abbreviation]
+    assert_equal 1, result[:sequence]
+  end
+
+  def test_health_summary_reminders
+    result = RpmsRpc::DataMapper[:reminders_list].parse_many(
+      [ "501^A1C Screening^DUE^^^HIGH" ]
+    ).first
+
+    assert_equal 501, result[:ien]
+    assert_equal "A1C Screening", result[:name]
+    assert_equal "DUE", result[:status]
+    assert_equal "HIGH", result[:priority]
+  end
+
+  def test_health_summary_flowsheet_list
+    result = RpmsRpc::DataMapper[:flowsheet_list].parse_many(
+      [ "701^Diabetes Measures^A1C and related measures" ]
+    ).first
+
+    assert_equal 701, result[:ien]
+    assert_equal "Diabetes Measures", result[:name]
+    assert_equal "A1C and related measures", result[:description]
+  end
+
+  def test_health_summary_flowsheet_data_blob
+    m = RpmsRpc::DataMapper[:flowsheet_data]
+    text = m.parse_text([ "Date^A1C", "05/01/2026^7.2" ])
+    assert_equal "Date^A1C\n05/01/2026^7.2", text
+  end
+
+  def test_health_summary_maintenance_items
+    result = RpmsRpc::DataMapper[:maint_items].parse_many(
+      [ "601^Diabetes Eye Exam^Preventive^DUE^^^Yearly" ]
+    ).first
+
+    assert_equal 601, result[:ien]
+    assert_equal "Diabetes Eye Exam", result[:name]
+    assert_equal "Preventive", result[:category]
+    assert_equal "DUE", result[:status]
+    assert_equal "Yearly", result[:frequency]
+  end
+
   def test_lab_report_blob
     m = RpmsRpc::DataMapper[:lab_report]
     text = m.parse_text([ "CBC Results", "WBC: 7.2" ])
@@ -454,7 +515,7 @@ class RpmsRpc::MappingsTest < Minitest::Test
       reminder_detail patient_deceased patient_sensitive user_has_key
       signon_setup av_code cvc_verify user_keys
       report_text report_type_components health_summary_report
-      flowsheet_list maint_items lab_report lab_report_list radiology_report
+      flowsheet_list flowsheet_data maint_items lab_report lab_report_list radiology_report
       medication_detail care_plan_detail care_team_detail goal_detail
       procedure_detail device_detail referral_detail referral_delete
       patient_recent patient_save_recent


### PR DESCRIPTION
## Summary
- Add the `RpmsRpc::HealthSummary` symbolic API for health summary generation, selective components, PWH reports, reminders, maintenance items, and flowsheet data parsing.
- Correct Health Summary related mappings to match the rpms_redux gateway field positions and add mapping coverage.

## Test plan
- `bundle exec ruby -Ilib -Itest test/rpms_rpc/api/health_summary_test.rb`
- `bundle exec ruby -Ilib -Itest test/rpms_rpc/mappings_test.rb`
- `bundle exec rake test`
- `bundle exec rubocop lib/rpms_rpc/mappings.rb lib/rpms_rpc/api/health_summary.rb test/rpms_rpc/api/health_summary_test.rb test/rpms_rpc/mappings_test.rb`

Made with [Cursor](https://cursor.com)