### PR TITLE
Detect CAN-prefixed VistA-M error frames; brief_header degrades to nil

### DIFF
--- a/lib/rpms_rpc/api/patient.rb
+++ b/lib/rpms_rpc/api/patient.rb
@@ -60,6 +60,10 @@ module RpmsRpc
         ad_flag:          cwad.to_s.include?("D"),
         primary_provider: provider
       }
+    rescue RpmsRpc::Client::RpcError
+      # BEHO* RPCs unavailable on this Broker (e.g., BHS package not
+      # installed). Treat as "feature unavailable", not as a hard error.
+      nil
     end
 
     # Compute integer years between dob and today. `today:` is a keyword arg

--- a/lib/rpms_rpc/api/patient.rb
+++ b/lib/rpms_rpc/api/patient.rb
@@ -60,9 +60,13 @@ module RpmsRpc
         ad_flag:          cwad.to_s.include?("D"),
         primary_provider: provider
       }
-    rescue RpmsRpc::Client::RpcError
-      # BEHO* RPCs unavailable on this Broker (e.g., BHS package not
-      # installed). Treat as "feature unavailable", not as a hard error.
+    rescue RpmsRpc::Client::RpcError => e
+      # Only degrade to nil when the error signature indicates the RPC
+      # itself is unavailable on this Broker (BHS package not installed,
+      # OPTION lacks the RPC, etc.). Genuine M-runtime errors and
+      # permission/authorization failures must propagate so they aren't
+      # silently masked as "feature unavailable".
+      raise unless e.message.match?(/<NOLINE>|Remote Procedure .* (?:doesn't exist|not found)/i)
       nil
     end
 

--- a/lib/rpms_rpc/client.rb
+++ b/lib/rpms_rpc/client.rb
@@ -397,11 +397,16 @@ module RpmsRpc
       raise ConnectionError, "Connection lost - network error: #{e.message}"
     end
 
-    # Check for M errors returned as data (not via SNDERR)
+    # Check for M errors returned as data (not via SNDERR).
+    #
+    # Some Brokers prefix error payloads with \x18 (CAN, wire-level error
+    # sentinel) before the "M  ERROR=" frame. String#strip does not remove
+    # \x18, so anchor-matching on the raw response misses these — peel the
+    # sentinel before the regex.
     def check_for_rpc_error(response)
       return if response.nil? || response.empty?
 
-      clean = response.strip.gsub(/\x00+$/, "")
+      clean = response.sub(/\A\x18/, "").strip.gsub(/\x00+$/, "")
       if clean.match?(/\A(?:M  ERROR|E?Remote Procedure '.*' doesn't exist|E?Remote Procedure '.*' not found)/i)
         raise RpcError, clean
       end

--- a/test/rpms_rpc/api/patient_brief_header_test.rb
+++ b/test/rpms_rpc/api/patient_brief_header_test.rb
@@ -164,4 +164,36 @@ class PatientBriefHeaderTest < Minitest::Test
 
     assert_nil RpmsRpc::Patient.brief_header(8791)
   end
+
+  def test_brief_header_returns_nil_for_remote_procedure_not_found
+    raising_client = Class.new do
+      def call_rpc(*)
+        raise RpmsRpc::Client::RpcError, "Remote Procedure 'BEHOPTCX PTINFO' doesn't exist"
+      end
+    end.new
+
+    RpmsRpc.reset!
+    RpmsRpc.configure { |cfg| cfg.client = raising_client }
+
+    assert_nil RpmsRpc::Patient.brief_header(8791)
+  end
+
+  # Genuine M-runtime errors (e.g., <UNDEFINED>, <SUBSCRIPT>) and permission
+  # failures indicate a real problem, not "feature unavailable". They must
+  # propagate so they aren't silently masked.
+  def test_brief_header_propagates_non_missing_routine_rpc_errors
+    raising_client = Class.new do
+      def call_rpc(*)
+        raise RpmsRpc::Client::RpcError, "M  ERROR=<UNDEFINED>FOO+5^XYZ^"
+      end
+    end.new
+
+    RpmsRpc.reset!
+    RpmsRpc.configure { |cfg| cfg.client = raising_client }
+
+    err = assert_raises(RpmsRpc::Client::RpcError) do
+      RpmsRpc::Patient.brief_header(8791)
+    end
+    assert_includes err.message, "UNDEFINED"
+  end
 end

--- a/test/rpms_rpc/api/patient_brief_header_test.rb
+++ b/test/rpms_rpc/api/patient_brief_header_test.rb
@@ -2,6 +2,7 @@
 
 require "minitest/autorun"
 require "date"
+require "rpms_rpc/client"
 require "rpms_rpc/mock_client"
 require "rpms_rpc/api/patient"
 
@@ -141,5 +142,26 @@ class PatientBriefHeaderTest < Minitest::Test
       m.seed(:patient_select, "1", { name: "TEST,ONE", sex: "F", age: 30 })
     end
     refute_nil RpmsRpc::Patient.find(1)
+  end
+
+  # === Broker error tolerance (issue #117) ===
+  #
+  # `brief_header` routes through BEHO* RPCs (BHS package). If the target
+  # Broker doesn't have BHS installed, the underlying call raises RpcError
+  # ("<NOLINE>" / "doesn't exist"). brief_header should treat that as
+  # "feature unavailable on this Broker" and return nil cleanly — silent
+  # garbage projection was the failure mode in #117.
+
+  def test_brief_header_returns_nil_when_broker_raises_rpc_error
+    raising_client = Class.new do
+      def call_rpc(*)
+        raise RpmsRpc::Client::RpcError, "M  ERROR=<NOLINE>PTINFO+22 BEHOPTCX"
+      end
+    end.new
+
+    RpmsRpc.reset!
+    RpmsRpc.configure { |cfg| cfg.client = raising_client }
+
+    assert_nil RpmsRpc::Patient.brief_header(8791)
   end
 end

--- a/test/rpms_rpc/client_test.rb
+++ b/test/rpms_rpc/client_test.rb
@@ -166,4 +166,40 @@ class RpmsRpc::ClientTest < Minitest::Test
   def test_create_context_raises_when_not_connected
     assert_raises(Client::ConnectionError) { Client.new.create_context }
   end
+
+  # -- check_for_rpc_error: VistA-M error frame detection --------------------
+
+  # Real wire shape observed against FOIA-RPMS when a BHS-namespace RPC
+  # targets a routine that isn't installed on the server. The Broker prefixes
+  # the error payload with \x18 (CAN, "wire-level error signal"), then the
+  # literal "M  ERROR=" frame, then the runtime context.
+  def test_check_for_rpc_error_raises_on_can_prefixed_m_error_frame
+    payload = "\x18M  ERROR=<NOLINE>PTINFO+22^BEHOPTCX^"
+    err = assert_raises(Client::RpcError) do
+      Client.new.send(:check_for_rpc_error, payload)
+    end
+    assert_includes err.message, "NOLINE"
+    assert_includes err.message, "BEHOPTCX"
+  end
+
+  # Some Brokers emit the error without the CAN sentinel. Keep the existing
+  # bare-"M  ERROR=" case working as a regression guard.
+  def test_check_for_rpc_error_raises_on_bare_m_error_frame
+    payload = "M  ERROR=<UNDEFINED>FOO+5^BAR^"
+    err = assert_raises(Client::RpcError) do
+      Client.new.send(:check_for_rpc_error, payload)
+    end
+    assert_includes err.message, "UNDEFINED"
+  end
+
+  # Patient name happens to contain "M" — must not be misread as M error.
+  def test_check_for_rpc_error_does_not_raise_on_data_containing_letter_m
+    payload = "1^MOUSE,MICKEY M^M^2840214^"
+    assert_nil Client.new.send(:check_for_rpc_error, payload)
+  end
+
+  def test_check_for_rpc_error_no_raise_on_empty_or_nil
+    assert_nil Client.new.send(:check_for_rpc_error, "")
+    assert_nil Client.new.send(:check_for_rpc_error, nil)
+  end
 end


### PR DESCRIPTION
## Summary

- `check_for_rpc_error` peels a leading `\x18` (CAN sentinel) before anchor-matching on `M  ERROR=`, so wire-level error frames raise `RpcError` instead of being silently projected as caret records.
- `Patient.brief_header` rescues `RpcError` and returns `nil` so callers against Brokers without the BHS (`BEHO*`) namespace get a clean "feature unavailable" result rather than a hash with the routine name leaking into typed fields like `sex:`.

## Background

Observed against a stock FOIA-RPMS demo Broker, every DFN returned:

```ruby
{name: "\x18M  ERROR=<NOLINE>PTINFO+22",
 sex:  "BEHOPTCX",          # routine name leaking into a typed field
 dob: nil, mrn: nil, ...}
```

Two bugs combined: the existing `check_for_rpc_error` regex anchors at `\A(?:M  ERROR|...)` and `String#strip` does not remove `\x18`, so the CAN-prefixed payload never matched and fell through to caret-projection. The symbolic API method then had no `rescue`.

## Test plan

- [x] `check_for_rpc_error` raises on CAN-prefixed `M  ERROR=` frames.
- [x] Regression guards: bare `M  ERROR=` still raises; data containing the letter "M" in a patient name does not raise; empty/nil inputs are no-ops.
- [x] `Patient.brief_header` returns `nil` when the underlying RPC raises `RpcError`.
- [x] Full suite: `bundle exec rake test` — 830 runs, 2276 assertions, 0 failures, 0 errors, 0 skips.

## Scope notes

This ships the **backstop**: detect the error at the wire layer + degrade gracefully at the symbolic API. The structurally cleaner fix — capability detection at `create_context` time so we never issue the unsupported call in the first place — is filed as #118 and supersedes the `rescue` as the primary path once landed.

Closes #117.