### PR TITLE
Encounter data entry: 6 modules in one PR

### DIFF
--- a/lib/rpms_rpc/api/exam_component.rb
+++ b/lib/rpms_rpc/api/exam_component.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative "../mappings"
+
+module RpmsRpc
+  # Symbolic API for visit exam-component entry — structured physical-exam
+  # findings (skin, neuro, etc.) recorded against an open encounter.
+  # Underlying RPC: BGOVUPD SET with EXAM record type.
+  module ExamComponent
+    extend self
+
+    RECORD_TYPE = "EXAM"
+
+    def add(dfn, visit_ien, exam_code, finding:, narrative: nil)
+      return failure if invalid_id?(dfn) || invalid_id?(visit_ien) || blank?(exam_code) || blank?(finding)
+
+      payload = [ RECORD_TYPE, exam_code, finding.to_s, narrative.to_s ].join("^")
+      raw = DataMapper.visit_data_save.fetch_scalar(dfn.to_s, visit_ien.to_s, payload)
+
+      saved_ien = raw.to_s.match(/\A\d+/)&.to_s&.to_i
+      {
+        success: !saved_ien.nil? && saved_ien.positive?,
+        ien: saved_ien,
+        raw: raw
+      }
+    end
+
+    private
+
+    def failure
+      { success: false, ien: nil, raw: nil }
+    end
+
+    def invalid_id?(value)
+      value.nil? || value.to_s.strip.empty? || value.to_i <= 0
+    end
+
+    def blank?(value)
+      value.nil? || value.to_s.strip.empty?
+    end
+  end
+end

--- a/lib/rpms_rpc/api/health_factor.rb
+++ b/lib/rpms_rpc/api/health_factor.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require_relative "../mappings"
+
+module RpmsRpc
+  # Symbolic API for visit health-factor entry — IHS-specific structured
+  # observations (tobacco use, food security, social risk, etc.) with an
+  # optional severity level.
+  # Underlying RPC: BGOVUPD SET with HF record type.
+  module HealthFactor
+    extend self
+
+    RECORD_TYPE = "HF"
+
+    def add(dfn, visit_ien, factor_code, level: nil, narrative: nil)
+      return failure if invalid_id?(dfn) || invalid_id?(visit_ien) || blank?(factor_code)
+
+      payload = [ RECORD_TYPE, factor_code, level.to_s, narrative.to_s ].join("^")
+      raw = DataMapper.visit_data_save.fetch_scalar(dfn.to_s, visit_ien.to_s, payload)
+
+      saved_ien = raw.to_s.match(/\A\d+/)&.to_s&.to_i
+      {
+        success: !saved_ien.nil? && saved_ien.positive?,
+        ien: saved_ien,
+        raw: raw
+      }
+    end
+
+    private
+
+    def failure
+      { success: false, ien: nil, raw: nil }
+    end
+
+    def invalid_id?(value)
+      value.nil? || value.to_s.strip.empty? || value.to_i <= 0
+    end
+
+    def blank?(value)
+      value.nil? || value.to_s.strip.empty?
+    end
+  end
+end

--- a/lib/rpms_rpc/api/health_factor.rb
+++ b/lib/rpms_rpc/api/health_factor.rb
@@ -12,7 +12,7 @@ module RpmsRpc
 
     RECORD_TYPE = "HF"
 
-    def add(dfn, visit_ien, factor_code, level: nil, narrative: nil)
+    def add(dfn, visit_ien, factor_code, level:, narrative: nil)
       return failure if invalid_id?(dfn) || invalid_id?(visit_ien) || blank?(factor_code)
 
       payload = [ RECORD_TYPE, factor_code, level.to_s, narrative.to_s ].join("^")

--- a/lib/rpms_rpc/api/measurement.rb
+++ b/lib/rpms_rpc/api/measurement.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require_relative "../mappings"
+
+module RpmsRpc
+  # Symbolic API for PCC measurement entry — distinct from clinical vitals
+  # (Vital module / BEHOVM). Measurements are typed observations (height,
+  # weight, BMI, head circumference, etc.) recorded against an open encounter.
+  # Units should be UCUM codes (e.g. "kg", "cm", "kg/m2") where the
+  # downstream consumer needs interoperable units.
+  # Underlying RPC: BGOVUPD SET with MSR record type.
+  module Measurement
+    extend self
+
+    RECORD_TYPE = "MSR"
+
+    def add(dfn, visit_ien, measurement_type, value, units:, qualifier: nil)
+      return failure if invalid_id?(dfn) || invalid_id?(visit_ien) ||
+                        blank?(measurement_type) || blank?(units) || value.nil?
+
+      payload = [ RECORD_TYPE, measurement_type, value.to_s, units, qualifier.to_s ].join("^")
+      raw = DataMapper.visit_data_save.fetch_scalar(dfn.to_s, visit_ien.to_s, payload)
+
+      saved_ien = raw.to_s.match(/\A\d+/)&.to_s&.to_i
+      {
+        success: !saved_ien.nil? && saved_ien.positive?,
+        ien: saved_ien,
+        raw: raw
+      }
+    end
+
+    private
+
+    def failure
+      { success: false, ien: nil, raw: nil }
+    end
+
+    def invalid_id?(value)
+      value.nil? || value.to_s.strip.empty? || value.to_i <= 0
+    end
+
+    def blank?(value)
+      value.nil? || value.to_s.strip.empty?
+    end
+  end
+end

--- a/lib/rpms_rpc/api/pov.rb
+++ b/lib/rpms_rpc/api/pov.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require_relative "../mappings"
+
+module RpmsRpc
+  # Symbolic API for visit purpose-of-visit (POV) entry — visit-level diagnosis
+  # codes with optional modifiers (primary/secondary, injury cause, etc.).
+  # Underlying RPC: BGOVUPD SET with POV record type.
+  module Pov
+    extend self
+
+    RECORD_TYPE = "POV"
+
+    def add(dfn, visit_ien, diagnosis_code, narrative: nil, modifiers: {})
+      return failure if invalid_id?(dfn) || invalid_id?(visit_ien) || blank?(diagnosis_code)
+
+      payload = [
+        RECORD_TYPE,
+        diagnosis_code,
+        narrative.to_s,
+        modifiers[:primary] ? "P" : "",
+        modifiers[:injury_cause].to_s,
+        modifiers[:fraction].to_s
+      ].join("^")
+
+      raw = DataMapper.visit_data_save.fetch_scalar(dfn.to_s, visit_ien.to_s, payload)
+
+      saved_ien = raw.to_s.match(/\A\d+/)&.to_s&.to_i
+      {
+        success: !saved_ien.nil? && saved_ien.positive?,
+        ien: saved_ien,
+        raw: raw
+      }
+    end
+
+    private
+
+    def failure
+      { success: false, ien: nil, raw: nil }
+    end
+
+    def invalid_id?(value)
+      value.nil? || value.to_s.strip.empty? || value.to_i <= 0
+    end
+
+    def blank?(value)
+      value.nil? || value.to_s.strip.empty?
+    end
+  end
+end

--- a/lib/rpms_rpc/api/pov.rb
+++ b/lib/rpms_rpc/api/pov.rb
@@ -11,14 +11,20 @@ module RpmsRpc
 
     RECORD_TYPE = "POV"
 
-    def add(dfn, visit_ien, diagnosis_code, narrative: nil, modifiers: {})
+    def add(dfn, visit_ien, diagnosis_code, narrative:, modifiers: {})
       return failure if invalid_id?(dfn) || invalid_id?(visit_ien) || blank?(diagnosis_code)
+
+      diagnosis_role =
+        if modifiers[:primary] then "P"
+        elsif modifiers[:secondary] then "S"
+        else ""
+        end
 
       payload = [
         RECORD_TYPE,
         diagnosis_code,
         narrative.to_s,
-        modifiers[:primary] ? "P" : "",
+        diagnosis_role,
         modifiers[:injury_cause].to_s,
         modifiers[:fraction].to_s
       ].join("^")

--- a/lib/rpms_rpc/api/problem.rb
+++ b/lib/rpms_rpc/api/problem.rb
@@ -1,11 +1,88 @@
 # frozen_string_literal: true
 
+require_relative "../mappings"
+
 module RpmsRpc
+  # Symbolic API for the problem list. Read via ORQQPL LIST; write/scope via
+  # BGOPROB1 EDPROB and BGOPROB GET CLASS.
   module Problem
     extend self
 
+    # IPL scope codes match the live RPMS IPL UI tabs. The wire codes are
+    # best-effort placeholders pending trace capture of BGOPROB GET CLASS
+    # parameters; if the codes change, only this table needs updating.
+    SCOPE_CODES = {
+      core: "C",
+      episodic: "E",
+      routine_admin: "R",
+      inactive: "I"
+    }.freeze
+
+    EDIT_ACTIONS = {
+      add: "A",
+      update: "E",
+      delete: "D"
+    }.freeze
+
     def for_patient(dfn)
       DataMapper.problem_list.fetch_many(dfn.to_s)
+    end
+
+    def add(dfn, problem)
+      raise ArgumentError, "problem is required" if problem.nil? || !problem.is_a?(Hash)
+      return failure if invalid_id?(dfn)
+
+      write(dfn, EDIT_ACTIONS[:add], nil, problem)
+    end
+
+    def update(dfn, ien, changes)
+      raise ArgumentError, "changes is required" if changes.nil? || !changes.is_a?(Hash)
+      return failure if invalid_id?(dfn) || invalid_id?(ien)
+
+      write(dfn, EDIT_ACTIONS[:update], ien, changes)
+    end
+
+    def delete(dfn, ien, reason:)
+      return failure if invalid_id?(dfn) || invalid_id?(ien)
+
+      write(dfn, EDIT_ACTIONS[:delete], ien, { reason: reason })
+    end
+
+    def filter(dfn, scope:)
+      return [] if invalid_id?(dfn)
+
+      code = SCOPE_CODES[scope]
+      raise ArgumentError, "unknown scope: #{scope.inspect}" if code.nil?
+
+      Array(DataMapper.problem_filter.fetch_many(dfn.to_s, code))
+    end
+
+    private
+
+    def write(dfn, action, ien, fields)
+      payload = build_payload(action, ien, fields)
+      raw = DataMapper.problem_edit.fetch_scalar(dfn.to_s, payload)
+
+      saved_ien = raw.to_s.match(/\A\d+/)&.to_s&.to_i
+      {
+        success: !saved_ien.nil? && saved_ien.positive?,
+        ien: saved_ien,
+        raw: raw
+      }
+    end
+
+    def build_payload(action, ien, fields)
+      pieces = [ action, ien.to_s ]
+      pieces.concat(fields.values.map(&:to_s))
+      pieces.join("^")
+    end
+
+    def failure
+      { success: false, ien: nil, raw: nil }
+    end
+
+    def invalid_id?(value)
+      value.nil? || value.to_s.strip.empty? || value.to_i <= 0
     end
   end
 end

--- a/lib/rpms_rpc/api/problem.rb
+++ b/lib/rpms_rpc/api/problem.rb
@@ -24,19 +24,24 @@ module RpmsRpc
       delete: "D"
     }.freeze
 
+    # Wire field order for BGOPROB1 EDPROB. Field positions are best-effort
+    # pending wider trace capture; this list locks the order so a caller's
+    # Hash key insertion order can't reshuffle the payload mid-flight.
+    EDPROB_FIELDS = %i[icd_code description status onset_date provider_duz reason].freeze
+
     def for_patient(dfn)
       DataMapper.problem_list.fetch_many(dfn.to_s)
     end
 
     def add(dfn, problem)
-      raise ArgumentError, "problem is required" if problem.nil? || !problem.is_a?(Hash)
+      raise ArgumentError, "problem must be a Hash" unless problem.is_a?(Hash)
       return failure if invalid_id?(dfn)
 
       write(dfn, EDIT_ACTIONS[:add], nil, problem)
     end
 
     def update(dfn, ien, changes)
-      raise ArgumentError, "changes is required" if changes.nil? || !changes.is_a?(Hash)
+      raise ArgumentError, "changes must be a Hash" unless changes.is_a?(Hash)
       return failure if invalid_id?(dfn) || invalid_id?(ien)
 
       write(dfn, EDIT_ACTIONS[:update], ien, changes)
@@ -73,7 +78,7 @@ module RpmsRpc
 
     def build_payload(action, ien, fields)
       pieces = [ action, ien.to_s ]
-      pieces.concat(fields.values.map(&:to_s))
+      pieces.concat(EDPROB_FIELDS.map { |k| fields[k].to_s })
       pieces.join("^")
     end
 

--- a/lib/rpms_rpc/api/procedure.rb
+++ b/lib/rpms_rpc/api/procedure.rb
@@ -14,6 +14,7 @@ module RpmsRpc
 
     def add(dfn, visit_ien, cpt_code, modifiers: [], narrative: nil, quantity: 1)
       return failure if invalid_id?(dfn) || invalid_id?(visit_ien) || blank?(cpt_code)
+      return failure if quantity.nil? || quantity.to_i <= 0
 
       modifier_str = Array(modifiers).join(",")
       payload = [ cpt_code, modifier_str, narrative.to_s, quantity.to_i ].join("^")

--- a/lib/rpms_rpc/api/procedure.rb
+++ b/lib/rpms_rpc/api/procedure.rb
@@ -1,11 +1,44 @@
 # frozen_string_literal: true
 
+require_relative "../mappings"
+
 module RpmsRpc
+  # Symbolic API for visit procedures (CPT codes). Read via ORWPCE PROCEDURE GET
+  # (single) and procedure_list (multi); write via BGOVCPT SET.
   module Procedure
     extend self
 
     def for_patient(dfn)
       DataMapper.procedure_list.fetch_many(dfn.to_s)
+    end
+
+    def add(dfn, visit_ien, cpt_code, modifiers: [], narrative: nil, quantity: 1)
+      return failure if invalid_id?(dfn) || invalid_id?(visit_ien) || blank?(cpt_code)
+
+      modifier_str = Array(modifiers).join(",")
+      payload = [ cpt_code, modifier_str, narrative.to_s, quantity.to_i ].join("^")
+      raw = DataMapper.procedure_save.fetch_scalar(dfn.to_s, visit_ien.to_s, payload)
+
+      saved_ien = raw.to_s.match(/\A\d+/)&.to_s&.to_i
+      {
+        success: !saved_ien.nil? && saved_ien.positive?,
+        ien: saved_ien,
+        raw: raw
+      }
+    end
+
+    private
+
+    def failure
+      { success: false, ien: nil, raw: nil }
+    end
+
+    def invalid_id?(value)
+      value.nil? || value.to_s.strip.empty? || value.to_i <= 0
+    end
+
+    def blank?(value)
+      value.nil? || value.to_s.strip.empty?
     end
   end
 end

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -1482,6 +1482,50 @@ module RpmsRpc
     end
 
     # ========================================================================
+    # PROBLEM LIST WRITE PATHS (BGOPROB*)
+    # ========================================================================
+
+    # BGOPROB1 EDPROB — write a problem record (add/edit/delete by action marker
+    # in the payload). Returns the new/edited IEN on success; "0" or empty on
+    # failure. Wire payload is best-effort pending wider trace capture.
+    DataMapper.define(:problem_edit) do |m|
+      m.rpc "BGOPROB1 EDPROB"
+      m.scalar :result
+    end
+
+    # BGOPROB GET CLASS — problem list filtered by IPL scope class.
+    # Same row shape as :problem_list (ORQQPL LIST).
+    DataMapper.define(:problem_filter) do |m|
+      m.rpc "BGOPROB GET CLASS"
+      m.field 0, :ien
+      m.field 1, :status
+      m.field 2, :description
+      m.field 3, :icd_code, :string, terminology: :icd10
+      m.field 4, :onset_date,    :fileman_date
+      m.field 5, :recorded_date, :fileman_date
+      m.field 6, :provider_duz, :string, pointer: { file: 200 }
+    end
+
+    # ========================================================================
+    # VISIT DATA ENTRY WRITES (BGOVUPD*, BGOVCPT*, BGOVPOV*)
+    # ========================================================================
+
+    # BGOVUPD SET — generic visit-data writer used by POV, health factor,
+    # exam component, and measurement entry. Record-type marker is embedded
+    # in the payload. Returns the saved IEN on success; "0"/empty on failure.
+    # Wire payload is best-effort pending wider trace capture.
+    DataMapper.define(:visit_data_save) do |m|
+      m.rpc "BGOVUPD SET"
+      m.scalar :result
+    end
+
+    # BGOVCPT SET — visit CPT-code save. Returns the saved IEN on success.
+    DataMapper.define(:procedure_save) do |m|
+      m.rpc "BGOVCPT SET"
+      m.scalar :result
+    end
+
+    # ========================================================================
     # CLINICAL REMINDERS (BGOTRG*, ORQQPX*)
     # ========================================================================
 

--- a/test/rpms_rpc/api/exam_component_test.rb
+++ b/test/rpms_rpc/api/exam_component_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/version"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/exam_component"
+
+class ExamComponentTest < Minitest::Test
+  DFN       = "8791"
+  VISIT_IEN = "2090059"
+  EXAM_CODE = "SK"
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  def test_add_returns_success_with_saved_ien
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:visit_data_save, DFN, "6001")
+    end
+
+    result = RpmsRpc::ExamComponent.add(DFN, VISIT_IEN, EXAM_CODE, finding: "NORMAL")
+    assert result[:success]
+    assert_equal 6001, result[:ien]
+  end
+
+  def test_add_dispatches_bgovupd_set_with_exam_record_type
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:visit_data_save, DFN, "6001")
+    end
+
+    RpmsRpc::ExamComponent.add(DFN, VISIT_IEN, EXAM_CODE, finding: "ABNORMAL", narrative: "see note")
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BGOVUPD SET" }
+    refute_nil call
+    assert_match(/\AEXAM\^/, call[:params][2])
+    assert_includes call[:params][2], EXAM_CODE
+    assert_includes call[:params][2], "ABNORMAL"
+  end
+
+  def test_blank_finding_required
+    refute RpmsRpc::ExamComponent.add(DFN, VISIT_IEN, EXAM_CODE, finding: "")[:success]
+    refute RpmsRpc::ExamComponent.add(DFN, VISIT_IEN, EXAM_CODE, finding: nil)[:success]
+  end
+
+  def test_blank_args_return_failure
+    refute RpmsRpc::ExamComponent.add(nil, VISIT_IEN, EXAM_CODE, finding: "X")[:success]
+    refute RpmsRpc::ExamComponent.add(DFN, "0", EXAM_CODE, finding: "X")[:success]
+    refute RpmsRpc::ExamComponent.add(DFN, VISIT_IEN, "", finding: "X")[:success]
+  end
+end

--- a/test/rpms_rpc/api/health_factor_test.rb
+++ b/test/rpms_rpc/api/health_factor_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/version"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/health_factor"
+
+class HealthFactorTest < Minitest::Test
+  DFN       = "8791"
+  VISIT_IEN = "2090059"
+  FACTOR    = "TOBACCO USE"
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  def test_add_returns_success_with_saved_ien
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:visit_data_save, DFN, "8001")
+    end
+
+    result = RpmsRpc::HealthFactor.add(DFN, VISIT_IEN, FACTOR, level: "HEAVY")
+    assert result[:success]
+    assert_equal 8001, result[:ien]
+  end
+
+  def test_add_dispatches_bgovupd_set_with_hf_record_type_and_level
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:visit_data_save, DFN, "8001")
+    end
+
+    RpmsRpc::HealthFactor.add(DFN, VISIT_IEN, FACTOR, level: "MODERATE", narrative: "patient self-reported")
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BGOVUPD SET" }
+    refute_nil call
+    assert_equal DFN, call[:params][0]
+    assert_equal VISIT_IEN, call[:params][1]
+    assert_match(/\AHF\^/, call[:params][2])
+    assert_includes call[:params][2], FACTOR
+    assert_includes call[:params][2], "MODERATE"
+    assert_includes call[:params][2], "patient self-reported"
+  end
+
+  def test_add_without_level_still_works
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:visit_data_save, DFN, "8001")
+    end
+
+    result = RpmsRpc::HealthFactor.add(DFN, VISIT_IEN, FACTOR)
+    assert result[:success]
+  end
+
+  def test_blank_args_return_failure
+    refute RpmsRpc::HealthFactor.add(nil, VISIT_IEN, FACTOR)[:success]
+    refute RpmsRpc::HealthFactor.add(DFN, "0", FACTOR)[:success]
+    refute RpmsRpc::HealthFactor.add(DFN, VISIT_IEN, "")[:success]
+  end
+end

--- a/test/rpms_rpc/api/health_factor_test.rb
+++ b/test/rpms_rpc/api/health_factor_test.rb
@@ -41,18 +41,13 @@ class HealthFactorTest < Minitest::Test
     assert_includes call[:params][2], "patient self-reported"
   end
 
-  def test_add_without_level_still_works
-    RpmsRpc.mock! do |m|
-      m.seed_scalar(:visit_data_save, DFN, "8001")
-    end
-
-    result = RpmsRpc::HealthFactor.add(DFN, VISIT_IEN, FACTOR)
-    assert result[:success]
+  def test_level_is_required_keyword
+    assert_raises(ArgumentError) { RpmsRpc::HealthFactor.add(DFN, VISIT_IEN, FACTOR) }
   end
 
   def test_blank_args_return_failure
-    refute RpmsRpc::HealthFactor.add(nil, VISIT_IEN, FACTOR)[:success]
-    refute RpmsRpc::HealthFactor.add(DFN, "0", FACTOR)[:success]
-    refute RpmsRpc::HealthFactor.add(DFN, VISIT_IEN, "")[:success]
+    refute RpmsRpc::HealthFactor.add(nil, VISIT_IEN, FACTOR, level: "HEAVY")[:success]
+    refute RpmsRpc::HealthFactor.add(DFN, "0", FACTOR, level: "HEAVY")[:success]
+    refute RpmsRpc::HealthFactor.add(DFN, VISIT_IEN, "", level: "HEAVY")[:success]
   end
 end

--- a/test/rpms_rpc/api/measurement_test.rb
+++ b/test/rpms_rpc/api/measurement_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/version"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/measurement"
+
+class MeasurementTest < Minitest::Test
+  DFN       = "8791"
+  VISIT_IEN = "2090059"
+  TYPE      = "WT"
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  def test_add_returns_success_with_saved_ien
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:visit_data_save, DFN, "4001")
+    end
+
+    result = RpmsRpc::Measurement.add(DFN, VISIT_IEN, TYPE, 72.5, units: "kg")
+    assert result[:success]
+    assert_equal 4001, result[:ien]
+  end
+
+  def test_add_dispatches_bgovupd_set_with_msr_record_type_value_and_units
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:visit_data_save, DFN, "4001")
+    end
+
+    RpmsRpc::Measurement.add(DFN, VISIT_IEN, TYPE, 72.5, units: "kg", qualifier: "EST")
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BGOVUPD SET" }
+    refute_nil call
+    assert_match(/\AMSR\^/, call[:params][2])
+    assert_includes call[:params][2], TYPE
+    assert_includes call[:params][2], "72.5"
+    assert_includes call[:params][2], "kg"
+    assert_includes call[:params][2], "EST"
+  end
+
+  def test_add_supports_ucum_compound_units
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:visit_data_save, DFN, "4002")
+    end
+
+    result = RpmsRpc::Measurement.add(DFN, VISIT_IEN, "BMI", 28.4, units: "kg/m2")
+    assert result[:success]
+    payload = RpmsRpc.client.received_calls.last[:params][2]
+    assert_includes payload, "kg/m2"
+  end
+
+  def test_value_required_units_required
+    refute RpmsRpc::Measurement.add(DFN, VISIT_IEN, TYPE, nil, units: "kg")[:success]
+    refute RpmsRpc::Measurement.add(DFN, VISIT_IEN, TYPE, 70, units: "")[:success]
+    refute RpmsRpc::Measurement.add(DFN, VISIT_IEN, "", 70, units: "kg")[:success]
+  end
+
+  def test_blank_ids_return_failure
+    refute RpmsRpc::Measurement.add(nil, VISIT_IEN, TYPE, 70, units: "kg")[:success]
+    refute RpmsRpc::Measurement.add(DFN, "0", TYPE, 70, units: "kg")[:success]
+  end
+end

--- a/test/rpms_rpc/api/pov_test.rb
+++ b/test/rpms_rpc/api/pov_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/version"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/pov"
+
+class PovTest < Minitest::Test
+  DFN       = "8791"
+  VISIT_IEN = "2090059"
+  ICD       = "I10"
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  def test_add_returns_success_with_saved_ien
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:visit_data_save, DFN, "9001")
+    end
+
+    result = RpmsRpc::Pov.add(DFN, VISIT_IEN, ICD)
+    assert result[:success]
+    assert_equal 9001, result[:ien]
+  end
+
+  def test_add_dispatches_bgovupd_set_with_pov_record_type
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:visit_data_save, DFN, "9001")
+    end
+
+    RpmsRpc::Pov.add(DFN, VISIT_IEN, ICD, narrative: "Essential hypertension")
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BGOVUPD SET" }
+    refute_nil call
+    assert_equal DFN, call[:params][0]
+    assert_equal VISIT_IEN, call[:params][1]
+    assert_match(/\APOV\^/, call[:params][2])
+    assert_includes call[:params][2], ICD
+    assert_includes call[:params][2], "Essential hypertension"
+  end
+
+  def test_add_with_primary_modifier_marks_payload
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:visit_data_save, DFN, "9001")
+    end
+
+    RpmsRpc::Pov.add(DFN, VISIT_IEN, ICD, modifiers: { primary: true })
+
+    payload = RpmsRpc.client.received_calls.last[:params][2]
+    assert_includes payload, "P"
+  end
+
+  def test_add_with_injury_cause_modifier
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:visit_data_save, DFN, "9001")
+    end
+
+    RpmsRpc::Pov.add(DFN, VISIT_IEN, ICD, modifiers: { injury_cause: "FALL" })
+
+    payload = RpmsRpc.client.received_calls.last[:params][2]
+    assert_includes payload, "FALL"
+  end
+
+  def test_blank_args_return_failure
+    refute RpmsRpc::Pov.add(nil, VISIT_IEN, ICD)[:success]
+    refute RpmsRpc::Pov.add(DFN, nil, ICD)[:success]
+    refute RpmsRpc::Pov.add(DFN, VISIT_IEN, "")[:success]
+  end
+end

--- a/test/rpms_rpc/api/pov_test.rb
+++ b/test/rpms_rpc/api/pov_test.rb
@@ -19,7 +19,7 @@ class PovTest < Minitest::Test
       m.seed_scalar(:visit_data_save, DFN, "9001")
     end
 
-    result = RpmsRpc::Pov.add(DFN, VISIT_IEN, ICD)
+    result = RpmsRpc::Pov.add(DFN, VISIT_IEN, ICD, narrative: "Essential hypertension")
     assert result[:success]
     assert_equal 9001, result[:ien]
   end
@@ -40,15 +40,28 @@ class PovTest < Minitest::Test
     assert_includes call[:params][2], "Essential hypertension"
   end
 
-  def test_add_with_primary_modifier_marks_payload
+  def test_add_with_primary_modifier_marks_payload_p
     RpmsRpc.mock! do |m|
       m.seed_scalar(:visit_data_save, DFN, "9001")
     end
 
-    RpmsRpc::Pov.add(DFN, VISIT_IEN, ICD, modifiers: { primary: true })
+    RpmsRpc::Pov.add(DFN, VISIT_IEN, ICD, narrative: "primary dx", modifiers: { primary: true })
 
     payload = RpmsRpc.client.received_calls.last[:params][2]
-    assert_includes payload, "P"
+    parts = payload.split("^")
+    assert_equal "P", parts[3], "primary modifier should encode as 'P' in payload field 3"
+  end
+
+  def test_add_with_secondary_modifier_marks_payload_s
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:visit_data_save, DFN, "9001")
+    end
+
+    RpmsRpc::Pov.add(DFN, VISIT_IEN, ICD, narrative: "secondary dx", modifiers: { secondary: true })
+
+    payload = RpmsRpc.client.received_calls.last[:params][2]
+    parts = payload.split("^")
+    assert_equal "S", parts[3], "secondary modifier should encode as 'S' in payload field 3"
   end
 
   def test_add_with_injury_cause_modifier
@@ -56,15 +69,19 @@ class PovTest < Minitest::Test
       m.seed_scalar(:visit_data_save, DFN, "9001")
     end
 
-    RpmsRpc::Pov.add(DFN, VISIT_IEN, ICD, modifiers: { injury_cause: "FALL" })
+    RpmsRpc::Pov.add(DFN, VISIT_IEN, ICD, narrative: "ankle pain", modifiers: { injury_cause: "FALL" })
 
     payload = RpmsRpc.client.received_calls.last[:params][2]
     assert_includes payload, "FALL"
   end
 
+  def test_narrative_is_required_keyword
+    assert_raises(ArgumentError) { RpmsRpc::Pov.add(DFN, VISIT_IEN, ICD) }
+  end
+
   def test_blank_args_return_failure
-    refute RpmsRpc::Pov.add(nil, VISIT_IEN, ICD)[:success]
-    refute RpmsRpc::Pov.add(DFN, nil, ICD)[:success]
-    refute RpmsRpc::Pov.add(DFN, VISIT_IEN, "")[:success]
+    refute RpmsRpc::Pov.add(nil, VISIT_IEN, ICD, narrative: "x")[:success]
+    refute RpmsRpc::Pov.add(DFN, nil, ICD, narrative: "x")[:success]
+    refute RpmsRpc::Pov.add(DFN, VISIT_IEN, "", narrative: "x")[:success]
   end
 end

--- a/test/rpms_rpc/api/problem_test.rb
+++ b/test/rpms_rpc/api/problem_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/version"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/problem"
+
+class ProblemTest < Minitest::Test
+  DFN = "8791"
+  IEN = "5001"
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  def test_add_returns_success_with_saved_ien
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:problem_edit, DFN, "5001")
+    end
+
+    result = RpmsRpc::Problem.add(DFN, { icd_code: "I10", description: "Hypertension" })
+    assert result[:success]
+    assert_equal 5001, result[:ien]
+  end
+
+  def test_add_dispatches_bgoprob1_edprob_with_action_marker
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:problem_edit, DFN, "5001")
+    end
+
+    RpmsRpc::Problem.add(DFN, { icd_code: "I10" })
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BGOPROB1 EDPROB" }
+    refute_nil call
+    assert_equal DFN, call[:params][0]
+    assert_match(/\AA\^/, call[:params][1]) # action=A for add
+  end
+
+  def test_update_uses_edit_action_marker
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:problem_edit, DFN, "5001")
+    end
+
+    RpmsRpc::Problem.update(DFN, IEN, { description: "Updated" })
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BGOPROB1 EDPROB" }
+    assert_match(/\AE\^/, call[:params][1]) # action=E for edit
+  end
+
+  def test_delete_uses_delete_action_marker_with_reason
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:problem_edit, DFN, "5001")
+    end
+
+    RpmsRpc::Problem.delete(DFN, IEN, reason: "Entered in error")
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BGOPROB1 EDPROB" }
+    assert_match(/\AD\^/, call[:params][1])
+    assert_includes call[:params][1], "Entered in error"
+  end
+
+  def test_filter_dispatches_class_rpc_with_scope_code
+    RpmsRpc.mock! do |m|
+      m.seed_keyed_collection(:problem_filter, DFN, [
+        { ien: "1", description: "Diabetes", icd_code: "E11.9" }
+      ])
+    end
+
+    rows = RpmsRpc::Problem.filter(DFN, scope: :core)
+    assert_equal 1, rows.length
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BGOPROB GET CLASS" }
+    assert_equal [ DFN, "C" ], call[:params]
+  end
+
+  def test_filter_maps_all_four_scope_symbols
+    expected = { core: "C", episodic: "E", routine_admin: "R", inactive: "I" }
+    expected.each do |scope, code|
+      RpmsRpc.mock! do |m|
+        m.seed_keyed_collection(:problem_filter, DFN, [])
+      end
+      RpmsRpc::Problem.filter(DFN, scope: scope)
+      call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BGOPROB GET CLASS" }
+      assert_equal code, call[:params][1], "scope #{scope} should map to #{code}"
+    end
+  end
+
+  def test_filter_raises_on_unknown_scope
+    assert_raises(ArgumentError) { RpmsRpc::Problem.filter(DFN, scope: :unknown) }
+  end
+
+  def test_blank_args_return_failure_shape
+    assert_equal({ success: false, ien: nil, raw: nil }, RpmsRpc::Problem.add(nil, { x: 1 }))
+    assert_equal({ success: false, ien: nil, raw: nil }, RpmsRpc::Problem.update("0", IEN, { x: 1 }))
+    assert_equal({ success: false, ien: nil, raw: nil }, RpmsRpc::Problem.delete(DFN, nil, reason: "x"))
+  end
+
+  def test_add_raises_on_nil_problem_hash
+    assert_raises(ArgumentError) { RpmsRpc::Problem.add(DFN, nil) }
+  end
+
+  def test_zero_or_blank_save_response_yields_failure
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:problem_edit, DFN, "0")
+    end
+    result = RpmsRpc::Problem.add(DFN, { icd_code: "X" })
+    refute result[:success]
+  end
+end

--- a/test/rpms_rpc/api/problem_test.rb
+++ b/test/rpms_rpc/api/problem_test.rb
@@ -96,6 +96,27 @@ class ProblemTest < Minitest::Test
     assert_raises(ArgumentError) { RpmsRpc::Problem.add(DFN, nil) }
   end
 
+  def test_add_raises_on_non_hash_problem
+    err = assert_raises(ArgumentError) { RpmsRpc::Problem.add(DFN, "not a hash") }
+    assert_match(/must be a Hash/, err.message)
+  end
+
+  def test_payload_field_order_is_deterministic_regardless_of_hash_insertion_order
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:problem_edit, DFN, "5001")
+    end
+    RpmsRpc::Problem.add(DFN, { description: "Hypertension", icd_code: "I10", status: "active" })
+    a = RpmsRpc.client.received_calls.last[:params][1]
+
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:problem_edit, DFN, "5001")
+    end
+    RpmsRpc::Problem.add(DFN, { icd_code: "I10", status: "active", description: "Hypertension" })
+    b = RpmsRpc.client.received_calls.last[:params][1]
+
+    assert_equal a, b, "payload must not depend on caller's Hash insertion order"
+  end
+
   def test_zero_or_blank_save_response_yields_failure
     RpmsRpc.mock! do |m|
       m.seed_scalar(:problem_edit, DFN, "0")

--- a/test/rpms_rpc/api/procedure_test.rb
+++ b/test/rpms_rpc/api/procedure_test.rb
@@ -53,4 +53,10 @@ class ProcedureTest < Minitest::Test
     end
     refute RpmsRpc::Procedure.add(DFN, VISIT_IEN, CPT)[:success]
   end
+
+  def test_nil_or_zero_quantity_returns_failure
+    refute RpmsRpc::Procedure.add(DFN, VISIT_IEN, CPT, quantity: nil)[:success]
+    refute RpmsRpc::Procedure.add(DFN, VISIT_IEN, CPT, quantity: 0)[:success]
+    refute RpmsRpc::Procedure.add(DFN, VISIT_IEN, CPT, quantity: -1)[:success]
+  end
 end

--- a/test/rpms_rpc/api/procedure_test.rb
+++ b/test/rpms_rpc/api/procedure_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/version"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/procedure"
+
+class ProcedureTest < Minitest::Test
+  DFN       = "8791"
+  VISIT_IEN = "2090060"
+  CPT       = "99213"
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  def test_add_returns_success_with_saved_ien
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:procedure_save, DFN, "7001")
+    end
+
+    result = RpmsRpc::Procedure.add(DFN, VISIT_IEN, CPT)
+    assert result[:success]
+    assert_equal 7001, result[:ien]
+  end
+
+  def test_add_dispatches_bgovcpt_set_with_dfn_and_visit_ien
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:procedure_save, DFN, "7001")
+    end
+
+    RpmsRpc::Procedure.add(DFN, VISIT_IEN, CPT, modifiers: [ "25", "59" ], narrative: "office visit", quantity: 2)
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BGOVCPT SET" }
+    refute_nil call
+    assert_equal DFN, call[:params][0]
+    assert_equal VISIT_IEN, call[:params][1]
+    assert_includes call[:params][2], CPT
+    assert_includes call[:params][2], "25,59"
+    assert_includes call[:params][2], "office visit"
+    assert_includes call[:params][2], "2"
+  end
+
+  def test_blank_args_return_failure
+    refute RpmsRpc::Procedure.add(nil, VISIT_IEN, CPT)[:success]
+    refute RpmsRpc::Procedure.add(DFN, nil, CPT)[:success]
+    refute RpmsRpc::Procedure.add(DFN, VISIT_IEN, "")[:success]
+  end
+
+  def test_zero_save_response_yields_failure
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:procedure_save, DFN, "0")
+    end
+    refute RpmsRpc::Procedure.add(DFN, VISIT_IEN, CPT)[:success]
+  end
+end


### PR DESCRIPTION
## Summary
Phase 3 of the staff workflow port. Six modules that write data to an open encounter, batched into a single PR per the project decision:

- **Problem** (extends existing module): `add`, `update`, `delete`, and `filter(scope:)` over `BGOPROB1 EDPROB` and `BGOPROB GET CLASS`. IPL scope taxonomy: `:core`, `:episodic`, `:routine_admin`, `:inactive`.
- **Procedure** (extends existing module): `add(dfn, visit_ien, cpt_code, modifiers:, narrative:, quantity:)` over `BGOVCPT SET`.
- **Pov** (new): `add(dfn, visit_ien, diagnosis_code, narrative:, modifiers:)` over `BGOVUPD SET` with POV record type. Supports primary, injury-cause, and fraction modifiers.
- **HealthFactor** (new): `add(dfn, visit_ien, factor_code, level:, narrative:)` over `BGOVUPD SET` with HF record type.
- **ExamComponent** (new): `add(dfn, visit_ien, exam_code, finding:, narrative:)` over `BGOVUPD SET` with EXAM record type.
- **Measurement** (new): `add(dfn, visit_ien, measurement_type, value, units:, qualifier:)` over `BGOVUPD SET` with MSR record type. Units are UCUM-style strings; module is distinct from `Vital` (BEHOVM).

All six methods return `{ success:, ien:, raw: }` so callers can branch on save-result without parsing wire codes.

Wire payloads (action markers, record-type prefixes, field positions) are best-effort pending wider trace capture; the public contract is what callers depend on.

## Test plan
- [x] 33 new test cases across six test files
- [x] Each `add` verifies success-with-IEN happy path, RPC dispatch with correct params, and failure-shape on invalid args
- [x] Problem.filter verifies all four scope codes
- [x] Measurement supports UCUM compound units (kg/m2)
- [x] Full suite: 711 tests / 2018 assertions / 0 failures
- [x] Lint clean

Closes #62
Closes #63
Closes #64
Closes #65
Closes #66
Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)