### PR TITLE
Site module: port from rpms_redux

### DIFF
--- a/lib/rpms_rpc/api/site.rb
+++ b/lib/rpms_rpc/api/site.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative "../mappings"
+
+module RpmsRpc
+  # Symbolic API for site/division context. A user may have access to several
+  # divisions; one is selected at any given moment and scopes downstream RPCs.
+  # Underlying RPC: BEHOSICX SITEINFO.
+  module Site
+    extend self
+
+    def list(user_duz)
+      return [] if invalid_duz?(user_duz)
+
+      Array(DataMapper.site_info.fetch_many(user_duz.to_s))
+    end
+
+    def current(user_duz)
+      list(user_duz).find { |site| site[:current] }
+    end
+
+    def select(user_duz, site_ien)
+      return false if invalid_duz?(user_duz) || invalid_ien?(site_ien)
+
+      RpmsRpc.client.call_rpc(DataMapper.site_info.rpc_name, user_duz.to_s, site_ien.to_s)
+      true
+    end
+
+    private
+
+    def invalid_duz?(value)
+      value.nil? || value.to_s.strip.empty? || value.to_i <= 0
+    end
+
+    def invalid_ien?(value)
+      value.nil? || value.to_s.strip.empty? || value.to_i <= 0
+    end
+  end
+end

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -1452,5 +1452,21 @@ module RpmsRpc
       m.field 1, :site_name
       m.field 2, :user_name
     end
+
+    # ========================================================================
+    # SITE / DIVISION CONTEXT (BEHOSICX*)
+    # ========================================================================
+
+    # BEHOSICX SITEINFO — divisions the user can access, with the currently
+    # selected division flagged. Used at cold launch and on division switch.
+    # Field positions are best-effort pending wider trace capture; the public
+    # contract is { ien, name, abbreviation, current }.
+    DataMapper.define(:site_info) do |m|
+      m.rpc "BEHOSICX SITEINFO"
+      m.field 0, :ien, :integer
+      m.field 1, :name
+      m.field 2, :abbreviation
+      m.field 3, :current, :boolean
+    end
   end
 end

--- a/test/rpms_rpc/api/site_test.rb
+++ b/test/rpms_rpc/api/site_test.rb
@@ -24,7 +24,7 @@ class SiteTest < Minitest::Test
   def test_list_returns_divisions_user_can_access
     sites = RpmsRpc::Site.list("301")
     assert_equal 3, sites.length
-    assert_equal [539, 540, 541], sites.map { |s| s[:ien] }
+    assert_equal [ 539, 540, 541 ], sites.map { |s| s[:ien] }
   end
 
   def test_list_blank_duz_returns_empty
@@ -53,7 +53,7 @@ class SiteTest < Minitest::Test
 
     call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BEHOSICX SITEINFO" && c[:params].length == 2 }
     refute_nil call, "expected BEHOSICX SITEINFO to be called with [duz, site_ien]"
-    assert_equal ["301", "540"], call[:params]
+    assert_equal [ "301", "540" ], call[:params]
   end
 
   def test_select_returns_false_for_invalid_args

--- a/test/rpms_rpc/api/site_test.rb
+++ b/test/rpms_rpc/api/site_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/site"
+
+class SiteTest < Minitest::Test
+  def setup
+    RpmsRpc.mock! do |m|
+      # BEHOSICX SITEINFO keyed by user DUZ: returns the divisions the user
+      # can access, with the currently-selected division flagged.
+      m.seed_keyed_collection(:site_info, "301", [
+        { ien: 539, name: "Yakama Service Unit", abbreviation: "YSU", current: true },
+        { ien: 540, name: "Toppenish Clinic", abbreviation: "TOP", current: false },
+        { ien: 541, name: "White Swan Clinic", abbreviation: "WS", current: false }
+      ])
+
+      m.seed_keyed_collection(:site_info, "999", [
+        { ien: 539, name: "Yakama Service Unit", abbreviation: "YSU", current: false }
+      ])
+    end
+  end
+
+  def test_list_returns_divisions_user_can_access
+    sites = RpmsRpc::Site.list("301")
+    assert_equal 3, sites.length
+    assert_equal [539, 540, 541], sites.map { |s| s[:ien] }
+  end
+
+  def test_list_blank_duz_returns_empty
+    assert_equal [], RpmsRpc::Site.list(nil)
+    assert_equal [], RpmsRpc::Site.list("")
+    assert_equal [], RpmsRpc::Site.list("0")
+  end
+
+  def test_current_returns_the_flagged_division
+    current = RpmsRpc::Site.current("301")
+    assert_equal 539, current[:ien]
+    assert_equal "Yakama Service Unit", current[:name]
+  end
+
+  def test_current_returns_nil_when_nothing_is_flagged
+    assert_nil RpmsRpc::Site.current("999")
+  end
+
+  def test_current_blank_duz_returns_nil
+    assert_nil RpmsRpc::Site.current(nil)
+    assert_nil RpmsRpc::Site.current("")
+  end
+
+  def test_select_dispatches_to_the_site_info_rpc_with_duz_and_site_ien
+    RpmsRpc::Site.select("301", 540)
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BEHOSICX SITEINFO" && c[:params].length == 2 }
+    refute_nil call, "expected BEHOSICX SITEINFO to be called with [duz, site_ien]"
+    assert_equal ["301", "540"], call[:params]
+  end
+
+  def test_select_returns_false_for_invalid_args
+    refute RpmsRpc::Site.select(nil, 540)
+    refute RpmsRpc::Site.select("301", nil)
+    refute RpmsRpc::Site.select("301", 0)
+  end
+end

--- a/test/rpms_rpc/api/site_test.rb
+++ b/test/rpms_rpc/api/site_test.rb
@@ -10,13 +10,13 @@ class SiteTest < Minitest::Test
       # BEHOSICX SITEINFO keyed by user DUZ: returns the divisions the user
       # can access, with the currently-selected division flagged.
       m.seed_keyed_collection(:site_info, "301", [
-        { ien: 539, name: "Yakama Service Unit", abbreviation: "YSU", current: true },
-        { ien: 540, name: "Toppenish Clinic", abbreviation: "TOP", current: false },
-        { ien: 541, name: "White Swan Clinic", abbreviation: "WS", current: false }
+        { ien: 539, name: "TEST SERVICE UNIT", abbreviation: "TSU", current: true },
+        { ien: 540, name: "TEST CLINIC A", abbreviation: "TCA", current: false },
+        { ien: 541, name: "TEST CLINIC B", abbreviation: "TCB", current: false }
       ])
 
       m.seed_keyed_collection(:site_info, "999", [
-        { ien: 539, name: "Yakama Service Unit", abbreviation: "YSU", current: false }
+        { ien: 539, name: "TEST SERVICE UNIT", abbreviation: "TSU", current: false }
       ])
     end
   end
@@ -36,7 +36,7 @@ class SiteTest < Minitest::Test
   def test_current_returns_the_flagged_division
     current = RpmsRpc::Site.current("301")
     assert_equal 539, current[:ien]
-    assert_equal "Yakama Service Unit", current[:name]
+    assert_equal "TEST SERVICE UNIT", current[:name]
   end
 
   def test_current_returns_nil_when_nothing_is_flagged


### PR DESCRIPTION
## Summary
- Adds `RpmsRpc::Site.list(user_duz)`, `current(user_duz)`, and `select(user_duz, site_ien)` over the `BEHOSICX SITEINFO` RPC.
- Engines use this to discover the divisions a user can access, identify the currently-selected one, and switch divisions.
- Field positions for `SITEINFO` are best-effort pending wider trace capture; the public contract (`ien`, `name`, `abbreviation`, `current`) is what callers depend on.
- Second of the Phase 1 cold-launch modules.

## Test plan
- [x] `list` returns the user's divisions
- [x] `current` returns the flagged division (or nil if none flagged)
- [x] `select` dispatches `BEHOSICX SITEINFO` with `[duz, site_ien]`
- [x] Invalid/blank args degrade gracefully (`[]`, `nil`, `false`)

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)