### PR TITLE
Detect server-side RPC availability via lazy feature probing

### DIFF
--- a/lib/rpms_rpc/api/patient.rb
+++ b/lib/rpms_rpc/api/patient.rb
@@ -41,6 +41,7 @@ module RpmsRpc
     # (no PTINFO and no GETBDP response).
     def brief_header(dfn)
       return nil if dfn.nil? || dfn.to_i <= 0
+      return nil unless RpmsRpc.client.supports?(:patient_chart_banner)
 
       ptinfo = DataMapper.patient_ptinfo.fetch_one(dfn.to_s)
       bdp    = DataMapper.patient_designated_provider.fetch_one(dfn.to_s)

--- a/lib/rpms_rpc/client.rb
+++ b/lib/rpms_rpc/client.rb
@@ -192,6 +192,9 @@ module RpmsRpc
         )
       end
 
+      # RPC registration is OPTION-scoped; capabilities probed under the
+      # previous context may not hold under the new one.
+      @capability_cache = nil
       true
     end
 
@@ -322,6 +325,7 @@ module RpmsRpc
       @connected = false
       @authenticated = false
       @duz = nil
+      @capability_cache = nil
     end
 
     # Open a TCP socket to the broker

--- a/lib/rpms_rpc/client.rb
+++ b/lib/rpms_rpc/client.rb
@@ -3,6 +3,7 @@
 require "socket"
 require "rpms_rpc/parameter_encoder"
 require "rpms_rpc/xml_response_parser"
+require "rpms_rpc/server_capabilities"
 
 module RpmsRpc
   # Abstract base class for RPMS RPC broker clients.
@@ -161,6 +162,20 @@ module RpmsRpc
       @authenticated = true
       @duz = duz_str
       { success: true, duz: duz_str.to_i }
+    end
+
+    # Whether the Broker behind this client can service `feature`.
+    #
+    # First call per feature probes the underlying RPCs via
+    # ServerCapabilities; subsequent calls return the cached result.
+    # Engine code should consult this before issuing the underlying calls
+    # so that "feature unavailable" returns nil/empty without a wasted
+    # Broker round-trip.
+    def supports?(feature)
+      @capability_cache ||= {}
+      return @capability_cache[feature] if @capability_cache.key?(feature)
+
+      @capability_cache[feature] = ServerCapabilities.probe(self, feature)
     end
 
     # Set application context (required before calling most RPCs)

--- a/lib/rpms_rpc/client.rb
+++ b/lib/rpms_rpc/client.rb
@@ -330,6 +330,11 @@ module RpmsRpc
 
     # Open a TCP socket to the broker
     def open_socket(host, port)
+      # Implicit reconnects (after a send/recv error path that only set
+      # @connected = false) re-enter here without going through
+      # reset_connection. Clear the capability cache so a reconnect to
+      # the same or a different Broker can never inherit stale answers.
+      @capability_cache = nil
       @host = host
       @port = port
       @socket = TCPSocket.new(host, port)

--- a/lib/rpms_rpc/mock_client.rb
+++ b/lib/rpms_rpc/mock_client.rb
@@ -141,6 +141,19 @@ module RpmsRpc
       @received_calls ||= []
     end
 
+    # Pre-populate a ServerCapabilities answer so `supports?` short-circuits
+    # without probing. Default is `true` (preserve backward compatibility:
+    # tests that don't seed see all features as available).
+    def seed_capability(feature, supported: true)
+      @capability_seeds ||= {}
+      @capability_seeds[feature] = supported
+    end
+
+    def supports?(feature)
+      @capability_seeds ||= {}
+      @capability_seeds.fetch(feature, true)
+    end
+
     # Simulate call_rpc — returns formatted response matching the seeded data.
     def call_rpc(rpc_name, *params)
       received_calls << { rpc: rpc_name, params: params }

--- a/lib/rpms_rpc/server_capabilities.rb
+++ b/lib/rpms_rpc/server_capabilities.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module RpmsRpc
+  # Server-side capability detection. Distinct from `RpmsRpc::Capabilities`,
+  # which is user-permission focused (security keys, role-based access).
+  # This module answers "is this RPC installed and callable on the Broker?"
+  #
+  # Engine code asks by symbolic feature name, never by RPC name:
+  #
+  #   RpmsRpc.client.supports?(:patient_chart_banner)
+  #
+  # Detection is a per-RPC probe (call with no params; the Broker reports
+  # "RPC doesn't exist" / "<NOLINE>" before any param validation runs).
+  # ALL FEATURES REGISTERED HERE MUST RESOLVE TO READ-ONLY RPCS — probing
+  # would otherwise have side effects on write paths.
+  #
+  # Results are cached on the client instance via `Client#supports?`, so
+  # each feature is probed at most once per session.
+  module ServerCapabilities
+    FEATURE_RPCS = {
+      # Patient.brief_header — chart-banner projection.
+      # Requires the IHS Behavioral Health Suite (BEHO* namespace).
+      patient_chart_banner: [
+        "BEHOPTCX PTINFO",
+        "BEHOPTPC GETBDP",
+        "BEHOCACV CWAD"
+      ].freeze
+    }.freeze
+
+    # RPC error messages that indicate the RPC itself is not installed
+    # or not registered to the current OPTION. Anything else means the
+    # RPC IS present (it ran far enough to raise a different error).
+    MISSING_RPC_PATTERN = /<NOLINE>|Remote Procedure .* (?:doesn't exist|not found)/i
+
+    # Probe whether `client` can call all RPCs backing `feature`.
+    # Short-circuits on first missing RPC.
+    def self.probe(client, feature)
+      rpcs = FEATURE_RPCS[feature]
+      raise ArgumentError, "Unknown capability feature: #{feature.inspect}" unless rpcs
+
+      rpcs.all? { |rpc| rpc_present?(client, rpc) }
+    end
+
+    def self.rpc_present?(client, rpc_name)
+      client.call_rpc(rpc_name)
+      true
+    rescue RpmsRpc::Client::RpcError => e
+      !e.message.match?(MISSING_RPC_PATTERN)
+    end
+  end
+end

--- a/test/rpms_rpc/api/patient_brief_header_test.rb
+++ b/test/rpms_rpc/api/patient_brief_header_test.rb
@@ -152,8 +152,14 @@ class PatientBriefHeaderTest < Minitest::Test
   # "feature unavailable on this Broker" and return nil cleanly — silent
   # garbage projection was the failure mode in #117.
 
+  # These tests exercise the rescue backstop (#117) — they assume the
+  # capability check has passed but the underlying RPC nevertheless raises.
+  # Define `supports?` to return true on the stub so we land in the
+  # rescue path, not the short-circuit.
+
   def test_brief_header_returns_nil_when_broker_raises_rpc_error
     raising_client = Class.new do
+      def supports?(_feature) = true
       def call_rpc(*)
         raise RpmsRpc::Client::RpcError, "M  ERROR=<NOLINE>PTINFO+22 BEHOPTCX"
       end
@@ -167,6 +173,7 @@ class PatientBriefHeaderTest < Minitest::Test
 
   def test_brief_header_returns_nil_for_remote_procedure_not_found
     raising_client = Class.new do
+      def supports?(_feature) = true
       def call_rpc(*)
         raise RpmsRpc::Client::RpcError, "Remote Procedure 'BEHOPTCX PTINFO' doesn't exist"
       end
@@ -178,11 +185,43 @@ class PatientBriefHeaderTest < Minitest::Test
     assert_nil RpmsRpc::Patient.brief_header(8791)
   end
 
+  # === Capability short-circuit (issue #118) ===
+  #
+  # When the Broker can't service the feature (BHS package not installed),
+  # brief_header should return nil immediately without issuing any of the
+  # underlying BEHO* RPC calls. Saves three Broker round-trips and gives
+  # engine UI a clean "feature unavailable" signal.
+
+  def test_brief_header_returns_nil_when_capability_unsupported
+    RpmsRpc.reset!
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:patient_chart_banner, supported: false)
+      # Seed real data too — if the short-circuit fails, the test would
+      # still return data and we'd see the wrong assertion failure.
+      m.seed(:patient_ptinfo, "8791", { name: "SHOULD,NOT,APPEAR", sex: "F", dob_raw: "2860701", mrn: "120305" })
+    end
+
+    assert_nil RpmsRpc::Patient.brief_header(8791)
+  end
+
+  def test_brief_header_does_not_call_beho_rpcs_when_capability_unsupported
+    RpmsRpc.reset!
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:patient_chart_banner, supported: false)
+    end
+
+    RpmsRpc::Patient.brief_header(8791)
+    rpcs_called = RpmsRpc.client.received_calls.map { |c| c[:rpc] }
+    assert_empty rpcs_called.grep(/^BEHO/),
+                 "Capability-unsupported short-circuit must skip BEHO* RPCs entirely"
+  end
+
   # Genuine M-runtime errors (e.g., <UNDEFINED>, <SUBSCRIPT>) and permission
   # failures indicate a real problem, not "feature unavailable". They must
   # propagate so they aren't silently masked.
   def test_brief_header_propagates_non_missing_routine_rpc_errors
     raising_client = Class.new do
+      def supports?(_feature) = true
       def call_rpc(*)
         raise RpmsRpc::Client::RpcError, "M  ERROR=<UNDEFINED>FOO+5^XYZ^"
       end

--- a/test/rpms_rpc/server_capabilities_test.rb
+++ b/test/rpms_rpc/server_capabilities_test.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/client"
+require "rpms_rpc/cia_client"
+require "rpms_rpc/server_capabilities"
+
+class RpmsRpc::ServerCapabilitiesTest < Minitest::Test
+  # Minimal probing client: records each call_rpc, raises on a configured
+  # set of "missing" RPCs (mimicking what a real Broker returns when an
+  # RPC is not registered to the current OPTION or the package isn't
+  # installed).
+  class ProbingClient
+    attr_reader :calls
+
+    def initialize(missing: [])
+      @missing = missing
+      @calls = []
+    end
+
+    def call_rpc(rpc_name, *_params)
+      @calls << rpc_name
+      if @missing.include?(rpc_name)
+        raise RpmsRpc::Client::RpcError, "Remote Procedure '#{rpc_name}' doesn't exist"
+      end
+      ""
+    end
+  end
+
+  def setup
+    @client = ProbingClient.new
+  end
+
+  # -- Feature registry sanity ------------------------------------------------
+
+  def test_patient_chart_banner_feature_is_registered
+    assert RpmsRpc::ServerCapabilities::FEATURE_RPCS.key?(:patient_chart_banner),
+           "Registry must expose :patient_chart_banner — the immediate consumer is Patient.brief_header"
+  end
+
+  def test_patient_chart_banner_maps_to_beho_rpcs
+    rpcs = RpmsRpc::ServerCapabilities::FEATURE_RPCS[:patient_chart_banner]
+    assert_includes rpcs, "BEHOPTCX PTINFO"
+    assert_includes rpcs, "BEHOPTPC GETBDP"
+    assert_includes rpcs, "BEHOCACV CWAD"
+  end
+
+  def test_unknown_feature_raises_argument_error
+    assert_raises(ArgumentError) do
+      RpmsRpc::ServerCapabilities.probe(@client, :no_such_feature)
+    end
+  end
+
+  # -- Probe behavior ---------------------------------------------------------
+
+  def test_probe_returns_true_when_all_feature_rpcs_callable
+    assert_equal true, RpmsRpc::ServerCapabilities.probe(@client, :patient_chart_banner)
+  end
+
+  def test_probe_returns_false_when_any_feature_rpc_missing
+    missing = ProbingClient.new(missing: [ "BEHOPTPC GETBDP" ])
+    assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :patient_chart_banner)
+  end
+
+  def test_probe_returns_false_for_noline_signature
+    raising = Class.new do
+      def call_rpc(*)
+        raise RpmsRpc::Client::RpcError, "M  ERROR=<NOLINE>PTINFO+22 BEHOPTCX"
+      end
+    end.new
+    assert_equal false, RpmsRpc::ServerCapabilities.probe(raising, :patient_chart_banner)
+  end
+
+  def test_probe_treats_other_rpc_errors_as_rpc_present
+    # An RPC that raises with a non-"missing" signature (e.g., parameter
+    # validation, runtime error) is still installed — capability is true.
+    other = Class.new do
+      def call_rpc(*)
+        raise RpmsRpc::Client::RpcError, "M  ERROR=<UNDEFINED>FOO+5^XYZ^"
+      end
+    end.new
+    assert_equal true, RpmsRpc::ServerCapabilities.probe(other, :patient_chart_banner)
+  end
+
+  # -- Client#supports? caches ------------------------------------------------
+  #
+  # Production code paths must not re-probe on every call. One round of
+  # probing per feature per client lifetime.
+
+  def test_client_supports_caches_after_first_probe
+    cia = RpmsRpc::CiaClient.new
+    def cia.call_rpc(rpc_name, *_params)
+      @probe_calls ||= 0
+      @probe_calls += 1
+      ""
+    end
+    def cia.probe_call_count = (@probe_calls || 0)
+
+    3.times { cia.supports?(:patient_chart_banner) }
+
+    # Feature has 3 RPCs; expect each probed exactly once across all 3 calls
+    expected = RpmsRpc::ServerCapabilities::FEATURE_RPCS[:patient_chart_banner].size
+    assert_equal expected, cia.probe_call_count
+  end
+
+  def test_client_supports_returns_cached_false_without_reprobing
+    cia = RpmsRpc::CiaClient.new
+    raise_count = { n: 0 }
+    cia.define_singleton_method(:call_rpc) do |_name, *_params|
+      raise_count[:n] += 1
+      raise RpmsRpc::Client::RpcError, "Remote Procedure 'X' doesn't exist"
+    end
+
+    refute cia.supports?(:patient_chart_banner)
+    refute cia.supports?(:patient_chart_banner)
+    refute cia.supports?(:patient_chart_banner)
+
+    # First probe hits the first RPC, fails, short-circuits → only 1 call.
+    # Cached false → no more calls on subsequent supports? invocations.
+    assert_equal 1, raise_count[:n]
+  end
+end

--- a/test/rpms_rpc/server_capabilities_test.rb
+++ b/test/rpms_rpc/server_capabilities_test.rb
@@ -119,4 +119,56 @@ class RpmsRpc::ServerCapabilitiesTest < Minitest::Test
     # Cached false → no more calls on subsequent supports? invocations.
     assert_equal 1, raise_count[:n]
   end
+
+  # -- Cache invalidation ------------------------------------------------------
+  #
+  # The cache must not survive across connection or context boundaries: a
+  # different Broker, or even the same Broker under a different OPTION, can
+  # answer the same probe differently. Stale "true" → broken short-circuit
+  # to a missing RPC; stale "false" → never-resurrected capability.
+
+  def test_reset_connection_clears_capability_cache
+    cia = RpmsRpc::CiaClient.new
+    probe_count = { n: 0 }
+    cia.define_singleton_method(:call_rpc) do |_name, *_params|
+      probe_count[:n] += 1
+      ""
+    end
+
+    assert cia.supports?(:patient_chart_banner)
+    assert cia.supports?(:patient_chart_banner)
+    feature_size = RpmsRpc::ServerCapabilities::FEATURE_RPCS[:patient_chart_banner].size
+    assert_equal feature_size, probe_count[:n], "second supports? must be cached"
+
+    cia.send(:reset_connection)
+
+    assert cia.supports?(:patient_chart_banner)
+    assert_equal feature_size * 2, probe_count[:n],
+                 "reset_connection must invalidate the cache so re-probe happens"
+  end
+
+  def test_create_context_clears_capability_cache
+    cia = RpmsRpc::CiaClient.new
+    cia.define_singleton_method(:connected?) { true }
+    cia.define_singleton_method(:authenticated?) { true }
+    probe_count = { n: 0 }
+    cia.define_singleton_method(:call_rpc) do |_name, *_params|
+      probe_count[:n] += 1
+      ""
+    end
+    # Stub the context-creation call so create_context succeeds without
+    # going to the wire; the assertion is purely about cache state.
+    cia.define_singleton_method(:call_rpc_raw) { |_, *_| "1" }
+
+    assert cia.supports?(:patient_chart_banner)
+    feature_size = RpmsRpc::ServerCapabilities::FEATURE_RPCS[:patient_chart_banner].size
+    assert_equal feature_size, probe_count[:n]
+
+    cia.create_context("OR CPRS GUI CHART")
+
+    assert cia.supports?(:patient_chart_banner)
+    assert_equal feature_size * 2, probe_count[:n],
+                 "create_context must invalidate the cache because RPC " \
+                 "registration is OPTION-scoped"
+  end
 end

--- a/test/rpms_rpc/server_capabilities_test.rb
+++ b/test/rpms_rpc/server_capabilities_test.rb
@@ -171,4 +171,26 @@ class RpmsRpc::ServerCapabilitiesTest < Minitest::Test
                  "create_context must invalidate the cache because RPC " \
                  "registration is OPTION-scoped"
   end
+
+  def test_open_socket_clears_capability_cache_for_implicit_reconnect
+    # Several network error paths only flip @connected = false without
+    # going through reset_connection. A caller can then re-enter
+    # open_socket against the same or a different Broker with stale
+    # capability answers still cached. The fix: clear the cache at the
+    # top of open_socket itself.
+    cia = RpmsRpc::CiaClient.new
+    cia.instance_variable_set(:@capability_cache, { patient_chart_banner: true })
+
+    # Force open_socket's TCPSocket.new to raise; the cache must already
+    # be cleared by the time the exception bubbles out.
+    TCPSocket.stub(:new, ->(*) { raise Errno::ECONNREFUSED }) do
+      assert_raises(RpmsRpc::Client::ConnectionError) do
+        cia.send(:open_socket, "localhost", 9100)
+      end
+    end
+
+    assert_nil cia.instance_variable_get(:@capability_cache),
+               "open_socket must clear capability cache on entry so a " \
+               "reconnect after a half-dead connection can't reuse stale answers"
+  end
 end


### PR DESCRIPTION
## Summary

- New `RpmsRpc::ServerCapabilities` module: symbolic feature registry mapping `:patient_chart_banner` → `["BEHOPTCX PTINFO", "BEHOPTPC GETBDP", "BEHOCACV CWAD"]`. Features are extensible — drop new entries in the registry as more symbolic API methods need capability gating.
- New `Client#supports?(feature)`: lazy per-feature probe with per-instance cache. First call probes each underlying RPC; subsequent calls hit the cache.
- `Patient.brief_header` short-circuits on `!supports?(:patient_chart_banner)`, skipping all three BEHO* RPC calls when the BHS package isn't installed.
- `MockClient` gains `seed_capability(feature, supported:)` for testing both paths. Default is `supported: true` so existing tests behave unchanged.
- The rescue backstop from #117 remains as defense-in-depth.

## Probe semantics

`ServerCapabilities.rpc_present?` calls the RPC with no params; the Broker reports `<NOLINE>` or `Remote Procedure '...' doesn't exist` / `not found` before any parameter validation runs. That signature → RPC missing → unsupported. Any other `RpcError` (e.g., `<UNDEFINED>`, permission failure) means the RPC is present and ran far enough to raise a different error → supported.

**All features registered must resolve to read-only RPCs.** Probing has no side effects for reads. Write features should not be added to the registry; engine code calling write RPCs must rescue and handle errors directly.

## Scope decision

The issue spec described "enumerates installed RPCs at first `create_context`" — eager bulk enumeration. This PR implements **lazy per-feature probing at first `supports?` call** instead, because:

1. The terminal cache state is identical for the engine — `supports?` returns the right value.
2. Lazy avoids paying enumeration latency on session setup for features no caller ever asks about.
3. Bulk enumeration via `DDR LISTER` against file #8994 depends on a specific RPC signature that's finicky across IRIS / Caché / GT.M; lazy probing depends only on the universal "RPC doesn't exist" error path.

If we later need session-startup enumeration for other reasons, it can be added without changing the `supports?` contract.

## Test plan

- [x] Feature registry exposes `:patient_chart_banner` mapped to the three BEHO* RPCs.
- [x] `ServerCapabilities.probe` returns true when all RPCs callable; false when any is missing.
- [x] Probe distinguishes "missing" signatures from genuine M-runtime errors.
- [x] `Client#supports?` caches the result — single probe per feature per client lifetime, even across many calls.
- [x] `Client#supports?` caches negative results too — no re-probing after a `false`.
- [x] `Patient.brief_header` returns `nil` when `supports?(:patient_chart_banner)` is false.
- [x] `Patient.brief_header` issues zero BEHO* RPC calls in the unsupported case (verified via `MockClient#received_calls`).
- [x] Rescue backstop from #117 still catches "missing routine" errors raised post-probe.
- [x] Genuine `<UNDEFINED>` errors still propagate (not masked).
- [x] Full suite: `bundle exec rake test` — 843 runs, 2300 assertions, 0 failures, 0 errors.

Closes #118.