### PR TITLE
ChsBudget module: port from rpms_redux (Part of #80)

### DIFF
--- a/lib/rpms_rpc/api/chs_budget.rb
+++ b/lib/rpms_rpc/api/chs_budget.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+require "bigdecimal"
+require "date"
+require "time"
+
+module RpmsRpc
+  # Symbolic API for Contract Health Services / Purchased Referred Care budget data.
+  module ChsBudget
+    extend self
+
+    def fiscal_year_budget(fiscal_year: nil)
+      fy = fiscal_year || current_fiscal_year
+      row = DataMapper.chs_budget.fetch_one(fy)
+
+      apply_budget_defaults(row, fy)
+    end
+
+    def remaining_funds(fiscal_year: nil)
+      fy = fiscal_year || current_fiscal_year
+      row = DataMapper.chs_remaining_funds.fetch_one(fy)
+
+      apply_funds_defaults(row)
+    end
+
+    def quarterly_allocation(quarter: nil, fiscal_year: nil)
+      qtr = quarter || current_quarter
+      fy = fiscal_year || current_fiscal_year
+      row = DataMapper.chs_quarterly_allocation.fetch_one(fy, qtr)
+
+      apply_quarterly_defaults(row, qtr)
+    end
+
+    def obligations(status: nil, fiscal_year: nil)
+      fy = fiscal_year || current_fiscal_year
+      rows = DataMapper.chs_obligation_list.fetch_many(fy, status)
+      rows = rows.select { |obligation| obligation[:status] == status } unless blank?(status)
+
+      rows
+    end
+
+    def find(ien)
+      return nil if invalid_id?(ien)
+
+      DataMapper.chs_obligation_detail.fetch_one(ien.to_s)
+    end
+
+    def by_referral(referral_ien)
+      return nil if invalid_id?(referral_ien)
+
+      DataMapper.chs_obligation_by_referral.fetch_one(referral_ien.to_s)
+    end
+
+    def payments(obligation_id:)
+      return [] if blank?(obligation_id)
+
+      DataMapper.chs_payment_list.fetch_many(obligation_id.to_s)
+    end
+
+    def outstanding_obligations(fiscal_year: nil)
+      obligations(fiscal_year: fiscal_year).select { |o| %w[PENDING PARTIAL].include?(o[:status]) }.map do |obligation|
+        paid = payments(obligation_id: obligation[:id]).sum { |payment| decimal(payment[:amount]) }
+        amount = decimal(obligation[:amount])
+
+        obligation.merge(amount_paid: paid, amount_due: (amount - paid).round(2))
+      end
+    end
+
+    def obligation_summary(fiscal_year: nil)
+      fy = fiscal_year || current_fiscal_year
+      rows = obligations(fiscal_year: fy)
+      total_obligated = rows.sum { |obligation| decimal(obligation[:amount]) }
+      total_paid = rows.sum do |obligation|
+        payments(obligation_id: obligation[:id]).sum { |payment| decimal(payment[:amount]) }
+      end
+
+      {
+        total_obligated: total_obligated,
+        total_paid: total_paid,
+        total_outstanding: total_obligated - total_paid,
+        by_status: summarize_by_status(rows),
+        fiscal_year: fy
+      }
+    end
+
+    def budget_summary
+      budget = fiscal_year_budget
+      funds = remaining_funds
+      quarters = %w[Q1 Q2 Q3 Q4].to_h { |qtr| [ qtr, quarterly_allocation(quarter: qtr) ] }
+      total_budget = decimal(budget[:total_budget])
+      remaining = decimal(funds[:remaining])
+
+      {
+        fiscal_year: budget[:fiscal_year],
+        total_budget: total_budget,
+        obligated: decimal(funds[:obligated]),
+        expended: decimal(funds[:expended]),
+        remaining: remaining,
+        percent_remaining: total_budget.positive? ? ((remaining / total_budget) * 100).round(2) : BigDecimal("0"),
+        quarters: quarters,
+        as_of: Time.now
+      }
+    end
+
+    def low_funds?(threshold: 0.20)
+      budget = fiscal_year_budget
+      total = decimal(budget[:total_budget])
+      return false unless total.positive?
+
+      (decimal(remaining_funds[:remaining]) / total) < threshold
+    end
+
+    def current_fiscal_year
+      today = Date.today
+      today.month >= 10 ? "FY#{today.year + 1}" : "FY#{today.year}"
+    end
+
+    def current_quarter
+      case Date.today.month
+      when 10, 11, 12 then "Q1"
+      when 1, 2, 3 then "Q2"
+      when 4, 5, 6 then "Q3"
+      when 7, 8, 9 then "Q4"
+      end
+    end
+
+    private
+
+    def apply_budget_defaults(row, fiscal_year)
+      row ||= {}
+      row.merge(
+        fiscal_year: blank?(row[:fiscal_year]) ? fiscal_year : row[:fiscal_year],
+        total_budget: decimal(row[:total_budget])
+      )
+    end
+
+    def apply_funds_defaults(row)
+      row ||= {}
+      {
+        remaining: decimal(row[:remaining]),
+        obligated: decimal(row[:obligated]),
+        expended: decimal(row[:expended])
+      }
+    end
+
+    def apply_quarterly_defaults(row, quarter)
+      row ||= {}
+      {
+        quarter: blank?(row[:quarter]) ? quarter : row[:quarter],
+        allocated: decimal(row[:allocated]),
+        spent: decimal(row[:spent]),
+        remaining: decimal(row[:remaining])
+      }
+    end
+
+    def summarize_by_status(rows)
+      rows.group_by { |obligation| obligation[:status] }.transform_values do |status_rows|
+        {
+          count: status_rows.size,
+          total: status_rows.sum { |obligation| decimal(obligation[:amount]) }
+        }
+      end
+    end
+
+    def decimal(value)
+      return BigDecimal("0") if blank?(value)
+
+      BigDecimal(value.to_s)
+    rescue ArgumentError
+      BigDecimal("0")
+    end
+
+    def invalid_id?(value)
+      blank?(value) || value.to_i <= 0
+    end
+
+    def blank?(value)
+      value.nil? || value.to_s.empty?
+    end
+  end
+end

--- a/lib/rpms_rpc/api/chs_budget.rb
+++ b/lib/rpms_rpc/api/chs_budget.rb
@@ -33,7 +33,11 @@ module RpmsRpc
 
     def obligations(status: nil, fiscal_year: nil)
       fy = fiscal_year || current_fiscal_year
-      rows = DataMapper.chs_obligation_list.fetch_many(fy, status)
+      # Pass status only when present — sending a trailing empty param
+      # changes the RPC signature on some sites where BMCRPC GTOBLIG
+      # treats argument arity as significant.
+      params = blank?(status) ? [ fy ] : [ fy, status ]
+      rows = DataMapper.chs_obligation_list.fetch_many(*params)
       rows = rows.select { |obligation| obligation[:status] == status } unless blank?(status)
 
       rows
@@ -131,10 +135,14 @@ module RpmsRpc
 
     def apply_budget_defaults(row, fiscal_year)
       row ||= {}
-      row.merge(
+      # Always present the full shape so callers see stable keys even when
+      # the RPC returned nil/empty for an unknown fiscal year.
+      {
         fiscal_year: blank?(row[:fiscal_year]) ? fiscal_year : row[:fiscal_year],
-        total_budget: decimal(row[:total_budget])
-      )
+        total_budget: decimal(row[:total_budget]),
+        start_date: row[:start_date],
+        end_date: row[:end_date]
+      }
     end
 
     def apply_funds_defaults(row)

--- a/lib/rpms_rpc/api/chs_budget.rb
+++ b/lib/rpms_rpc/api/chs_budget.rb
@@ -46,7 +46,10 @@ module RpmsRpc
     end
 
     def by_referral(referral_ien)
-      return nil if invalid_id?(referral_ien)
+      # Referral IDs are opaque tokens (e.g. "REF-001"), not numeric IENs —
+      # the `to_i <= 0` guard would reject legitimate values. Only reject
+      # truly blank input.
+      return nil if blank?(referral_ien)
 
       DataMapper.chs_obligation_by_referral.fetch_one(referral_ien.to_s)
     end
@@ -175,7 +178,7 @@ module RpmsRpc
     end
 
     def blank?(value)
-      value.nil? || value.to_s.empty?
+      value.nil? || value.to_s.strip.empty?
     end
   end
 end

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -606,8 +606,12 @@ module RpmsRpc
     DataMapper.define(:chs_obligation_list) do |m|
       m.rpc "BMCRPC GTOBLIG"
       m.field 0, :id
-      m.field 1, :referral_ien, :integer
-      m.field 2, :patient_dfn,  :integer
+      # :referral_ien and :patient_dfn are opaque string identifiers (the
+      # CHS mock fixtures use "REF-001" style tokens, and the rpms_redux
+      # gateway calls pick_string on these fields). Coercing to integer
+      # would turn legitimate values into 0.
+      m.field 1, :referral_ien
+      m.field 2, :patient_dfn
       m.field 3, :amount
       m.field 4, :status
       m.field 5, :service_type
@@ -619,8 +623,12 @@ module RpmsRpc
     DataMapper.define(:chs_obligation_detail) do |m|
       m.rpc "BMCRPC GTOBLIGID"
       m.field 0, :id
-      m.field 1, :referral_ien, :integer
-      m.field 2, :patient_dfn,  :integer
+      # :referral_ien and :patient_dfn are opaque string identifiers (the
+      # CHS mock fixtures use "REF-001" style tokens, and the rpms_redux
+      # gateway calls pick_string on these fields). Coercing to integer
+      # would turn legitimate values into 0.
+      m.field 1, :referral_ien
+      m.field 2, :patient_dfn
       m.field 3, :amount
       m.field 4, :amount_paid
       m.field 5, :status
@@ -634,8 +642,12 @@ module RpmsRpc
     DataMapper.define(:chs_obligation_by_referral) do |m|
       m.rpc "BMCRPC GTREFOBLIG"
       m.field 0, :id
-      m.field 1, :referral_ien, :integer
-      m.field 2, :patient_dfn,  :integer
+      # :referral_ien and :patient_dfn are opaque string identifiers (the
+      # CHS mock fixtures use "REF-001" style tokens, and the rpms_redux
+      # gateway calls pick_string on these fields). Coercing to integer
+      # would turn legitimate values into 0.
+      m.field 1, :referral_ien
+      m.field 2, :patient_dfn
       m.field 3, :amount
       m.field 4, :amount_paid
       m.field 5, :status

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -572,6 +572,92 @@ module RpmsRpc
       m.field 3, :effective_date, :fileman_date
     end
 
+    # BMCRPC GTBUDGET — CHS/PRC budget allocation by fiscal year
+    # Format: FISCAL_YEAR^TOTAL_BUDGET^START_DATE^END_DATE
+    DataMapper.define(:chs_budget) do |m|
+      m.rpc "BMCRPC GTBUDGET"
+      m.field 0, :fiscal_year
+      m.field 1, :total_budget
+      m.field 2, :start_date, :fileman_date
+      m.field 3, :end_date,   :fileman_date
+    end
+
+    # BMCRPC GTREMAIN — remaining CHS/PRC funds for a fiscal year
+    # Format: REMAINING^OBLIGATED^EXPENDED
+    DataMapper.define(:chs_remaining_funds) do |m|
+      m.rpc "BMCRPC GTREMAIN"
+      m.field 0, :remaining
+      m.field 1, :obligated
+      m.field 2, :expended
+    end
+
+    # BMCRPC GTQTRALLOC — quarterly CHS/PRC allocation
+    # Format: QUARTER^ALLOCATED^SPENT^REMAINING
+    DataMapper.define(:chs_quarterly_allocation) do |m|
+      m.rpc "BMCRPC GTQTRALLOC"
+      m.field 0, :quarter
+      m.field 1, :allocated
+      m.field 2, :spent
+      m.field 3, :remaining
+    end
+
+    # BMCRPC GTOBLIG — CHS/PRC obligation list
+    # Format: ID^REFERRAL_IEN^PATIENT_DFN^AMOUNT^STATUS^SERVICE_TYPE^CREATED_DATE
+    DataMapper.define(:chs_obligation_list) do |m|
+      m.rpc "BMCRPC GTOBLIG"
+      m.field 0, :id
+      m.field 1, :referral_ien, :integer
+      m.field 2, :patient_dfn,  :integer
+      m.field 3, :amount
+      m.field 4, :status
+      m.field 5, :service_type
+      m.field 6, :created_date, :fileman_date
+    end
+
+    # BMCRPC GTOBLIGID — single CHS/PRC obligation
+    # Format: ID^REFERRAL_IEN^PATIENT_DFN^AMOUNT^AMOUNT_PAID^STATUS^SERVICE_TYPE^VENDOR_ID^CREATED_DATE^PAID_DATE
+    DataMapper.define(:chs_obligation_detail) do |m|
+      m.rpc "BMCRPC GTOBLIGID"
+      m.field 0, :id
+      m.field 1, :referral_ien, :integer
+      m.field 2, :patient_dfn,  :integer
+      m.field 3, :amount
+      m.field 4, :amount_paid
+      m.field 5, :status
+      m.field 6, :service_type
+      m.field 7, :vendor_id
+      m.field 8, :created_date, :fileman_date
+      m.field 9, :paid_date,    :fileman_date
+    end
+
+    # BMCRPC GTREFOBLIG — single CHS/PRC obligation by referral IEN
+    DataMapper.define(:chs_obligation_by_referral) do |m|
+      m.rpc "BMCRPC GTREFOBLIG"
+      m.field 0, :id
+      m.field 1, :referral_ien, :integer
+      m.field 2, :patient_dfn,  :integer
+      m.field 3, :amount
+      m.field 4, :amount_paid
+      m.field 5, :status
+      m.field 6, :service_type
+      m.field 7, :vendor_id
+      m.field 8, :created_date, :fileman_date
+      m.field 9, :paid_date,    :fileman_date
+    end
+
+    # BMCRPC GTPAYMENT — payments against a CHS/PRC obligation
+    # Format: ID^OBLIGATION_ID^AMOUNT^PAYMENT_DATE^CHECK_NUMBER^VENDOR_ID^CREATED_DATE
+    DataMapper.define(:chs_payment_list) do |m|
+      m.rpc "BMCRPC GTPAYMENT"
+      m.field 0, :id
+      m.field 1, :obligation_id
+      m.field 2, :amount
+      m.field 3, :payment_date, :fileman_date
+      m.field 4, :check_number
+      m.field 5, :vendor_id
+      m.field 6, :created_date, :fileman_date
+    end
+
     # ========================================================================
     # AUTHENTICATION (XUS*)
     # ========================================================================

--- a/test/rpms_rpc/api/chs_budget_test.rb
+++ b/test/rpms_rpc/api/chs_budget_test.rb
@@ -9,14 +9,20 @@ require "rpms_rpc/api/chs_budget"
 
 class ChsBudgetTest < Minitest::Test
   FY = RpmsRpc::ChsBudget.current_fiscal_year
+  # Derive FY date bounds from the dynamic FY string so the test stays
+  # green across fiscal-year rollovers. FY runs Oct 1 (prior calendar year)
+  # through Sep 30 (FY year).
+  FY_YEAR  = FY.delete_prefix("FY").to_i
+  FY_START = Date.new(FY_YEAR - 1, 10, 1)
+  FY_END   = Date.new(FY_YEAR, 9, 30)
 
   def setup
     RpmsRpc.mock! do |m|
       m.seed(:chs_budget, FY, {
         fiscal_year: FY,
         total_budget: "1000000.00",
-        start_date: Date.new(2025, 10, 1),
-        end_date: Date.new(2026, 9, 30)
+        start_date: FY_START,
+        end_date: FY_END
       })
 
       m.seed(:chs_remaining_funds, FY, {
@@ -137,8 +143,8 @@ class ChsBudgetTest < Minitest::Test
 
     assert_equal FY, budget[:fiscal_year]
     assert_equal BigDecimal("1000000.00"), budget[:total_budget]
-    assert_equal Date.new(2025, 10, 1), budget[:start_date]
-    assert_equal Date.new(2026, 9, 30), budget[:end_date]
+    assert_equal FY_START, budget[:start_date]
+    assert_equal FY_END, budget[:end_date]
   end
 
   def test_fiscal_year_budget_defaults_unknown_or_blank_response

--- a/test/rpms_rpc/api/chs_budget_test.rb
+++ b/test/rpms_rpc/api/chs_budget_test.rb
@@ -1,0 +1,282 @@
+# frozen_string_literal: true
+
+require "bigdecimal"
+require "date"
+require "minitest/autorun"
+require "rpms_rpc/version"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/chs_budget"
+
+class ChsBudgetTest < Minitest::Test
+  FY = RpmsRpc::ChsBudget.current_fiscal_year
+
+  def setup
+    RpmsRpc.mock! do |m|
+      m.seed(:chs_budget, FY, {
+        fiscal_year: FY,
+        total_budget: "1000000.00",
+        start_date: Date.new(2025, 10, 1),
+        end_date: Date.new(2026, 9, 30)
+      })
+
+      m.seed(:chs_remaining_funds, FY, {
+        remaining: "750000.00",
+        obligated: "200000.00",
+        expended: "50000.00"
+      })
+
+      %w[Q1 Q2 Q3 Q4].each_with_index do |quarter, index|
+        m.seed(:chs_quarterly_allocation, "#{FY}:#{quarter}", {
+          quarter: quarter,
+          allocated: "250000.00",
+          spent: (50_000 + (index * 10_000)).to_s,
+          remaining: (200_000 - (index * 10_000)).to_s
+        })
+      end
+
+      # Also seed the keys used by the production call shape: fiscal year first.
+      m.seed(:chs_quarterly_allocation, FY, {
+        quarter: "Q1",
+        allocated: "250000.00",
+        spent: "50000.00",
+        remaining: "200000.00"
+      })
+
+      m.seed_keyed_collection(:chs_obligation_list, FY, [
+        {
+          id: "101",
+          referral_ien: 501,
+          patient_dfn: 8791,
+          amount: "15000.00",
+          status: "PENDING",
+          service_type: "Specialty Care",
+          created_date: Date.new(2026, 1, 15)
+        },
+        {
+          id: "102",
+          referral_ien: 502,
+          patient_dfn: 8792,
+          amount: "25000.00",
+          status: "PAID",
+          service_type: "Surgery",
+          created_date: Date.new(2026, 1, 20)
+        }
+      ])
+
+      m.seed(:chs_obligation_detail, "101", {
+        id: "101",
+        referral_ien: 501,
+        patient_dfn: 8791,
+        amount: "15000.00",
+        amount_paid: "5000.00",
+        status: "PARTIAL",
+        service_type: "Specialty Care",
+        vendor_id: "701",
+        created_date: Date.new(2026, 1, 15)
+      })
+
+      m.seed(:chs_obligation_by_referral, "501", {
+        id: "101",
+        referral_ien: 501,
+        patient_dfn: 8791,
+        amount: "15000.00",
+        amount_paid: "5000.00",
+        status: "PARTIAL",
+        service_type: "Specialty Care",
+        vendor_id: "701",
+        created_date: Date.new(2026, 1, 15)
+      })
+
+      m.seed_keyed_collection(:chs_payment_list, "101", [
+        {
+          id: "301",
+          obligation_id: "101",
+          amount: "5000.00",
+          payment_date: Date.new(2026, 2, 1),
+          check_number: "CHK-12345",
+          vendor_id: "701",
+          created_date: Date.new(2026, 2, 1)
+        },
+        {
+          id: "302",
+          obligation_id: "101",
+          amount: "2500.00",
+          payment_date: Date.new(2026, 2, 15),
+          check_number: "CHK-12346",
+          vendor_id: "701",
+          created_date: Date.new(2026, 2, 15)
+        }
+      ])
+
+      m.seed(:chs_budget, "FY_BLANK", {
+        fiscal_year: nil,
+        total_budget: nil,
+        start_date: nil,
+        end_date: nil
+      })
+      m.seed(:chs_remaining_funds, "FY_BLANK", {
+        remaining: nil,
+        obligated: nil,
+        expended: nil
+      })
+      m.seed(:chs_quarterly_allocation, "FY_BLANK", {
+        quarter: nil,
+        allocated: nil,
+        spent: nil,
+        remaining: nil
+      })
+    end
+  end
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  def test_fiscal_year_budget_returns_budget_allocation
+    budget = RpmsRpc::ChsBudget.fiscal_year_budget(fiscal_year: FY)
+
+    assert_equal FY, budget[:fiscal_year]
+    assert_equal BigDecimal("1000000.00"), budget[:total_budget]
+    assert_equal Date.new(2025, 10, 1), budget[:start_date]
+    assert_equal Date.new(2026, 9, 30), budget[:end_date]
+  end
+
+  def test_fiscal_year_budget_defaults_unknown_or_blank_response
+    missing = RpmsRpc::ChsBudget.fiscal_year_budget(fiscal_year: "FY2099")
+    blank = RpmsRpc::ChsBudget.fiscal_year_budget(fiscal_year: "FY_BLANK")
+
+    assert_equal "FY2099", missing[:fiscal_year]
+    assert_equal BigDecimal("0"), missing[:total_budget]
+    assert_equal "FY_BLANK", blank[:fiscal_year]
+    assert_equal BigDecimal("0"), blank[:total_budget]
+  end
+
+  def test_remaining_funds_returns_fiscal_year_totals
+    funds = RpmsRpc::ChsBudget.remaining_funds(fiscal_year: FY)
+
+    assert_equal BigDecimal("750000.00"), funds[:remaining]
+    assert_equal BigDecimal("200000.00"), funds[:obligated]
+    assert_equal BigDecimal("50000.00"), funds[:expended]
+  end
+
+  def test_remaining_funds_defaults_blank_fields_to_zero
+    funds = RpmsRpc::ChsBudget.remaining_funds(fiscal_year: "FY_BLANK")
+
+    assert_equal BigDecimal("0"), funds[:remaining]
+    assert_equal BigDecimal("0"), funds[:obligated]
+    assert_equal BigDecimal("0"), funds[:expended]
+  end
+
+  def test_quarterly_allocation_sends_fiscal_year_then_quarter
+    RpmsRpc::ChsBudget.quarterly_allocation(quarter: "Q1", fiscal_year: FY)
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BMCRPC GTQTRALLOC" }
+    refute_nil call
+    assert_equal [ FY, "Q1" ], call[:params]
+  end
+
+  def test_quarterly_allocation_defaults_blank_fields
+    allocation = RpmsRpc::ChsBudget.quarterly_allocation(quarter: "Q3", fiscal_year: "FY_BLANK")
+
+    assert_equal "Q3", allocation[:quarter]
+    assert_equal BigDecimal("0"), allocation[:allocated]
+    assert_equal BigDecimal("0"), allocation[:spent]
+    assert_equal BigDecimal("0"), allocation[:remaining]
+  end
+
+  def test_obligations_returns_multi_line_obligations
+    obligations = RpmsRpc::ChsBudget.obligations(fiscal_year: FY)
+
+    assert_equal 2, obligations.length
+    pending = obligations.find { |o| o[:id] == "101" }
+    assert_equal 501, pending[:referral_ien]
+    assert_equal 8791, pending[:patient_dfn]
+    assert_equal "15000.00", pending[:amount]
+    assert_equal Date.new(2026, 1, 15), pending[:created_date]
+  end
+
+  def test_obligations_filters_by_status
+    obligations = RpmsRpc::ChsBudget.obligations(status: "PENDING", fiscal_year: FY)
+
+    assert_equal [ "101" ], obligations.map { |o| o[:id] }
+  end
+
+  def test_find_returns_single_obligation
+    obligation = RpmsRpc::ChsBudget.find(101)
+
+    refute_nil obligation
+    assert_equal "101", obligation[:id]
+    assert_equal "PARTIAL", obligation[:status]
+    assert_equal "5000.00", obligation[:amount_paid]
+    assert_equal "701", obligation[:vendor_id]
+  end
+
+  def test_find_rejects_blank_zero_negative_and_non_numeric_ids
+    assert_nil RpmsRpc::ChsBudget.find(nil)
+    assert_nil RpmsRpc::ChsBudget.find("")
+    assert_nil RpmsRpc::ChsBudget.find(0)
+    assert_nil RpmsRpc::ChsBudget.find(-1)
+    assert_nil RpmsRpc::ChsBudget.find("NONEXISTENT")
+  end
+
+  def test_find_returns_nil_for_unknown_id
+    assert_nil RpmsRpc::ChsBudget.find(999_999)
+  end
+
+  def test_by_referral_returns_single_obligation
+    obligation = RpmsRpc::ChsBudget.by_referral(501)
+
+    refute_nil obligation
+    assert_equal "101", obligation[:id]
+    assert_equal 501, obligation[:referral_ien]
+  end
+
+  def test_payments_returns_multi_line_payments
+    payments = RpmsRpc::ChsBudget.payments(obligation_id: 101)
+
+    assert_equal 2, payments.length
+    assert_equal "301", payments.first[:id]
+    assert_equal "CHK-12345", payments.first[:check_number]
+    assert_equal Date.new(2026, 2, 1), payments.first[:payment_date]
+  end
+
+  def test_payments_returns_empty_for_blank_or_unknown_obligation
+    assert_equal [], RpmsRpc::ChsBudget.payments(obligation_id: nil)
+    assert_equal [], RpmsRpc::ChsBudget.payments(obligation_id: "")
+    assert_equal [], RpmsRpc::ChsBudget.payments(obligation_id: 999_999)
+  end
+
+  def test_outstanding_obligations_calculates_amount_due
+    outstanding = RpmsRpc::ChsBudget.outstanding_obligations(fiscal_year: FY)
+
+    assert_equal 1, outstanding.length
+    assert_equal "101", outstanding.first[:id]
+    assert_equal BigDecimal("7500.00"), outstanding.first[:amount_paid]
+    assert_equal BigDecimal("7500.00"), outstanding.first[:amount_due]
+  end
+
+  def test_obligation_summary_returns_totals_by_status
+    summary = RpmsRpc::ChsBudget.obligation_summary(fiscal_year: FY)
+
+    assert_equal BigDecimal("40000.00"), summary[:total_obligated]
+    assert_equal BigDecimal("7500.00"), summary[:total_paid]
+    assert_equal BigDecimal("32500.00"), summary[:total_outstanding]
+    assert_equal 1, summary[:by_status]["PENDING"][:count]
+    assert_equal BigDecimal("25000.00"), summary[:by_status]["PAID"][:total]
+  end
+
+  def test_budget_summary_returns_comprehensive_budget_overview
+    summary = RpmsRpc::ChsBudget.budget_summary
+
+    assert_equal RpmsRpc::ChsBudget.current_fiscal_year, summary[:fiscal_year]
+    assert_equal BigDecimal("1000000.00"), summary[:total_budget]
+    assert_equal BigDecimal("75.0"), summary[:percent_remaining]
+    assert_equal %w[Q1 Q2 Q3 Q4], summary[:quarters].keys
+    assert_kind_of Time, summary[:as_of]
+  end
+
+  def test_low_funds_detects_threshold
+    assert_equal false, RpmsRpc::ChsBudget.low_funds?(threshold: 0.20)
+    assert_equal true, RpmsRpc::ChsBudget.low_funds?(threshold: 0.80)
+  end
+end

--- a/test/rpms_rpc/api/chs_budget_test.rb
+++ b/test/rpms_rpc/api/chs_budget_test.rb
@@ -189,8 +189,8 @@ class ChsBudgetTest < Minitest::Test
 
     assert_equal 2, obligations.length
     pending = obligations.find { |o| o[:id] == "101" }
-    assert_equal 501, pending[:referral_ien]
-    assert_equal 8791, pending[:patient_dfn]
+    assert_equal "501", pending[:referral_ien]
+    assert_equal "8791", pending[:patient_dfn]
     assert_equal "15000.00", pending[:amount]
     assert_equal Date.new(2026, 1, 15), pending[:created_date]
   end
@@ -228,7 +228,22 @@ class ChsBudgetTest < Minitest::Test
 
     refute_nil obligation
     assert_equal "101", obligation[:id]
-    assert_equal 501, obligation[:referral_ien]
+    assert_equal "501", obligation[:referral_ien]
+  end
+
+  def test_by_referral_accepts_non_numeric_referral_id
+    RpmsRpc.client.seed(:chs_obligation_by_referral, "REF-001", {
+      id: "OBL-099",
+      referral_ien: "REF-001",
+      patient_dfn: "8791",
+      amount: "1200.00",
+      status: "PENDING"
+    })
+
+    obligation = RpmsRpc::ChsBudget.by_referral("REF-001")
+    refute_nil obligation, "non-numeric referral IDs must reach the RPC"
+    assert_equal "REF-001", obligation[:referral_ien]
+    assert_equal "OBL-099", obligation[:id]
   end
 
   def test_payments_returns_multi_line_payments

--- a/test/rpms_rpc/mappings_test.rb
+++ b/test/rpms_rpc/mappings_test.rb
@@ -509,6 +509,9 @@ class RpmsRpc::MappingsTest < Minitest::Test
       medication_list care_plan_list care_team_list goal_list
       procedure_list device_list lab_result_list radiology_list
       hospital_location institution referral_search site_params
+      chs_budget chs_remaining_funds chs_quarterly_allocation
+      chs_obligation_list chs_obligation_detail chs_obligation_by_referral
+      chs_payment_list
       user_info mailman_message mailman_messages_for_patient mailman_send
       mailman_reply mailman_thread mailman_inbox xqal_alert xqal_mark_read
       xqal_forward report_types reminders_list


### PR DESCRIPTION
## Summary
- Add CHS/PRC budget, funds, quarterly allocation, obligation, and payment mappings.
- Add the `RpmsRpc::ChsBudget` read-only symbolic API for budget summaries, fiscal-year totals, obligation lookup, payments, and low-funds checks.
- Cover happy paths, invalid IDs, defaults, unknown IDs, and multi-line obligation/payment responses.

## Test plan
- `bundle exec ruby -Ilib -Itest test/rpms_rpc/api/chs_budget_test.rb`
- `bundle exec rake test`
- `bundle exec rubocop lib/rpms_rpc/api/chs_budget.rb lib/rpms_rpc/mappings.rb test/rpms_rpc/api/chs_budget_test.rb test/rpms_rpc/mappings_test.rb`

Follow-up filed for deferred authorization write paths: `rr-psi`.

Made with [Cursor](https://cursor.com)
