### PR TITLE
Immunization: structured for_patient/find via BIPC IMMLIST/IMMGET

### DIFF
--- a/lib/rpms_rpc/api/immunization.rb
+++ b/lib/rpms_rpc/api/immunization.rb
@@ -1,11 +1,44 @@
 # frozen_string_literal: true
 
+require_relative "../mappings"
+
 module RpmsRpc
+  # Symbolic API for patient-administered immunization records.
+  #
+  # Underlying RPCs:
+  #   - BIPC IMMLIST: patient-scoped administered record list
+  #   - BIPC IMMGET:  single administered record by IEN
+  #   - BEHOCIR GETTXT (text_summary): the CCD patient-summary text blob
+  #
+  # Wire field positions for IMMLIST / IMMGET are best-effort pending
+  # wider trace capture; if the positions change, only :immunization_list
+  # and :immunization_detail in mappings.rb need updating.
   module Immunization
     extend self
 
     def for_patient(dfn)
+      return [] if invalid_id?(dfn)
+
+      Array(DataMapper.immunization_list.fetch_many(dfn.to_s))
+    end
+
+    def find(ien)
+      return nil if invalid_id?(ien)
+
+      DataMapper.immunization_detail.fetch_one(ien.to_s)
+    end
+
+    # The CCD patient-summary text blob (BEHOCIR GETTXT). Kept under a
+    # distinct accessor so callers that want the summary text don't have
+    # to compete with the structured list shape on `for_patient`.
+    def text_summary(dfn)
       DataMapper.immunization_text.fetch_text(dfn.to_s)
+    end
+
+    private
+
+    def invalid_id?(value)
+      value.nil? || value.to_s.strip.empty? || value.to_i <= 0
     end
   end
 end

--- a/lib/rpms_rpc/api/immunization.rb
+++ b/lib/rpms_rpc/api/immunization.rb
@@ -32,6 +32,8 @@ module RpmsRpc
     # distinct accessor so callers that want the summary text don't have
     # to compete with the structured list shape on `for_patient`.
     def text_summary(dfn)
+      return nil if invalid_id?(dfn)
+
       DataMapper.immunization_text.fetch_text(dfn.to_s)
     end
 

--- a/lib/rpms_rpc/data_mapper.rb
+++ b/lib/rpms_rpc/data_mapper.rb
@@ -252,6 +252,8 @@ module RpmsRpc
           raw
         when :integer
           raw.to_i
+        when :float
+          Float(raw)
         when :fileman_date
           FilemanDateParser.parse_date(raw)
         when :fileman_datetime

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -1296,7 +1296,7 @@ module RpmsRpc
       m.field 7,  :route
       m.field 8,  :performer_duz, :string, pointer: { file: 200 }
       m.field 9,  :performer_name
-      m.field 10, :occurrence_datetime, :fileman_date
+      m.field 10, :occurrence_datetime, :fileman_datetime
       m.field 11, :dose_quantity,       :float
       m.field 12, :dose_unit
       m.field 13, :manufacturer
@@ -1318,7 +1318,7 @@ module RpmsRpc
       m.field 7,  :route
       m.field 8,  :performer_duz, :string, pointer: { file: 200 }
       m.field 9,  :performer_name
-      m.field 10, :occurrence_datetime, :fileman_date
+      m.field 10, :occurrence_datetime, :fileman_datetime
       m.field 11, :dose_quantity,       :float
       m.field 12, :dose_unit
       m.field 13, :manufacturer

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -1281,6 +1281,51 @@ module RpmsRpc
       m.text_blob :content
     end
 
+    # BIPC IMMLIST — patient-scoped administered immunization records.
+    # Field positions are best-effort pending wider trace capture.
+    # Format: IEN^CVX^DISPLAY^STATUS^LOT^EXP^SITE^ROUTE^PRDUZ^PRNAME^OCC^DOSE^UNIT^MFG^VFC^FUND
+    DataMapper.define(:immunization_list) do |m|
+      m.rpc "BIPC IMMLIST"
+      m.field 0,  :ien
+      m.field 1,  :vaccine_code
+      m.field 2,  :vaccine_display
+      m.field 3,  :status
+      m.field 4,  :lot_number
+      m.field 5,  :expiration_date,     :fileman_date
+      m.field 6,  :site
+      m.field 7,  :route
+      m.field 8,  :performer_duz, :string, pointer: { file: 200 }
+      m.field 9,  :performer_name
+      m.field 10, :occurrence_datetime, :fileman_date
+      m.field 11, :dose_quantity,       :float
+      m.field 12, :dose_unit
+      m.field 13, :manufacturer
+      m.field 14, :vfc_eligibility_code
+      m.field 15, :funding_source
+    end
+
+    # BIPC IMMGET — single administered immunization record by IEN.
+    # Same field shape as :immunization_list.
+    DataMapper.define(:immunization_detail) do |m|
+      m.rpc "BIPC IMMGET"
+      m.field 0,  :ien
+      m.field 1,  :vaccine_code
+      m.field 2,  :vaccine_display
+      m.field 3,  :status
+      m.field 4,  :lot_number
+      m.field 5,  :expiration_date,     :fileman_date
+      m.field 6,  :site
+      m.field 7,  :route
+      m.field 8,  :performer_duz, :string, pointer: { file: 200 }
+      m.field 9,  :performer_name
+      m.field 10, :occurrence_datetime, :fileman_date
+      m.field 11, :dose_quantity,       :float
+      m.field 12, :dose_unit
+      m.field 13, :manufacturer
+      m.field 14, :vfc_eligibility_code
+      m.field 15, :funding_source
+    end
+
     # BEHOCIR GETNUM — CCD count and reconciliation status
     # Format: TOTAL^RECONCILED
     DataMapper.define(:immunization_count) do |m|

--- a/test/rpms_rpc/api/clinical_data_test.rb
+++ b/test/rpms_rpc/api/clinical_data_test.rb
@@ -151,4 +151,19 @@ class ClinicalDataApiTest < Minitest::Test
     # Structured list semantics: no seeded :immunization_list rows → [].
     assert_equal [], RpmsRpc::Immunization.for_patient("99999")
   end
+
+  def test_immunization_for_patient_returns_structured_records_when_seeded
+    RpmsRpc.mock! do |m|
+      m.seed_keyed_collection(:immunization_list, "1", [
+        { ien: 7001, vaccine_code: "207", vaccine_display: "COVID-19 Pfizer",
+          status: "completed", lot_number: "EX1234" }
+      ])
+    end
+
+    result = RpmsRpc::Immunization.for_patient("1")
+
+    assert_equal 1, result.length
+    assert_equal "207", result.first[:vaccine_code]
+    assert_equal "EX1234", result.first[:lot_number]
+  end
 end

--- a/test/rpms_rpc/api/clinical_data_test.rb
+++ b/test/rpms_rpc/api/clinical_data_test.rb
@@ -139,16 +139,16 @@ class ClinicalDataApiTest < Minitest::Test
   # IMMUNIZATION
   # =============================================================================
 
-  def test_immunization_for_patient_returns_text
-    result = RpmsRpc::Immunization.for_patient("1")
+  def test_immunization_text_summary_returns_text
+    result = RpmsRpc::Immunization.text_summary("1")
+    flattened = Array(result).join("\n")
 
     refute_nil result
-    assert_includes result, "COVID-19"
+    assert_includes flattened, "COVID-19"
   end
 
-  def test_immunization_for_patient_nil_when_none
-    result = RpmsRpc::Immunization.for_patient("99999")
-
-    assert_nil result
+  def test_immunization_for_patient_returns_empty_when_none
+    # Structured list semantics: no seeded :immunization_list rows → [].
+    assert_equal [], RpmsRpc::Immunization.for_patient("99999")
   end
 end

--- a/test/rpms_rpc/api/immunization_test.rb
+++ b/test/rpms_rpc/api/immunization_test.rb
@@ -128,4 +128,10 @@ class ImmunizationTest < Minitest::Test
     refute_nil call, "expected BEHOCIR GETTXT to be dispatched"
     assert_equal [ DFN ], call[:params]
   end
+
+  def test_text_summary_returns_nil_for_invalid_dfn
+    assert_nil RpmsRpc::Immunization.text_summary(nil)
+    assert_nil RpmsRpc::Immunization.text_summary("")
+    assert_nil RpmsRpc::Immunization.text_summary("0")
+  end
 end

--- a/test/rpms_rpc/api/immunization_test.rb
+++ b/test/rpms_rpc/api/immunization_test.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/version"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/immunization"
+
+class ImmunizationTest < Minitest::Test
+  DFN = "8791"
+  IMM_IEN = "7001"
+
+  SEEDED_RECORD = {
+    ien: 7001,
+    vaccine_code: "207",
+    vaccine_display: "COVID-19 Pfizer-BioNTech, mRNA",
+    status: "completed",
+    lot_number: "EX1234",
+    expiration_date: Date.new(2026, 12, 31),
+    site: "Left deltoid",
+    route: "IM",
+    performer_duz: "301",
+    performer_name: "MARTINEZ,SARAH",
+    occurrence_datetime: Time.utc(2026, 1, 15, 10, 0, 0),
+    dose_quantity: 0.3,
+    dose_unit: "mL",
+    manufacturer: "Pfizer-BioNTech",
+    vfc_eligibility_code: "V04",
+    funding_source: "VFC"
+  }.freeze
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  # --- for_patient ---
+
+  def test_for_patient_returns_array_of_structured_records
+    RpmsRpc.mock! do |m|
+      m.seed_keyed_collection(:immunization_list, DFN, [ SEEDED_RECORD ])
+    end
+
+    result = RpmsRpc::Immunization.for_patient(DFN)
+
+    assert_kind_of Array, result
+    assert_equal 1, result.length
+    assert_equal "207", result.first[:vaccine_code]
+    assert_equal "EX1234", result.first[:lot_number]
+    assert_equal "V04", result.first[:vfc_eligibility_code]
+  end
+
+  def test_for_patient_dispatches_bipc_immlist_with_dfn
+    RpmsRpc.mock! do |m|
+      m.seed_keyed_collection(:immunization_list, DFN, [])
+    end
+
+    RpmsRpc::Immunization.for_patient(DFN)
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BIPC IMMLIST" }
+    refute_nil call, "expected BIPC IMMLIST to be dispatched"
+    assert_equal [ DFN ], call[:params]
+  end
+
+  def test_for_patient_returns_empty_for_invalid_dfn
+    assert_equal [], RpmsRpc::Immunization.for_patient(nil)
+    assert_equal [], RpmsRpc::Immunization.for_patient("")
+    assert_equal [], RpmsRpc::Immunization.for_patient("0")
+  end
+
+  # --- find ---
+
+  def test_find_returns_a_single_structured_record
+    RpmsRpc.mock! do |m|
+      m.seed(:immunization_detail, IMM_IEN, SEEDED_RECORD)
+    end
+
+    result = RpmsRpc::Immunization.find(IMM_IEN)
+
+    assert_kind_of Hash, result
+    assert_equal "207", result[:vaccine_code]
+    assert_equal "Pfizer-BioNTech", result[:manufacturer]
+  end
+
+  def test_find_dispatches_bipc_immget_with_ien
+    RpmsRpc.mock! do |m|
+      m.seed(:immunization_detail, IMM_IEN, SEEDED_RECORD)
+    end
+
+    RpmsRpc::Immunization.find(IMM_IEN)
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BIPC IMMGET" }
+    refute_nil call, "expected BIPC IMMGET to be dispatched"
+    assert_equal [ IMM_IEN ], call[:params]
+  end
+
+  def test_find_returns_nil_for_invalid_ien
+    assert_nil RpmsRpc::Immunization.find(nil)
+    assert_nil RpmsRpc::Immunization.find("")
+    assert_nil RpmsRpc::Immunization.find("0")
+  end
+
+  def test_find_returns_nil_when_no_record_exists
+    RpmsRpc.mock! do |m|
+      m.seed(:immunization_detail, IMM_IEN, SEEDED_RECORD) # other record exists; the one we ask for doesn't
+    end
+
+    assert_nil RpmsRpc::Immunization.find("999999")
+  end
+
+  # --- text_summary (preserves old BEHOCIR GETTXT behavior) ---
+
+  def test_text_summary_returns_the_patient_summary_text_blob
+    summary = "PATIENT IMMUNIZATIONS:\n  2026-01-15 COVID-19 Pfizer EX1234\n"
+    RpmsRpc.mock! do |m|
+      m.seed_text(:immunization_text, DFN, summary)
+    end
+
+    text = RpmsRpc::Immunization.text_summary(DFN)
+    flattened = Array(text).join("\n")
+    assert_includes flattened, "COVID-19 Pfizer EX1234"
+  end
+
+  def test_text_summary_dispatches_behocir_gettxt
+    RpmsRpc.mock! { |m| m.seed_text(:immunization_text, DFN, "") }
+
+    RpmsRpc::Immunization.text_summary(DFN)
+
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BEHOCIR GETTXT" }
+    refute_nil call, "expected BEHOCIR GETTXT to be dispatched"
+    assert_equal [ DFN ], call[:params]
+  end
+end

--- a/test/rpms_rpc/data_mapper_test.rb
+++ b/test/rpms_rpc/data_mapper_test.rb
@@ -77,6 +77,16 @@ class RpmsRpc::DataMapperTest < Minitest::Test
     assert_equal Date.new(1980, 1, 15), result[:dob]
   end
 
+  def test_parse_one_coerces_float_fields
+    mapping = RpmsRpc::DataMapper.define(:test) do
+      rpc "TEST"
+      field 0, :amount, :float
+    end
+
+    assert_in_delta 0.3, mapping.parse_one("0.3")[:amount], 0.0001
+    assert_kind_of Float, mapping.parse_one("0.3")[:amount]
+  end
+
   def test_parse_one_coerces_boolean_fields
     mapping = RpmsRpc::DataMapper.define(:test) do
       rpc "TEST"


### PR DESCRIPTION
## Summary
- \`RpmsRpc::Immunization.for_patient(dfn)\` now returns an Array of structured immunization records (CVX code, vaccine display, status, lot, expiration, site/route, performer, occurrence datetime, dose, manufacturer, VFC eligibility, funding source). Invalid dfn returns \`[]\`.
- New \`find(ien)\` returns a single record hash or \`nil\`.
- The old text-blob behavior is preserved under a renamed accessor: \`text_summary(dfn)\` still calls BEHOCIR GETTXT for callers that want the patient-summary text.
- Adds two new mappings: \`:immunization_list\` (BIPC IMMLIST) and \`:immunization_detail\` (BIPC IMMGET). Wire field positions are best-effort pending wider trace capture, per the staff-workflow port convention.

## Why
The lakeraven-ehr engine model \`Immunization\` has ~16 structured attributes and an \`ImmunizationsController#index\` that expects an Array of hashes. The old text-blob \`for_patient\` couldn't satisfy that shape, so the engine had a placeholder gateway delegating to \`RpmsRpc::Allergy\` (wrong domain). This unblocks the engine-side migration.

## Out of scope
- VIS (Vaccine Information Statement) metadata — a separate lookup; track as a follow-up.

## Test plan
- [x] \`bundle exec rake test\` — 799 runs, 2210 assertions, 0 failures, 0 errors
- [x] Test coverage in \`test/rpms_rpc/api/immunization_test.rb\` includes structured-record assertions, BIPC IMMLIST/IMMGET dispatch checks, invalid-id edge cases, and the preserved \`text_summary\` behavior
- [x] Updated \`clinical_data_test.rb\` to assert against the new \`text_summary\` accessor + structured \`for_patient\` empty-list semantics
- [x] \`bundle exec rubocop\` — clean on changed files

Closes #106