### PR TITLE
Sanitize exception messages that interpolate broker payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,25 @@ client.disconnect
 | `RpmsRpc::UserRoles`           | Role-based authorization (provider, nurse, etc.) |
 | `RpmsRpc::Capabilities`        | Feature-gated permission checks                  |
 
+### Exception-message sanitization
+
+The gem doesn't emit internal logs of its own; the PHI risk vector is
+**exception messages** that interpolate raw broker response payloads
+(authentication errors, BMX security / application errors, handshake
+rejections). Those raise sites pass through `RpmsRpc.sanitize_error`,
+which scrubs PHI patterns via `RpmsRpc::PhiSanitizer.sanitize_message`
+before the exception propagates to the host.
+
+This is on by default. To opt out — for example, in a local
+forensic-capture session where the raw broker payload is what you
+need to see:
+
+```ruby
+RpmsRpc.configure { |c| c.unsafe_raw_errors = true }
+```
+
+Leave this off in production.
+
 ### PhiSanitizer secret
 
 `RpmsRpc::PhiSanitizer` uses HMAC-SHA256 to hash patient identifiers

--- a/lib/rpms_rpc/bmx_client.rb
+++ b/lib/rpms_rpc/bmx_client.rb
@@ -32,7 +32,7 @@ module RpmsRpc
       else
         @socket&.close
         @socket = nil
-        raise ConnectionError, "BMX server rejected handshake: #{response}"
+        raise ConnectionError, RpmsRpc.sanitize_error("BMX server rejected handshake: #{response}")
       end
 
       @connected
@@ -170,7 +170,7 @@ module RpmsRpc
         if sec_len > 0 && pos + sec_len <= raw.length
           sec_err = raw[pos, sec_len]
           pos += sec_len
-          raise ConnectionError, "BMX security error: #{sec_err}" unless sec_err.empty?
+          raise ConnectionError, RpmsRpc.sanitize_error("BMX security error: #{sec_err}") unless sec_err.empty?
         end
       end
 
@@ -181,7 +181,7 @@ module RpmsRpc
         if app_len > 0 && pos + app_len <= raw.length
           app_err = raw[pos, app_len]
           pos += app_len
-          raise RpcError, "BMX application error: #{app_err}" unless app_err.empty?
+          raise RpcError, RpmsRpc.sanitize_error("BMX application error: #{app_err}") unless app_err.empty?
         end
       end
 

--- a/lib/rpms_rpc/cia_client.rb
+++ b/lib/rpms_rpc/cia_client.rb
@@ -29,7 +29,7 @@ module RpmsRpc
       else
         @socket&.close
         @socket = nil
-        raise ConnectionError, "Server rejected handshake: #{response}"
+        raise ConnectionError, RpmsRpc.sanitize_error("Server rejected handshake: #{response}")
       end
 
       @connected

--- a/lib/rpms_rpc/client.rb
+++ b/lib/rpms_rpc/client.rb
@@ -153,7 +153,9 @@ module RpmsRpc
 
       if duz_str == "0" || duz_str.empty?
         err_msg = lines[3]&.strip if lines.length > 3
-        raise AuthenticationError, (err_msg.nil? || err_msg.empty? ? "Authentication failed" : err_msg)
+        raise AuthenticationError, RpmsRpc.sanitize_error(
+          err_msg.nil? || err_msg.empty? ? "Authentication failed" : err_msg
+        )
       end
 
       @authenticated = true
@@ -170,7 +172,9 @@ module RpmsRpc
       reply = call_rpc_raw("XWB CREATE CONTEXT", encrypted)
 
       unless reply&.strip == "1"
-        raise RpcError, "Failed to create context '#{option_name}': #{reply}"
+        raise RpcError, RpmsRpc.sanitize_error(
+          "Failed to create context '#{option_name}': #{reply}"
+        )
       end
 
       true

--- a/lib/rpms_rpc/version.rb
+++ b/lib/rpms_rpc/version.rb
@@ -10,7 +10,17 @@ module RpmsRpc
   class NotConfiguredError < StandardError; end
 
   class Configuration
-    attr_accessor :client, :fhir_client
+    # `unsafe_raw_errors` opts out of PhiSanitizer scrubbing for
+    # exception messages. Off by default — production deploys should
+    # leave it off. Turn on only for development / offline forensic
+    # captures where preserving raw broker payloads matters.
+    attr_accessor :client, :fhir_client, :unsafe_raw_errors
+
+    def initialize
+      @client = nil
+      @fhir_client = nil
+      @unsafe_raw_errors = false
+    end
   end
 
   class << self
@@ -40,6 +50,18 @@ module RpmsRpc
 
     def reset!
       @configuration = Configuration.new
+    end
+
+    # Scrub PHI patterns from `message` before it propagates to a host
+    # logger / exception handler. Used at exception-raise sites where
+    # the gem interpolates raw broker response payloads. Honors the
+    # `unsafe_raw_errors` flag.
+    def sanitize_error(message)
+      return "" if message.nil?
+      return message.to_s if configuration.unsafe_raw_errors
+
+      require_relative "phi_sanitizer"
+      PhiSanitizer.sanitize_message(message.to_s)
     end
 
     # Convenience: configure a MockClient for testing.

--- a/test/rpms_rpc/error_sanitization_test.rb
+++ b/test/rpms_rpc/error_sanitization_test.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/version"
+require "rpms_rpc/client"
+require "rpms_rpc/phi_sanitizer"
+
+# Tests for PHI sanitization of exception messages.
+#
+# The gem doesn't emit internal logs (no @logger calls anywhere); the
+# PHI risk vector is exception messages that interpolate raw broker
+# response payloads (auth errors, handshake rejections, BMX security
+# errors). Those raise sites must scrub PHI before the exception
+# propagates to the host.
+class ErrorSanitizationTest < Minitest::Test
+  def teardown
+    RpmsRpc.configuration.unsafe_raw_errors = false
+  end
+
+  # --- Configuration flag --------------------------------------------------
+
+  def test_unsafe_raw_errors_defaults_to_false
+    refute RpmsRpc.configuration.unsafe_raw_errors,
+      "Strict sanitization must be the default"
+  end
+
+  def test_unsafe_raw_errors_is_a_configuration_attribute
+    RpmsRpc.configuration.unsafe_raw_errors = true
+    assert RpmsRpc.configuration.unsafe_raw_errors
+  end
+
+  # --- sanitize_error helper -----------------------------------------------
+
+  def test_sanitize_error_scrubs_phi_name
+    raw = "Authentication failed for patient: SMITH,JOHN"
+    sanitized = RpmsRpc.sanitize_error(raw)
+
+    refute_includes sanitized, "SMITH,JOHN"
+    assert_includes sanitized, "Authentication failed"
+  end
+
+  def test_sanitize_error_scrubs_dfn_identifier
+    # PHI redaction of the DFN itself. (The patient-name regex can
+    # greedy-consume an immediately-adjacent token; this test uses a
+    # message shape where DFN appears on its own so the substitution
+    # is testable end-to-end.)
+    raw = "RPC failed; DFN: 12345 not found"
+    sanitized = RpmsRpc.sanitize_error(raw)
+
+    refute_includes sanitized, "12345"
+    assert_includes sanitized, "DFN:[REDACTED]"
+  end
+
+  def test_sanitize_error_passes_through_when_unsafe_raw_errors_enabled
+    RpmsRpc.configuration.unsafe_raw_errors = true
+    raw = "Authentication failed for patient: SMITH,JOHN"
+
+    assert_equal raw, RpmsRpc.sanitize_error(raw)
+  end
+
+  def test_sanitize_error_leaves_innocuous_messages_unchanged
+    raw = "Failed to create context 'OR CPRS GUI CHART': 0"
+    sanitized = RpmsRpc.sanitize_error(raw)
+
+    assert_includes sanitized, "OR CPRS GUI CHART"
+    assert_includes sanitized, "Failed to create context"
+  end
+
+  def test_sanitize_error_handles_nil_safely
+    assert_equal "", RpmsRpc.sanitize_error(nil)
+  end
+
+  # --- exception-message wrapping at the raise sites ----------------------
+
+  # Pin a couple of the highest-risk sites end-to-end. A focused unit test
+  # is cheaper than a full mock-broker integration; we just ensure the
+  # raise site goes through sanitize_error.
+  def test_authentication_error_message_is_sanitized
+    require "rpms_rpc/client"
+    client = RpmsRpc::Client.new
+    client.instance_variable_set(:@connected, true)
+    client.instance_variable_set(:@socket, StringIO.new)
+
+    # Stub signon_setup and call_rpc_raw to return a broker response
+    # that embeds PHI in line 3 (the error message slot).
+    def client.signon_setup; end
+    def client.call_rpc_raw(*)
+      "0\r\nfoo\r\nbar\r\nauth fail for patient: SMITH,JOHN\r\n"
+    end
+
+    err = assert_raises(RpmsRpc::Client::AuthenticationError) do
+      client.authenticate("REAL", "REAL!!")
+    end
+    refute_includes err.message, "SMITH,JOHN"
+  ensure
+    ENV.delete("VISTA_RPC_ENV")
+  end
+end


### PR DESCRIPTION
## Summary
- The gem has no internal logs (no \`@logger\` / \`puts\` / \`STDERR\` calls anywhere); the real PHI vector is **exception messages** that interpolate raw broker response payloads.
- Adds \`RpmsRpc.sanitize_error(message)\` — routes through \`PhiSanitizer.sanitize_message\` when the new \`Configuration#unsafe_raw_errors\` flag is false (the default).
- Wraps every raise site where broker data gets interpolated:
  - \`Client#authenticate\` — broker auth-failure message
  - \`Client#create_context\` — context-create error embedding broker reply
  - \`CiaClient\` handshake rejection
  - \`BmxClient\` handshake rejection, security error, application error
- Bare \"Not connected\" / \"Timed out\" / \"S-PACK too long\" raises don't carry broker data and are left alone.
- README adds an 'Exception-message sanitization' section documenting the default-on behavior and the \`unsafe_raw_errors\` opt-out.

## Why
Issue #109's body talked about routing internal logs through PhiSanitizer, but the gem doesn't emit any. The actual PHI propagation path is via exception messages, which currently leak raw broker payloads to whatever the host catches them with.

## Test plan
- [x] \`bundle exec rake test\` — 825 runs, 2264 assertions, 0 failures, 0 errors
- [x] New \`test/rpms_rpc/error_sanitization_test.rb\` (8 tests, 19 assertions):
  - \`unsafe_raw_errors\` defaults to false
  - \`sanitize_error\` scrubs names + DFN identifiers; preserves innocuous strings; handles nil
  - \`sanitize_error\` passes through when \`unsafe_raw_errors\` is true
  - End-to-end through \`Client#authenticate\` — a broker auth-failure response embedding a PHI-shaped name is sanitized in the raised \`AuthenticationError.message\`
- [x] \`bundle exec rubocop\` — clean

Closes #109