### PR TITLE
Client: hard-fail on missing/default credentials in non-development env

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,14 +90,17 @@ client.disconnect
 | `VISTA_RPC_HOST`     | `localhost` | Broker hostname                    |
 | `VISTA_RPC_PORT`     | `9100`/`9200` | Default depends on subclass      |
 | `VISTA_RPC_TIMEOUT`  | `30`        | Read timeout in seconds            |
-| `RPMS_ACCESS_CODE`   | `PROV123`   | Default access code (dev only)     |
-| `RPMS_VERIFY_CODE`   | `PROV123!!` | Default verify code (dev only)     |
+| `RPMS_ACCESS_CODE`   | _(required)_ | Access code. In development only, falls back to `PROV123`. |
+| `RPMS_VERIFY_CODE`   | _(required)_ | Verify code. In development only, falls back to `PROV123!!`. |
+| `VISTA_RPC_ENV`      | _(unset = strict)_ | Set to `development` to opt into the PROV123/PROV123!! fallback. Unset or any other value is treated as production-strict. |
 
-> **Security:** the `PROV123` / `PROV123!!` defaults exist for the
-> standard FOIA-RPMS dev image. **Never** ship a deployment that
-> falls through to those defaults — always set `RPMS_ACCESS_CODE`
-> and `RPMS_VERIFY_CODE` (or pass them explicitly to
-> `#authenticate`) for any host that talks to real PHI.
+> **Strict-by-default credentials.** Outside a development environment
+> (`Rails.env.development?`, or `VISTA_RPC_ENV=development` when running
+> without Rails), `#authenticate` will raise `RpmsRpc::Client::CredentialError`
+> if `RPMS_ACCESS_CODE` / `RPMS_VERIFY_CODE` are missing, or if they are
+> set to the dev-only `PROV123` / `PROV123!!` debug values. This prevents
+> a misconfigured production deploy from silently talking to the broker
+> as a debug account.
 
 ## Components
 

--- a/README.md
+++ b/README.md
@@ -99,10 +99,18 @@ client.disconnect
 > **Strict-by-default credentials.** Outside a development environment
 > (`Rails.env.development?`, or `VISTA_RPC_ENV=development` when running
 > without Rails), `#authenticate` will raise `RpmsRpc::Client::CredentialError`
-> if `RPMS_ACCESS_CODE` / `RPMS_VERIFY_CODE` are missing, or if they are
-> set to the dev-only `PROV123` / `PROV123!!` debug values. This prevents
-> a misconfigured production deploy from silently talking to the broker
-> as a debug account.
+> in any of these cases:
+>
+> - `RPMS_ACCESS_CODE` / `RPMS_VERIFY_CODE` are missing, blank, or
+>   whitespace-only.
+> - The resolved access or verify code equals its dev-only `PROV123` /
+>   `PROV123!!` value — whether sourced from ENV, the legacy fallback,
+>   or passed *explicitly* as an argument to `#authenticate`.
+>
+> Explicit arguments take the same path as ENV-sourced values, so a
+> snippet like `client.authenticate("PROV123", "PROV123!!")` also
+> raises in production. This prevents a misconfigured deploy from
+> silently talking to the broker as a debug account.
 
 ## Components
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ require "rpms_rpc/cia_client"
 
 client = RpmsRpc::CiaClient.new(host: "vista.example.com", port: 9100)
 client.connect
-client.authenticate("PROV123", "PROV123!!")
+# Real Access / Verify codes. In development you can set
+# VISTA_RPC_ENV=development and omit args to fall back to PROV123 / PROV123!!
+client.authenticate(ENV.fetch("RPMS_ACCESS_CODE"), ENV.fetch("RPMS_VERIFY_CODE"))
 client.create_context("OR CPRS GUI CHART")
 
 result = client.call_rpc("XUS SIGNON SETUP")

--- a/lib/rpms_rpc/client.rb
+++ b/lib/rpms_rpc/client.rb
@@ -22,6 +22,12 @@ module RpmsRpc
     # Error classes
     class ConnectionError < StandardError; end
     class AuthenticationError < StandardError; end
+    # Raised when RPMS credentials are missing or set to the dev-only
+    # PROV123/PROV123!! defaults outside a development environment.
+    # Subclass of AuthenticationError so existing rescue blocks keep
+    # working, but callers can distinguish "credential misconfigured"
+    # from "credential rejected by broker".
+    class CredentialError < AuthenticationError; end
     class RpcError < StandardError; end
     class TimeoutError < ConnectionError; end
 
@@ -132,8 +138,7 @@ module RpmsRpc
     def authenticate(access_code = nil, verify_code = nil, **)
       raise ConnectionError, "Not connected" unless connected?
 
-      ac = access_code || ENV.fetch("RPMS_ACCESS_CODE", "PROV123")
-      vc = verify_code || ENV.fetch("RPMS_VERIFY_CODE", "PROV123!!")
+      ac, vc = resolve_credentials(access_code, verify_code)
 
       # Step 1: XUS SIGNON SETUP
       signon_setup
@@ -170,6 +175,58 @@ module RpmsRpc
 
       true
     end
+
+    # -- credential resolution ------------------------------------------------
+
+    DEV_DEFAULT_ACCESS = "PROV123"
+    DEV_DEFAULT_VERIFY = "PROV123!!"
+    private_constant :DEV_DEFAULT_ACCESS, :DEV_DEFAULT_VERIFY
+
+    # Resolve the access / verify pair from (in order) explicit args,
+    # then ENV. In a non-development environment, refuses to fall through
+    # to the DEV_DEFAULT_* values — raises CredentialError so a
+    # misconfigured deploy can't silently talk to the broker as a debug
+    # account.
+    #
+    # Development detection: `Rails.env == "development"` if Rails is
+    # loaded; otherwise `ENV["VISTA_RPC_ENV"] == "development"`. Anything
+    # unset is treated as production for strict-by-default safety.
+    def resolve_credentials(access_code, verify_code)
+      ac = access_code || ENV["RPMS_ACCESS_CODE"]
+      vc = verify_code || ENV["RPMS_VERIFY_CODE"]
+
+      if development_environment?
+        ac ||= DEV_DEFAULT_ACCESS
+        vc ||= DEV_DEFAULT_VERIFY
+        return [ ac, vc ]
+      end
+
+      if ac.nil? || vc.nil?
+        raise CredentialError,
+              "RPMS credentials not configured. Set RPMS_ACCESS_CODE and " \
+              "RPMS_VERIFY_CODE in the environment (or pass explicit args " \
+              "to #authenticate) — production deploys must not rely on " \
+              "the development PROV123 fallback."
+      end
+
+      if ac == DEV_DEFAULT_ACCESS && vc == DEV_DEFAULT_VERIFY
+        raise CredentialError,
+              "RPMS credentials are set to the development PROV123 / " \
+              "PROV123!! defaults. Refusing to authenticate against a " \
+              "production broker with debug credentials."
+      end
+
+      [ ac, vc ]
+    end
+
+    def development_environment?
+      if defined?(Rails) && Rails.respond_to?(:env) && Rails.env
+        Rails.env.development?
+      else
+        ENV["VISTA_RPC_ENV"] == "development"
+      end
+    end
+    private :development_environment?
 
     # XWB cipher encryption (matches $$ENCRYP^XUSRB1 in M)
     def xwb_encrypt(plaintext)

--- a/lib/rpms_rpc/client.rb
+++ b/lib/rpms_rpc/client.rb
@@ -209,11 +209,14 @@ module RpmsRpc
               "the development PROV123 fallback."
       end
 
-      if ac == DEV_DEFAULT_ACCESS && vc == DEV_DEFAULT_VERIFY
+      # Reject if EITHER value equals its dev default — a half-copied
+      # config (one real value, one PROV123 placeholder) is just as
+      # broken as the all-defaults case.
+      if ac == DEV_DEFAULT_ACCESS || vc == DEV_DEFAULT_VERIFY
         raise CredentialError,
-              "RPMS credentials are set to the development PROV123 / " \
-              "PROV123!! defaults. Refusing to authenticate against a " \
-              "production broker with debug credentials."
+              "RPMS credentials include the development PROV123 / " \
+              "PROV123!! default value. Refusing to authenticate against " \
+              "a production broker with any debug credential."
       end
 
       [ ac, vc ]

--- a/lib/rpms_rpc/client.rb
+++ b/lib/rpms_rpc/client.rb
@@ -201,7 +201,9 @@ module RpmsRpc
         return [ ac, vc ]
       end
 
-      if ac.nil? || vc.nil?
+      # Blank strings (empty / whitespace-only) are just as broken as
+      # unset credentials. Don't let an empty ENV value bypass the check.
+      if blank_credential?(ac) || blank_credential?(vc)
         raise CredentialError,
               "RPMS credentials not configured. Set RPMS_ACCESS_CODE and " \
               "RPMS_VERIFY_CODE in the environment (or pass explicit args " \
@@ -230,6 +232,11 @@ module RpmsRpc
       end
     end
     private :development_environment?
+
+    def blank_credential?(value)
+      value.nil? || value.to_s.strip.empty?
+    end
+    private :blank_credential?
 
     # XWB cipher encryption (matches $$ENCRYP^XUSRB1 in M)
     def xwb_encrypt(plaintext)

--- a/test/rpms_rpc/credential_strict_test.rb
+++ b/test/rpms_rpc/credential_strict_test.rb
@@ -66,6 +66,28 @@ class CredentialStrictTest < Minitest::Test
     end
   end
 
+  def test_production_env_raises_when_only_access_code_is_a_dev_default
+    ENV["VISTA_RPC_ENV"] = "production"
+    ENV["RPMS_ACCESS_CODE"] = DEV_ACCESS
+    ENV["RPMS_VERIFY_CODE"] = "REAL!!"
+    client = Client.new
+
+    assert_raises(RpmsRpc::Client::CredentialError) do
+      client.send(:resolve_credentials, nil, nil)
+    end
+  end
+
+  def test_production_env_raises_when_only_verify_code_is_a_dev_default
+    ENV["VISTA_RPC_ENV"] = "production"
+    ENV["RPMS_ACCESS_CODE"] = "REAL"
+    ENV["RPMS_VERIFY_CODE"] = DEV_VERIFY
+    client = Client.new
+
+    assert_raises(RpmsRpc::Client::CredentialError) do
+      client.send(:resolve_credentials, nil, nil)
+    end
+  end
+
   def test_production_env_accepts_explicit_non_default_credentials
     ENV["VISTA_RPC_ENV"] = "production"
     client = Client.new
@@ -93,6 +115,59 @@ class CredentialStrictTest < Minitest::Test
     client = Client.new
     assert_raises(RpmsRpc::Client::CredentialError) do
       client.send(:resolve_credentials, nil, nil)
+    end
+  end
+
+  # --- Rails.env branches of development_environment? -----------------------
+
+  # Minimal Rails / Rails.env stub so tests don't need to load Rails.
+  class FakeRailsEnv
+    def initialize(name); @name = name; end
+    def development?; @name == "development"; end
+    def production?;  @name == "production"; end
+    def to_s; @name; end
+  end
+
+  module FakeRails
+    class << self
+      attr_accessor :env
+    end
+  end
+
+  def with_rails_const(env_name)
+    Object.const_set(:Rails, FakeRails)
+    FakeRails.env = env_name.nil? ? nil : FakeRailsEnv.new(env_name)
+    yield
+  ensure
+    Object.send(:remove_const, :Rails) if Object.const_defined?(:Rails)
+  end
+
+  def test_rails_development_env_uses_dev_fallback
+    with_rails_const("development") do
+      client = Client.new
+      ac, vc = client.send(:resolve_credentials, nil, nil)
+      assert_equal DEV_ACCESS, ac
+      assert_equal DEV_VERIFY, vc
+    end
+  end
+
+  def test_rails_production_env_raises_on_unset_credentials
+    with_rails_const("production") do
+      client = Client.new
+      assert_raises(RpmsRpc::Client::CredentialError) do
+        client.send(:resolve_credentials, nil, nil)
+      end
+    end
+  end
+
+  def test_rails_env_nil_falls_back_to_vista_rpc_env_check
+    # Rails defined but Rails.env is nil — treat as production-strict
+    # (the strict-by-default rule applies).
+    with_rails_const(nil) do
+      client = Client.new
+      assert_raises(RpmsRpc::Client::CredentialError) do
+        client.send(:resolve_credentials, nil, nil)
+      end
     end
   end
 

--- a/test/rpms_rpc/credential_strict_test.rb
+++ b/test/rpms_rpc/credential_strict_test.rb
@@ -88,6 +88,36 @@ class CredentialStrictTest < Minitest::Test
     end
   end
 
+  def test_production_env_raises_on_blank_or_whitespace_credentials
+    ENV["VISTA_RPC_ENV"] = "production"
+    client = Client.new
+
+    [ "", "   ", "\t\n" ].each do |blank|
+      ENV["RPMS_ACCESS_CODE"] = blank
+      ENV["RPMS_VERIFY_CODE"] = "REAL!!"
+      assert_raises(RpmsRpc::Client::CredentialError) do
+        client.send(:resolve_credentials, nil, nil)
+      end
+
+      ENV["RPMS_ACCESS_CODE"] = "REAL"
+      ENV["RPMS_VERIFY_CODE"] = blank
+      assert_raises(RpmsRpc::Client::CredentialError) do
+        client.send(:resolve_credentials, nil, nil)
+      end
+    end
+  end
+
+  def test_production_env_raises_when_explicit_args_are_dev_defaults
+    # The doc + Copilot review correctly note: explicit args take the
+    # same path; passing PROV123 / PROV123!! literally must also raise.
+    ENV["VISTA_RPC_ENV"] = "production"
+    client = Client.new
+
+    assert_raises(RpmsRpc::Client::CredentialError) do
+      client.send(:resolve_credentials, DEV_ACCESS, DEV_VERIFY)
+    end
+  end
+
   def test_production_env_accepts_explicit_non_default_credentials
     ENV["VISTA_RPC_ENV"] = "production"
     client = Client.new

--- a/test/rpms_rpc/credential_strict_test.rb
+++ b/test/rpms_rpc/credential_strict_test.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/client"
+
+# Tests for the credential-strict behavior — credentials must be set
+# explicitly (or via env) in non-development environments. Falling through
+# to the legacy `PROV123` debug defaults must hard-fail in production so a
+# misconfigured deploy can't silently talk to the broker as a debug account.
+class CredentialStrictTest < Minitest::Test
+  Client = RpmsRpc::Client
+  DEV_ACCESS = "PROV123"
+  DEV_VERIFY = "PROV123!!"
+
+  def setup
+    @prev = {
+      "RPMS_ACCESS_CODE" => ENV["RPMS_ACCESS_CODE"],
+      "RPMS_VERIFY_CODE" => ENV["RPMS_VERIFY_CODE"],
+      "VISTA_RPC_ENV" => ENV["VISTA_RPC_ENV"]
+    }
+    %w[RPMS_ACCESS_CODE RPMS_VERIFY_CODE VISTA_RPC_ENV].each { |k| ENV.delete(k) }
+  end
+
+  def teardown
+    @prev.each { |k, v| ENV[k] = v }
+  end
+
+  # --- development env preserves the legacy fallback (so dev workflows keep working) ---
+
+  def test_development_env_falls_through_to_dev_defaults_when_creds_unset
+    ENV["VISTA_RPC_ENV"] = "development"
+    client = Client.new
+    ac, vc = client.send(:resolve_credentials, nil, nil)
+    assert_equal DEV_ACCESS, ac
+    assert_equal DEV_VERIFY, vc
+  end
+
+  def test_development_env_accepts_explicit_credentials
+    ENV["VISTA_RPC_ENV"] = "development"
+    client = Client.new
+    ac, vc = client.send(:resolve_credentials, "REAL", "REAL!!")
+    assert_equal "REAL", ac
+    assert_equal "REAL!!", vc
+  end
+
+  # --- non-development env: hard-fail on unset / default creds ---
+
+  def test_production_env_raises_when_credentials_are_unset
+    ENV["VISTA_RPC_ENV"] = "production"
+    client = Client.new
+
+    err = assert_raises(RpmsRpc::Client::CredentialError) do
+      client.send(:resolve_credentials, nil, nil)
+    end
+    assert_match(/RPMS_ACCESS_CODE|production|credential/i, err.message)
+  end
+
+  def test_production_env_raises_when_env_values_are_dev_defaults
+    ENV["VISTA_RPC_ENV"] = "production"
+    ENV["RPMS_ACCESS_CODE"] = DEV_ACCESS
+    ENV["RPMS_VERIFY_CODE"] = DEV_VERIFY
+    client = Client.new
+
+    assert_raises(RpmsRpc::Client::CredentialError) do
+      client.send(:resolve_credentials, nil, nil)
+    end
+  end
+
+  def test_production_env_accepts_explicit_non_default_credentials
+    ENV["VISTA_RPC_ENV"] = "production"
+    client = Client.new
+
+    ac, vc = client.send(:resolve_credentials, "REAL", "REAL!!")
+    assert_equal "REAL", ac
+    assert_equal "REAL!!", vc
+  end
+
+  def test_production_env_accepts_env_supplied_non_default_credentials
+    ENV["VISTA_RPC_ENV"] = "production"
+    ENV["RPMS_ACCESS_CODE"] = "REALPROV"
+    ENV["RPMS_VERIFY_CODE"] = "REALPROV!!"
+    client = Client.new
+
+    ac, vc = client.send(:resolve_credentials, nil, nil)
+    assert_equal "REALPROV", ac
+    assert_equal "REALPROV!!", vc
+  end
+
+  # --- VISTA_RPC_ENV defaults to production (strict-by-default) ---
+
+  def test_unset_environment_defaults_to_strict_production
+    # VISTA_RPC_ENV unset, no Rails
+    client = Client.new
+    assert_raises(RpmsRpc::Client::CredentialError) do
+      client.send(:resolve_credentials, nil, nil)
+    end
+  end
+
+  # --- CredentialError is an AuthenticationError subclass (preserves catch shape) ---
+
+  def test_credential_error_is_an_authentication_error
+    assert_operator RpmsRpc::Client::CredentialError, :<, RpmsRpc::Client::AuthenticationError
+  end
+end


### PR DESCRIPTION
## Summary
- Removes the \`PROV123\` / \`PROV123!!\` literal fallbacks from the \`authenticate\` call path.
- New \`resolve_credentials\` helper raises \`RpmsRpc::Client::CredentialError\` (subclass of \`AuthenticationError\`) outside a development environment when credentials are unset or set to the dev-only debug pair.
- Development detection: \`Rails.env.development?\` if Rails is loaded; otherwise \`VISTA_RPC_ENV == \"development\"\`. Unset = strict production by default — safer.
- README updated to describe the strict-by-default behavior and the new \`VISTA_RPC_ENV\` opt-in.

## Why
Silent prod-as-dev is the most dangerous failure mode for a healthcare integration. A misconfigured deploy that fell through to \`PROV123\` would authenticate as a debug account, with whatever security keys that account holds, against real PHI. Spelling correctness > availability for credentials.

## Test plan
- [x] \`bundle exec rake test\` — 810 runs, 2232 assertions, 0 failures, 0 errors
- [x] New \`test/rpms_rpc/credential_strict_test.rb\` exercises 8 paths:
  - development env preserves the legacy fallback (both unset and explicit)
  - production env raises when both creds unset
  - production env raises when both ENVs are set to dev defaults
  - production env accepts explicit non-default args
  - production env accepts non-default ENVs
  - unset \`VISTA_RPC_ENV\` defaults to strict production
  - \`CredentialError < AuthenticationError\` (preserves catch shape)
- [x] \`bundle exec rubocop\` — clean

Closes #108