### PR TITLE
Capabilities: add imaging_user? predicate

### DIFF
--- a/lib/rpms_rpc/capabilities.rb
+++ b/lib/rpms_rpc/capabilities.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "mappings"
+
 module RpmsRpc
   # Framework-agnostic capability checks derived from RPMS security keys.
   # Used by authorization policies in any engine (Pundit, Action Policy, etc.).
@@ -7,6 +9,8 @@ module RpmsRpc
   # All methods accept a user-like object that responds to:
   #   - security_keys: Array of symbols (e.g., [:prc_supervisor, :consult_manager])
   #   - user_type: String (e.g., "provider", "nurse")
+  #
+  # `imaging_user?` is RPC-backed and requires only `duz` on the user object.
   #
   module Capabilities
     # PRC / CHS
@@ -85,6 +89,24 @@ module RpmsRpc
     def self.has_any_key?(user, *key_symbols)
       keys = Array(user.security_keys)
       key_symbols.any? { |k| keys.include?(k) }
+    end
+
+    # Imaging access — probed on every chart open. Backed by MAGGUSERKEYS;
+    # cached per user_duz since imaging keys don't change mid-session.
+    def self.imaging_user?(user)
+      duz = user.respond_to?(:duz) ? user&.duz : nil
+      return false if duz.nil? || duz.to_s.strip.empty?
+
+      key = duz.to_s
+      @imaging_cache ||= {}
+      return @imaging_cache[key] if @imaging_cache.key?(key)
+
+      keys = Array(DataMapper.imaging_user_keys.fetch_many(key))
+      @imaging_cache[key] = keys.any? { |row| !row[:key_name].to_s.strip.empty? }
+    end
+
+    def self.clear_imaging_cache!
+      @imaging_cache = {}
     end
   end
 end

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -1468,5 +1468,17 @@ module RpmsRpc
       m.field 2, :abbreviation
       m.field 3, :current, :boolean
     end
+
+    # ========================================================================
+    # IMAGING CAPABILITIES (MAG*)
+    # ========================================================================
+
+    # MAGGUSERKEYS — user's imaging keys (multi-line, one key per line).
+    # MAGGUSER2 (per-user permission detail) is referenced in trace but not
+    # yet modeled; the boolean predicate derives from key presence alone.
+    DataMapper.define(:imaging_user_keys) do |m|
+      m.rpc "MAGGUSERKEYS"
+      m.field 0, :key_name
+    end
   end
 end

--- a/test/rpms_rpc/capabilities_test.rb
+++ b/test/rpms_rpc/capabilities_test.rb
@@ -3,9 +3,11 @@
 require "minitest/autorun"
 require "set"
 require_relative "../../lib/rpms_rpc/capabilities"
+require_relative "../../lib/rpms_rpc/mock_client"
 
 class RpmsRpc::CapabilitiesTest < Minitest::Test
   User = Struct.new(:user_type, :security_keys, keyword_init: true)
+  ImagingUser = Struct.new(:duz, keyword_init: true)
 
   def test_can_approve_chs_with_supervisor_key
     user = User.new(user_type: "case_manager", security_keys: [ :prc_supervisor ])
@@ -97,5 +99,50 @@ class RpmsRpc::CapabilitiesTest < Minitest::Test
     user = User.new(user_type: "unknown", security_keys: [])
     perms = RpmsRpc::Capabilities.permissions_for(user)
     assert_equal [ :view_own_referrals ], perms
+  end
+
+  # --- imaging_user? (RPC-backed) ------------------------------------------
+
+  def test_imaging_user_is_true_when_user_has_mag_keys
+    RpmsRpc::Capabilities.clear_imaging_cache!
+    RpmsRpc.mock! do |m|
+      m.seed_keyed_collection(:imaging_user_keys, "301", [
+        { key_name: "MAG WINDOWS" }
+      ])
+    end
+
+    user = ImagingUser.new(duz: "301")
+    assert RpmsRpc::Capabilities.imaging_user?(user)
+  end
+
+  def test_imaging_user_is_false_when_user_has_no_mag_keys
+    RpmsRpc::Capabilities.clear_imaging_cache!
+    RpmsRpc.mock! do |m|
+      m.seed_keyed_collection(:imaging_user_keys, "999", [])
+    end
+
+    user = ImagingUser.new(duz: "999")
+    refute RpmsRpc::Capabilities.imaging_user?(user)
+  end
+
+  def test_imaging_user_caches_per_user_so_chart_open_does_not_rehit_rpc
+    RpmsRpc::Capabilities.clear_imaging_cache!
+    RpmsRpc.mock! do |m|
+      m.seed_keyed_collection(:imaging_user_keys, "301", [
+        { key_name: "MAG WINDOWS" }
+      ])
+    end
+
+    user = ImagingUser.new(duz: "301")
+    5.times { RpmsRpc::Capabilities.imaging_user?(user) }
+
+    rpcs = RpmsRpc.client.received_calls.count { |c| c[:rpc] == "MAGGUSERKEYS" }
+    assert_equal 1, rpcs
+  end
+
+  def test_imaging_user_is_false_for_blank_or_invalid_duz
+    refute RpmsRpc::Capabilities.imaging_user?(ImagingUser.new(duz: nil))
+    refute RpmsRpc::Capabilities.imaging_user?(ImagingUser.new(duz: ""))
+    refute RpmsRpc::Capabilities.imaging_user?(nil)
   end
 end

--- a/test/rpms_rpc/capabilities_test.rb
+++ b/test/rpms_rpc/capabilities_test.rb
@@ -2,6 +2,7 @@
 
 require "minitest/autorun"
 require "set"
+require_relative "../../lib/rpms_rpc/version"
 require_relative "../../lib/rpms_rpc/capabilities"
 require_relative "../../lib/rpms_rpc/mock_client"
 
@@ -144,5 +145,22 @@ class RpmsRpc::CapabilitiesTest < Minitest::Test
     refute RpmsRpc::Capabilities.imaging_user?(ImagingUser.new(duz: nil))
     refute RpmsRpc::Capabilities.imaging_user?(ImagingUser.new(duz: ""))
     refute RpmsRpc::Capabilities.imaging_user?(nil)
+  end
+
+  def test_clear_imaging_cache_forces_redispatch
+    RpmsRpc::Capabilities.clear_imaging_cache!
+    RpmsRpc.mock! do |m|
+      m.seed_keyed_collection(:imaging_user_keys, "301", [
+        { key_name: "MAG WINDOWS" }
+      ])
+    end
+
+    user = ImagingUser.new(duz: "301")
+    RpmsRpc::Capabilities.imaging_user?(user)
+    RpmsRpc::Capabilities.clear_imaging_cache!
+    RpmsRpc::Capabilities.imaging_user?(user)
+
+    rpcs = RpmsRpc.client.received_calls.count { |c| c[:rpc] == "MAGGUSERKEYS" }
+    assert_equal 2, rpcs, "expected clear_imaging_cache! to force a second RPC dispatch"
   end
 end


### PR DESCRIPTION
## Summary
- Adds `RpmsRpc::Capabilities.imaging_user?(user)` over the `MAGGUSERKEYS` RPC.
- Result is cached per `user.duz` because imaging keys don't change mid-session and the predicate fires on every chart open.
- `MAGGUSER2` is referenced in the trace evidence but not yet modeled — the boolean derives from `MAGGUSERKEYS` presence alone. The mapping comment notes this; a follow-up can extend with detail-level checks if needed.
- Third of the Phase 1 cold-launch modules.

## Test plan
- [x] Returns `true` when user has any MAG key
- [x] Returns `false` when user has no MAG keys
- [x] Caches per-user — repeated calls dispatch the RPC once
- [x] Blank/nil duz returns `false`
- [x] `clear_imaging_cache!` resets the cache

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)