### PR TITLE
Session module: port from rpms_redux

### DIFF
--- a/lib/rpms_rpc/api/session.rb
+++ b/lib/rpms_rpc/api/session.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative "../mappings"
+
+module RpmsRpc
+  # Symbolic API for the cold-launch session bootstrap sequence.
+  # Underlying RPCs: CIAVMRPC GETPAR, CIAVMCFG GETREG, CIAVCXUS VIMINFO.
+  module Session
+    extend self
+
+    DEFAULT_SOURCE_PARAM = "CIAVM DEFAULT SOURCE"
+
+    def bootstrap(user_duz)
+      return nil if invalid_duz?(user_duz)
+
+      config_root = DataMapper.session_default_source.fetch_scalar(DEFAULT_SOURCE_PARAM)
+      registry    = DataMapper.session_registry.fetch_one || {}
+      vim_info    = DataMapper.session_vim_info.fetch_one(user_duz.to_s) || {}
+
+      {
+        config_root: presence(config_root),
+        registry: registry,
+        vim_info: vim_info,
+        default_site_ien: vim_info[:site_ien]
+      }
+    end
+
+    private
+
+    def invalid_duz?(value)
+      value.nil? || value.to_s.strip.empty? || value.to_i <= 0
+    end
+
+    def presence(val)
+      return nil if val.nil?
+
+      str = val.to_s
+      str.empty? ? nil : str
+    end
+  end
+end

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -1423,5 +1423,34 @@ module RpmsRpc
       m.field 10, :doses_unused, :integer
       m.field 11, :facility_ien
     end
+
+    # ========================================================================
+    # SESSION BOOTSTRAP (CIAVMRPC*, CIAVMCFG*, CIAVCXUS*)
+    # ========================================================================
+
+    # CIAVMRPC GETPAR — fetch a CIAVM parameter by name.
+    # Used at cold launch to retrieve "CIAVM DEFAULT SOURCE" → config root path.
+    DataMapper.define(:session_default_source) do |m|
+      m.rpc "CIAVMRPC GETPAR"
+      m.scalar :value, :string
+    end
+
+    # CIAVMCFG GETREG — fetch the launching client's registry settings.
+    # Field positions are best-effort pending wider trace capture; the RPC
+    # returns the registry/config root path used to locate cached config.
+    DataMapper.define(:session_registry) do |m|
+      m.rpc "CIAVMCFG GETREG"
+      m.field 0, :root
+    end
+
+    # CIAVCXUS VIMINFO — fetch the user's launch context (site/division).
+    # Field positions are best-effort pending wider trace capture; the RPC
+    # carries the user's launch site IEN among other context fields.
+    DataMapper.define(:session_vim_info) do |m|
+      m.rpc "CIAVCXUS VIMINFO"
+      m.field 0, :site_ien, :integer
+      m.field 1, :site_name
+      m.field 2, :user_name
+    end
   end
 end

--- a/test/rpms_rpc/api/session_test.rb
+++ b/test/rpms_rpc/api/session_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/session"
+
+class SessionTest < Minitest::Test
+  CONFIG_ROOT = "c:\\CEHRTT15\\lib\\"
+
+  def setup
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:session_default_source, "CIAVM DEFAULT SOURCE", CONFIG_ROOT)
+      m.seed(:session_registry, "", { root: "HKLM\\Software\\IHS\\CIAVM" })
+      m.seed(:session_vim_info, "301", {
+        site_ien: 539,
+        site_name: "Yakama Service Unit",
+        user_name: "PROVIDER,TEST"
+      })
+    end
+  end
+
+  def test_bootstrap_returns_documented_hash_shape
+    result = RpmsRpc::Session.bootstrap("301")
+
+    assert_equal CONFIG_ROOT, result[:config_root]
+    assert_equal({ root: "HKLM\\Software\\IHS\\CIAVM" }, result[:registry])
+    assert_equal "Yakama Service Unit", result[:vim_info][:site_name]
+    assert_equal 539, result[:default_site_ien]
+  end
+
+  def test_bootstrap_issues_all_three_rpcs
+    RpmsRpc::Session.bootstrap("301")
+
+    rpcs = RpmsRpc.client.received_calls.map { |c| c[:rpc] }
+    assert_includes rpcs, "CIAVMRPC GETPAR"
+    assert_includes rpcs, "CIAVMCFG GETREG"
+    assert_includes rpcs, "CIAVCXUS VIMINFO"
+  end
+
+  def test_bootstrap_passes_default_source_param_to_getpar
+    RpmsRpc::Session.bootstrap("301")
+
+    getpar = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "CIAVMRPC GETPAR" }
+    assert_equal ["CIAVM DEFAULT SOURCE"], getpar[:params]
+  end
+
+  def test_bootstrap_passes_duz_to_viminfo
+    RpmsRpc::Session.bootstrap("301")
+
+    vim = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "CIAVCXUS VIMINFO" }
+    assert_equal ["301"], vim[:params]
+  end
+
+  def test_bootstrap_returns_nil_for_blank_duz
+    assert_nil RpmsRpc::Session.bootstrap(nil)
+    assert_nil RpmsRpc::Session.bootstrap("")
+    assert_nil RpmsRpc::Session.bootstrap("0")
+  end
+
+  def test_bootstrap_handles_missing_vim_info_gracefully
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:session_default_source, "CIAVM DEFAULT SOURCE", CONFIG_ROOT)
+      m.seed(:session_registry, "", { root: "HKLM" })
+    end
+
+    result = RpmsRpc::Session.bootstrap("9999")
+
+    assert_equal CONFIG_ROOT, result[:config_root]
+    assert_nil result[:default_site_ien]
+    assert_equal({}, result[:vim_info])
+  end
+end

--- a/test/rpms_rpc/api/session_test.rb
+++ b/test/rpms_rpc/api/session_test.rb
@@ -41,14 +41,14 @@ class SessionTest < Minitest::Test
     RpmsRpc::Session.bootstrap("301")
 
     getpar = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "CIAVMRPC GETPAR" }
-    assert_equal ["CIAVM DEFAULT SOURCE"], getpar[:params]
+    assert_equal [ "CIAVM DEFAULT SOURCE" ], getpar[:params]
   end
 
   def test_bootstrap_passes_duz_to_viminfo
     RpmsRpc::Session.bootstrap("301")
 
     vim = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "CIAVCXUS VIMINFO" }
-    assert_equal ["301"], vim[:params]
+    assert_equal [ "301" ], vim[:params]
   end
 
   def test_bootstrap_returns_nil_for_blank_duz

--- a/test/rpms_rpc/api/session_test.rb
+++ b/test/rpms_rpc/api/session_test.rb
@@ -13,7 +13,7 @@ class SessionTest < Minitest::Test
       m.seed(:session_registry, "", { root: "HKLM\\Software\\IHS\\CIAVM" })
       m.seed(:session_vim_info, "301", {
         site_ien: 539,
-        site_name: "Yakama Service Unit",
+        site_name: "TEST SERVICE UNIT",
         user_name: "PROVIDER,TEST"
       })
     end
@@ -24,7 +24,7 @@ class SessionTest < Minitest::Test
 
     assert_equal CONFIG_ROOT, result[:config_root]
     assert_equal({ root: "HKLM\\Software\\IHS\\CIAVM" }, result[:registry])
-    assert_equal "Yakama Service Unit", result[:vim_info][:site_name]
+    assert_equal "TEST SERVICE UNIT", result[:vim_info][:site_name]
     assert_equal 539, result[:default_site_ien]
   end
 


### PR DESCRIPTION
## Summary
- Adds `RpmsRpc::Session.bootstrap(user_duz)` — cold-launch sequence wrapping `CIAVMRPC GETPAR`, `CIAVMCFG GETREG`, and `CIAVCXUS VIMINFO` into a single hash with `config_root`, `registry`, `vim_info`, and `default_site_ien`.
- Field positions for `GETREG` and `VIMINFO` are best-effort pending wider trace capture; the public contract is what the issue documents.
- First of the Phase 1 cold-launch modules (Session + Site + Capabilities) feeding the staff workflow queue.

## Test plan
- [x] Unit tests verify the documented hash shape
- [x] Verify all three RPCs are dispatched in `bootstrap`
- [x] Verify GETPAR receives `"CIAVM DEFAULT SOURCE"`
- [x] Verify VIMINFO receives the user DUZ
- [x] Invalid/blank DUZ returns nil
- [x] Missing VIMINFO seed degrades gracefully

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)