### PR TITLE
Reminders module: port for_visit summary

### DIFF
--- a/lib/rpms_rpc/api/reminders.rb
+++ b/lib/rpms_rpc/api/reminders.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative "../mappings"
+
+module RpmsRpc
+  # Symbolic API for IHS clinical reminders. Fires at encounter open to
+  # surface what's due/applicable/satisfied for the patient.
+  # Underlying RPC: BGOTRG GETSUM.
+  module Reminders
+    extend self
+
+    STATUS_MAP = {
+      "DUE"        => :due,
+      "APPLICABLE" => :applicable,
+      "SATISFIED"  => :satisfied
+    }.freeze
+
+    def for_visit(dfn, visit_ien)
+      return [] if invalid_id?(dfn) || invalid_id?(visit_ien)
+
+      Array(DataMapper.reminder_summary.fetch_many(dfn.to_s, visit_ien.to_s)).map { |row| decorate(row) }
+    end
+
+    private
+
+    def decorate(row)
+      code = row[:status_code].to_s
+      {
+        id: row[:id],
+        name: row[:name],
+        status: STATUS_MAP[code] || code.downcase.to_sym,
+        priority: row[:priority],
+        due_date: row[:due_date]
+      }
+    end
+
+    def invalid_id?(value)
+      value.nil? || value.to_s.strip.empty? || value.to_i <= 0
+    end
+  end
+end

--- a/lib/rpms_rpc/api/reminders.rb
+++ b/lib/rpms_rpc/api/reminders.rb
@@ -25,10 +25,19 @@ module RpmsRpc
 
     def decorate(row)
       code = row[:status_code].to_s
+      status =
+        if STATUS_MAP.key?(code)
+          STATUS_MAP[code]
+        elsif code.strip.empty?
+          nil
+        else
+          code.downcase.to_sym
+        end
+
       {
         id: row[:id],
         name: row[:name],
-        status: STATUS_MAP[code] || code.downcase.to_sym,
+        status: status,
         priority: row[:priority],
         due_date: row[:due_date]
       }

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -1480,5 +1480,24 @@ module RpmsRpc
       m.rpc "MAGGUSERKEYS"
       m.field 0, :key_name
     end
+
+    # ========================================================================
+    # CLINICAL REMINDERS (BGOTRG*, ORQQPX*)
+    # ========================================================================
+
+    # BGOTRG GETSUM — reminder summary for a (patient_dfn, visit_ien).
+    # Multi-line response; each line one reminder.
+    # Field positions are best-effort pending wider trace capture.
+    # ORQQPX NEW REMINDERS ACTIVE and ORQQPXRM REMINDERS APPLICABLE are
+    # referenced in the issue but not yet modeled; for_visit derives the
+    # full list from GETSUM alone.
+    DataMapper.define(:reminder_summary) do |m|
+      m.rpc "BGOTRG GETSUM"
+      m.field 0, :id, :integer
+      m.field 1, :name
+      m.field 2, :status_code
+      m.field 3, :priority, :integer
+      m.field 4, :due_date, :fileman_date
+    end
   end
 end

--- a/test/rpms_rpc/api/reminders_test.rb
+++ b/test/rpms_rpc/api/reminders_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "date"
+require_relative "../../../lib/rpms_rpc/version"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/reminders"
+
+class RemindersTest < Minitest::Test
+  PATIENT_DFN = "8791"
+  VISIT_IEN   = "12345"
+  DUE_DATE    = Date.today + 14
+
+  def setup
+    RpmsRpc.mock! do |m|
+      m.seed_keyed_collection(:reminder_summary, PATIENT_DFN, [
+        { id: 1001, name: "Diabetic Foot Exam", status_code: "DUE",        priority: 1, due_date: DUE_DATE },
+        { id: 1002, name: "Influenza Vaccine",  status_code: "APPLICABLE", priority: 2, due_date: nil },
+        { id: 1003, name: "Mammogram",          status_code: "SATISFIED",  priority: 3, due_date: nil }
+      ])
+    end
+  end
+
+  def test_for_visit_returns_documented_shape
+    rows = RpmsRpc::Reminders.for_visit(PATIENT_DFN, VISIT_IEN)
+
+    assert_equal 3, rows.length
+    first = rows.first
+    assert_equal 1001, first[:id]
+    assert_equal "Diabetic Foot Exam", first[:name]
+    assert_equal :due, first[:status]
+    assert_equal 1, first[:priority]
+    assert_equal DUE_DATE, first[:due_date]
+  end
+
+  def test_for_visit_maps_status_codes_to_taxonomy_symbols
+    rows = RpmsRpc::Reminders.for_visit(PATIENT_DFN, VISIT_IEN)
+    statuses = rows.map { |r| r[:status] }
+
+    assert_equal [ :due, :applicable, :satisfied ], statuses
+  end
+
+  def test_for_visit_dispatches_bgotrg_getsum
+    RpmsRpc::Reminders.for_visit(PATIENT_DFN, VISIT_IEN)
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BGOTRG GETSUM" }
+    refute_nil call
+    assert_equal [ PATIENT_DFN, VISIT_IEN ], call[:params]
+  end
+
+  def test_for_visit_returns_empty_for_blank_args
+    assert_equal [], RpmsRpc::Reminders.for_visit(nil, VISIT_IEN)
+    assert_equal [], RpmsRpc::Reminders.for_visit(PATIENT_DFN, nil)
+    assert_equal [], RpmsRpc::Reminders.for_visit("", "")
+    assert_equal [], RpmsRpc::Reminders.for_visit("0", "0")
+  end
+
+  def test_for_visit_returns_empty_when_no_reminders_seeded
+    RpmsRpc.mock!
+    assert_equal [], RpmsRpc::Reminders.for_visit(PATIENT_DFN, VISIT_IEN)
+  end
+
+  def test_unknown_status_code_falls_back_to_symbol
+    RpmsRpc.mock! do |m|
+      m.seed_keyed_collection(:reminder_summary, PATIENT_DFN, [
+        { id: 2001, name: "Unknown State", status_code: "FROZEN", priority: 1, due_date: nil }
+      ])
+    end
+
+    rows = RpmsRpc::Reminders.for_visit(PATIENT_DFN, VISIT_IEN)
+    assert_equal :frozen, rows.first[:status]
+  end
+end

--- a/test/rpms_rpc/api/reminders_test.rb
+++ b/test/rpms_rpc/api/reminders_test.rb
@@ -2,7 +2,7 @@
 
 require "minitest/autorun"
 require "date"
-require_relative "../../../lib/rpms_rpc/version"
+require "rpms_rpc/version"
 require "rpms_rpc/mock_client"
 require "rpms_rpc/api/reminders"
 
@@ -19,6 +19,10 @@ class RemindersTest < Minitest::Test
         { id: 1003, name: "Mammogram",          status_code: "SATISFIED",  priority: 3, due_date: nil }
       ])
     end
+  end
+
+  def teardown
+    RpmsRpc.reset!
   end
 
   def test_for_visit_returns_documented_shape
@@ -69,5 +73,16 @@ class RemindersTest < Minitest::Test
 
     rows = RpmsRpc::Reminders.for_visit(PATIENT_DFN, VISIT_IEN)
     assert_equal :frozen, rows.first[:status]
+  end
+
+  def test_blank_status_code_yields_nil_not_empty_symbol
+    RpmsRpc.mock! do |m|
+      m.seed_keyed_collection(:reminder_summary, PATIENT_DFN, [
+        { id: 3001, name: "Missing State", status_code: "", priority: 1, due_date: nil }
+      ])
+    end
+
+    rows = RpmsRpc::Reminders.for_visit(PATIENT_DFN, VISIT_IEN)
+    assert_nil rows.first[:status]
   end
 end


### PR DESCRIPTION
## Summary
- Adds `RpmsRpc::Reminders.for_visit(dfn, visit_ien)` over the `BGOTRG GETSUM` RPC — the clinical reminder summary that fires at encounter open.
- Status taxonomy maps RPMS codes (`DUE`, `APPLICABLE`, `SATISFIED`) to symbols. Unknown codes fall through to a downcased symbol so future statuses don't silently break.
- Field positions for `GETSUM` are best-effort pending wider trace capture; the public contract (`id`, `name`, `status`, `priority`, `due_date`) is what callers depend on.
- Phase 2 of the staff workflow port.

## Test plan
- [x] `for_visit` returns the documented shape with status taxonomy
- [x] Status codes `DUE`/`APPLICABLE`/`SATISFIED` map to `:due`/`:applicable`/`:satisfied`
- [x] Unknown status code falls back to downcased symbol
- [x] Dispatches `BGOTRG GETSUM` with `[dfn, visit_ien]`
- [x] Invalid/blank args return `[]`
- [x] No seed → returns `[]`

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)