### PR TITLE
Fix three mapping shape mismatches found by live staging probe

### DIFF
--- a/lib/rpms_rpc/api/authentication.rb
+++ b/lib/rpms_rpc/api/authentication.rb
@@ -141,7 +141,13 @@ module RpmsRpc
     end
 
     def invalid_id?(value)
-      blank?(value) || value.to_i <= 0
+      return true if blank?(value)
+      return false if value.is_a?(Integer) && value.positive?
+
+      # Strict-digit guard: prevents inputs like "301abc" from sneaking
+      # past to_i (which would return 301 and accidentally match the
+      # session user via user_info's post-fetch duz comparison).
+      !value.to_s.strip.match?(/\A[1-9]\d*\z/)
     end
 
     def presence(value)

--- a/lib/rpms_rpc/api/authentication.rb
+++ b/lib/rpms_rpc/api/authentication.rb
@@ -40,7 +40,13 @@ module RpmsRpc
     def user_info(duz)
       return nil if invalid_id?(duz)
 
-      DataMapper.user_info.fetch_one(duz.to_s)
+      # XUS GET USER INFO returns the authenticated session user's info
+      # and takes no params; the duz arg is validated here only as an
+      # API guard, not passed to the broker.
+      info = DataMapper.user_info.fetch_lines
+      return nil if info.nil? || info[:duz].to_i != duz.to_i
+
+      info
     end
 
     def has_security_key?(duz, key_name)

--- a/lib/rpms_rpc/api/site.rb
+++ b/lib/rpms_rpc/api/site.rb
@@ -3,36 +3,32 @@
 require_relative "../mappings"
 
 module RpmsRpc
-  # Symbolic API for site/division context. A user may have access to several
-  # divisions; one is selected at any given moment and scopes downstream RPCs.
-  # Underlying RPC: BEHOSICX SITEINFO.
+  # Symbolic API for the authenticated user's current site. BEHOSICX SITEINFO
+  # returns a single site (not a list) and takes no params; the duz arg is
+  # an API-level guard, not a broker param.
+  #
+  # Note: site selection requires a different RPC path that BEHOSICX SITEINFO
+  # does not implement — see rr-5tm for the tracking issue.
   module Site
     extend self
 
-    def list(user_duz)
-      return [] if invalid_duz?(user_duz)
-
-      Array(DataMapper.site_info.fetch_many(user_duz.to_s))
-    end
-
     def current(user_duz)
-      list(user_duz).find { |site| site[:current] }
+      return nil if invalid_duz?(user_duz)
+
+      DataMapper.site_info.fetch_lines
     end
 
-    def select(user_duz, site_ien)
-      return false if invalid_duz?(user_duz) || invalid_ien?(site_ien)
-
-      RpmsRpc.client.call_rpc(DataMapper.site_info.rpc_name, user_duz.to_s, site_ien.to_s)
-      true
+    # Backward-compat: list-of-sites callers still expect an Array. Returns
+    # [current] so existing iteration patterns keep working until callers
+    # migrate to `current`.
+    def list(user_duz)
+      site = current(user_duz)
+      site ? [ site ] : []
     end
 
     private
 
     def invalid_duz?(value)
-      value.nil? || value.to_s.strip.empty? || value.to_i <= 0
-    end
-
-    def invalid_ien?(value)
       value.nil? || value.to_s.strip.empty? || value.to_i <= 0
     end
   end

--- a/lib/rpms_rpc/api/symptom.rb
+++ b/lib/rpms_rpc/api/symptom.rb
@@ -15,8 +15,28 @@ module RpmsRpc
       Array(DataMapper.symptom_search.fetch_many(query.to_s))
     end
 
+    # Parse the ORWDAL32 DEF typed tree into
+    #   [ { category: <name>, items: [ { code:, label: }, ... ] }, ... ]
     def defaults
-      Array(DataMapper.symptom_defaults.fetch_many)
+      text = DataMapper.symptom_defaults.fetch_text
+      return [] if text.nil? || text.empty?
+
+      categories = []
+      current = nil
+      text.each_line do |raw|
+        line = raw.chomp
+        case line[0]
+        when "~"
+          categories << current if current
+          current = { category: line[1..].to_s, items: [] }
+        when "i"
+          next unless current
+          code, label = line[1..].to_s.split("^", 2)
+          current[:items] << { code: code.to_s, label: label.to_s }
+        end
+      end
+      categories << current if current
+      categories
     end
 
     private

--- a/lib/rpms_rpc/api/user_management.rb
+++ b/lib/rpms_rpc/api/user_management.rb
@@ -17,8 +17,11 @@ module RpmsRpc
       duz = normalize_duz(duz)
       return nil if duz.nil?
 
-      user_info = DataMapper.user_info.fetch_one(duz.to_s)
-      return nil if user_info.nil?
+      # XUS GET USER INFO takes no params and returns the authenticated
+      # session user. For arbitrary-DUZ lookup the practitioner_info call
+      # below (ORWU USERINFO) is the source of truth; tracked in rr-fyf.
+      user_info = DataMapper.user_info.fetch_lines
+      return nil if user_info.nil? || user_info[:duz].to_i != duz
 
       {
         user_info: user_info,

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -674,15 +674,22 @@ module RpmsRpc
     # AUTHENTICATION (XUS*)
     # ========================================================================
 
-    # XUS GET USER INFO — authenticated user info
-    # Format: DUZ^NAME^ACCESS_CODE^VERIFY_CODE_EXISTS^DIVISION
+    # XUS GET USER INFO — authenticated user info. Response is line-based,
+    # one value per line — not caret-delimited. Live shape observed against
+    # staging:
+    #   [0] "1"                              → duz
+    #   [1] "PROVIDER,TEST"                  → name (FAMILY,GIVEN)
+    #   [2] "Adam Adam"                      → display_name
+    #   [3] "7819^DEMO IHS CLINIC^8904"      → current_site (IEN^NAME^ABBR)
+    #   [4]..[6] ""                          → reserved
+    #   [7] "30"                             → user_class_ien
     DataMapper.define(:user_info) do |m|
       m.rpc "XUS GET USER INFO"
-      m.field 0, :duz, :integer
-      m.field 1, :name
-      m.field 2, :access_code
-      m.field 3, :verify_code_exists, :boolean
-      m.field 4, :division
+      m.line_field 0, :duz,  :integer
+      m.line_field 1, :name
+      m.line_field 2, :display_name
+      m.line_field 3, :current_site
+      m.line_field 7, :user_class, :integer
     end
 
     # ========================================================================

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -682,14 +682,17 @@ module RpmsRpc
     #   [2] "Adam Adam"                      → display_name
     #   [3] "7819^DEMO IHS CLINIC^8904"      → current_site (IEN^NAME^ABBR)
     #   [4]..[6] ""                          → reserved
-    #   [7] "30"                             → user_class_ien
+    #   [7] "30"                             → user_class_ien (pointer into
+    #                                          USER CLASS file #8932.1 —
+    #                                          NOT the auth class code that
+    #                                          av_code's :user_class returns)
     DataMapper.define(:user_info) do |m|
       m.rpc "XUS GET USER INFO"
       m.line_field 0, :duz,  :integer
       m.line_field 1, :name
       m.line_field 2, :display_name
       m.line_field 3, :current_site
-      m.line_field 7, :user_class, :integer
+      m.line_field 7, :user_class_ien, :integer
     end
 
     # ========================================================================

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -1747,11 +1747,18 @@ module RpmsRpc
       m.field 2, :snomed_code
     end
 
+    # ORWDAL32 DEF — defaults tree for the allergy-symptom entry UI. Takes
+    # no params and returns a typed-tree response: lines starting with "~"
+    # are category headers, lines starting with "i" are items belonging to
+    # the most recent category and encode (type_code, label) via ^.
+    # Example:
+    #   ~Reactions
+    #   iD^Drug
+    #   iF^Food
+    # The mapping returns the raw lines; api/symptom.rb parses the tree.
     DataMapper.define(:symptom_defaults) do |m|
       m.rpc "ORWDAL32 DEF"
-      m.field 0, :ien, :integer
-      m.field 1, :name
-      m.field 2, :snomed_code
+      m.text_blob :tree_text
     end
 
     # ========================================================================

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -1509,16 +1509,30 @@ module RpmsRpc
     # SITE / DIVISION CONTEXT (BEHOSICX*)
     # ========================================================================
 
-    # BEHOSICX SITEINFO — divisions the user can access, with the currently
-    # selected division flagged. Used at cold launch and on division switch.
-    # Field positions are best-effort pending wider trace capture; the public
-    # contract is { ien, name, abbreviation, current }.
+    # BEHOSICX SITEINFO — the authenticated user's current site. The RPC
+    # takes no params and returns a single site across 11 response lines
+    # (not multi-record, not caret-delimited). Live shape:
+    #   [0]  "RPMS.MEDSPHERE.COM"   → domain
+    #   [1]  "DEMO IHS CLINIC"      → name
+    #   [2]  "8904"                 → abbreviation
+    #   [3]  "ILLINOIS"             → state
+    #   [4]  ""                     → (reserved)
+    #   [5]  "123 ELM STREET"       → address
+    #   [6]  ""                     → (reserved)
+    #   [7]  "ANYWHERE"             → city
+    #   [8]  "99999"                → zip
+    #   [9]  "7819"                 → ien
+    #   [10] (unknown, ignored)
     DataMapper.define(:site_info) do |m|
       m.rpc "BEHOSICX SITEINFO"
-      m.field 0, :ien, :integer
-      m.field 1, :name
-      m.field 2, :abbreviation
-      m.field 3, :current, :boolean
+      m.line_field 0, :domain
+      m.line_field 1, :name
+      m.line_field 2, :abbreviation
+      m.line_field 3, :state
+      m.line_field 5, :address
+      m.line_field 7, :city
+      m.line_field 8, :zip
+      m.line_field 9, :ien, :integer
     end
 
     # ========================================================================

--- a/lib/rpms_rpc/mock_client.rb
+++ b/lib/rpms_rpc/mock_client.rb
@@ -119,13 +119,14 @@ module RpmsRpc
         user_class: user_class.to_i
       })
 
-      # User info
-      seed(:user_info, duz.to_s, {
+      # User info (XUS GET USER INFO — line-based, no params; mock matches
+      # the live shape: one value per response line).
+      seed_lines(:user_info, "", {
         duz: duz.to_i,
         name: name,
-        access_code: "",
-        verify_code_exists: true,
-        division: ""
+        display_name: name,
+        current_site: "",
+        user_class: user_class.to_i
       })
 
       # Security keys (symbolic → RPMS strings)

--- a/lib/rpms_rpc/mock_client.rb
+++ b/lib/rpms_rpc/mock_client.rb
@@ -120,13 +120,16 @@ module RpmsRpc
       })
 
       # User info (XUS GET USER INFO — line-based, no params; mock matches
-      # the live shape: one value per response line).
+      # the live shape: one value per response line). user_class_ien is a
+      # pointer into USER CLASS file #8932.1, distinct from av_code's
+      # auth-class code — seed with a plausible IEN placeholder so tests
+      # don't conflate the two.
       seed_lines(:user_info, "", {
         duz: duz.to_i,
         name: name,
         display_name: name,
         current_site: "",
-        user_class: user_class.to_i
+        user_class_ien: 30
       })
 
       # Security keys (symbolic → RPMS strings)

--- a/test/rpms_rpc/api/authentication_test.rb
+++ b/test/rpms_rpc/api/authentication_test.rb
@@ -75,7 +75,10 @@ class AuthenticationTest < Minitest::Test
     assert_equal 301, info[:duz]
     assert_equal "PROVIDER,TEST", info[:name]
     assert_equal "PROVIDER,TEST", info[:display_name]
-    assert_equal 3, info[:user_class]
+    # :user_class_ien is a pointer into USER CLASS file #8932.1; assert
+    # positivity rather than a specific value (the mock seeds a placeholder
+    # IEN, live values are site-specific).
+    assert info[:user_class_ien].is_a?(Integer) && info[:user_class_ien] > 0
   end
 
   def test_user_info_rejects_blank_zero_negative_and_non_numeric_duz

--- a/test/rpms_rpc/api/authentication_test.rb
+++ b/test/rpms_rpc/api/authentication_test.rb
@@ -74,8 +74,8 @@ class AuthenticationTest < Minitest::Test
 
     assert_equal 301, info[:duz]
     assert_equal "PROVIDER,TEST", info[:name]
-    assert_nil info[:access_code]
-    assert_equal true, info[:verify_code_exists]
+    assert_equal "PROVIDER,TEST", info[:display_name]
+    assert_equal 3, info[:user_class]
   end
 
   def test_user_info_rejects_blank_zero_negative_and_non_numeric_duz

--- a/test/rpms_rpc/api/site_test.rb
+++ b/test/rpms_rpc/api/site_test.rb
@@ -7,58 +7,44 @@ require "rpms_rpc/api/site"
 class SiteTest < Minitest::Test
   def setup
     RpmsRpc.mock! do |m|
-      # BEHOSICX SITEINFO keyed by user DUZ: returns the divisions the user
-      # can access, with the currently-selected division flagged.
-      m.seed_keyed_collection(:site_info, "301", [
-        { ien: 539, name: "TEST SERVICE UNIT", abbreviation: "TSU", current: true },
-        { ien: 540, name: "TEST CLINIC A", abbreviation: "TCA", current: false },
-        { ien: 541, name: "TEST CLINIC B", abbreviation: "TCB", current: false }
-      ])
-
-      m.seed_keyed_collection(:site_info, "999", [
-        { ien: 539, name: "TEST SERVICE UNIT", abbreviation: "TSU", current: false }
-      ])
+      # BEHOSICX SITEINFO is line-based and takes no params; mock seeds the
+      # response under the empty key to mirror the dispatch behavior.
+      m.seed_lines(:site_info, "", {
+        domain: "RPMS.MEDSPHERE.COM",
+        name: "DEMO IHS CLINIC",
+        abbreviation: "8904",
+        state: "ILLINOIS",
+        address: "123 ELM STREET",
+        city: "ANYWHERE",
+        zip: "99999",
+        ien: 7819
+      })
     end
   end
 
-  def test_list_returns_divisions_user_can_access
+  def test_current_returns_the_authenticated_users_site
+    site = RpmsRpc::Site.current("301")
+    assert_equal 7819, site[:ien]
+    assert_equal "DEMO IHS CLINIC", site[:name]
+    assert_equal "8904", site[:abbreviation]
+    assert_equal "RPMS.MEDSPHERE.COM", site[:domain]
+  end
+
+  def test_current_blank_duz_returns_nil
+    assert_nil RpmsRpc::Site.current(nil)
+    assert_nil RpmsRpc::Site.current("")
+    assert_nil RpmsRpc::Site.current("0")
+  end
+
+  def test_list_returns_current_as_single_element_array
     sites = RpmsRpc::Site.list("301")
-    assert_equal 3, sites.length
-    assert_equal [ 539, 540, 541 ], sites.map { |s| s[:ien] }
+    assert_equal 1, sites.length
+    assert_equal 7819, sites.first[:ien]
   end
 
   def test_list_blank_duz_returns_empty
     assert_equal [], RpmsRpc::Site.list(nil)
     assert_equal [], RpmsRpc::Site.list("")
     assert_equal [], RpmsRpc::Site.list("0")
-  end
-
-  def test_current_returns_the_flagged_division
-    current = RpmsRpc::Site.current("301")
-    assert_equal 539, current[:ien]
-    assert_equal "TEST SERVICE UNIT", current[:name]
-  end
-
-  def test_current_returns_nil_when_nothing_is_flagged
-    assert_nil RpmsRpc::Site.current("999")
-  end
-
-  def test_current_blank_duz_returns_nil
-    assert_nil RpmsRpc::Site.current(nil)
-    assert_nil RpmsRpc::Site.current("")
-  end
-
-  def test_select_dispatches_to_the_site_info_rpc_with_duz_and_site_ien
-    RpmsRpc::Site.select("301", 540)
-
-    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BEHOSICX SITEINFO" && c[:params].length == 2 }
-    refute_nil call, "expected BEHOSICX SITEINFO to be called with [duz, site_ien]"
-    assert_equal [ "301", "540" ], call[:params]
-  end
-
-  def test_select_returns_false_for_invalid_args
-    refute RpmsRpc::Site.select(nil, 540)
-    refute RpmsRpc::Site.select("301", nil)
-    refute RpmsRpc::Site.select("301", 0)
   end
 end

--- a/test/rpms_rpc/api/symptom_test.rb
+++ b/test/rpms_rpc/api/symptom_test.rb
@@ -38,21 +38,41 @@ class SymptomTest < Minitest::Test
     assert_equal [], RpmsRpc::Symptom.search("   ")
   end
 
-  def test_defaults_returns_default_symptom_set
+  def test_defaults_parses_the_typed_tree_into_categories_with_items
     RpmsRpc.mock! do |m|
-      m.seed_collection(:symptom_defaults, [
-        { ien: 10, name: "Hives", snomed_code: "247472004" },
-        { ien: 11, name: "Anaphylaxis", snomed_code: "39579001" }
-      ])
+      m.seed_text(:symptom_defaults, "", <<~TREE.chomp)
+        ~Reactions
+        iD^Drug
+        iF^Food
+        iO^Other
+        ~Top Ten
+        iO^Common Drug Reactions
+        ~Observ/Hist
+        io^Observed
+      TREE
     end
 
-    rows = RpmsRpc::Symptom.defaults
-    assert_equal 2, rows.length
+    categories = RpmsRpc::Symptom.defaults
+
+    assert_equal [ "Reactions", "Top Ten", "Observ/Hist" ], categories.map { |c| c[:category] }
+    assert_equal [
+      { code: "D", label: "Drug" },
+      { code: "F", label: "Food" },
+      { code: "O", label: "Other" }
+    ], categories.first[:items]
+    assert_equal [ { code: "o", label: "Observed" } ], categories.last[:items]
+  end
+
+  def test_defaults_returns_empty_when_response_is_blank
+    RpmsRpc.mock! do |m|
+      m.seed_text(:symptom_defaults, "", "")
+    end
+    assert_equal [], RpmsRpc::Symptom.defaults
   end
 
   def test_defaults_dispatches_orwdal32_def
     RpmsRpc.mock! do |m|
-      m.seed_collection(:symptom_defaults, [])
+      m.seed_text(:symptom_defaults, "", "~Reactions\niD^Drug")
     end
     RpmsRpc::Symptom.defaults
     call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWDAL32 DEF" }

--- a/test/rpms_rpc/api/user_management_test.rb
+++ b/test/rpms_rpc/api/user_management_test.rb
@@ -21,7 +21,7 @@ class UserManagementTest < Minitest::Test
         name: "PROVIDER,TEST",
         display_name: "PROVIDER,TEST",
         current_site: "7819^DEMO IHS CLINIC^8904",
-        user_class: 3
+        user_class_ien: 30
       })
 
       m.seed(:practitioner_info, DUZ.to_s, {

--- a/test/rpms_rpc/api/user_management_test.rb
+++ b/test/rpms_rpc/api/user_management_test.rb
@@ -16,13 +16,12 @@ class UserManagementTest < Minitest::Test
         { duz: 405, name: "NURSE,TEST", title: "RN" }
       ], filter_field: :name)
 
-      m.seed(:user_info, DUZ.to_s, {
+      m.seed_lines(:user_info, "", {
         duz: DUZ,
         name: "PROVIDER,TEST",
-        user_class: "PROVIDER",
-        can_sign: true,
-        is_provider: true,
-        order_role: "PHYSICIAN"
+        display_name: "PROVIDER,TEST",
+        current_site: "7819^DEMO IHS CLINIC^8904",
+        user_class: 3
       })
 
       m.seed(:practitioner_info, DUZ.to_s, {

--- a/test/rpms_rpc/mappings_test.rb
+++ b/test/rpms_rpc/mappings_test.rb
@@ -237,12 +237,16 @@ class RpmsRpc::MappingsTest < Minitest::Test
   # -- XUS GET USER INFO -----------------------------------------------------
 
   def test_user_info
-    result = RpmsRpc::DataMapper[:user_info].parse_one("101^PROVIDER,TEST^ACCESS123^1^PRIMARY")
+    # XUS GET USER INFO is line-based: one value per response line, not
+    # caret-delimited. Live shape against staging.
+    result = RpmsRpc::DataMapper[:user_info].parse_lines(
+      [ "101", "PROVIDER,TEST", "Adam Adam", "7819^DEMO IHS CLINIC^8904", "", "", "", "30" ]
+    )
     assert_equal 101, result[:duz]
     assert_equal "PROVIDER,TEST", result[:name]
-    assert_equal "ACCESS123", result[:access_code]
-    assert_equal true, result[:verify_code_exists]
-    assert_equal "PRIMARY", result[:division]
+    assert_equal "Adam Adam", result[:display_name]
+    assert_equal "7819^DEMO IHS CLINIC^8904", result[:current_site]
+    assert_equal 30, result[:user_class]
   end
 
   # -- Scalar RPCs -----------------------------------------------------------

--- a/test/rpms_rpc/mappings_test.rb
+++ b/test/rpms_rpc/mappings_test.rb
@@ -246,7 +246,7 @@ class RpmsRpc::MappingsTest < Minitest::Test
     assert_equal "PROVIDER,TEST", result[:name]
     assert_equal "Adam Adam", result[:display_name]
     assert_equal "7819^DEMO IHS CLINIC^8904", result[:current_site]
-    assert_equal 30, result[:user_class]
+    assert_equal 30, result[:user_class_ien]
   end
 
   # -- Scalar RPCs -----------------------------------------------------------


### PR DESCRIPTION
## Summary

A full probe of every entry in `lib/rpms_rpc/mappings.rb` against the live staging RPMS broker (via SSM port-forward to `i-0cef6ae75fc88bb2a:9100`) surfaced three mappings whose declared shape didn't match what the RPC actually returns. None are FOIA-staging drift — all three were aspirational/copy-pasted shapes that had never been verified against any broker, consistent with the project memory note _"mappings.rb entries have wrong field positions, not just placeholder names"_.

## Commits

1. **`user_info` (XUS GET USER INFO)** — was 5 caret-positioned fields including invented `access_code`, `verify_code_exists`, `division` (likely confused with XUS AV CODE's signon fields). Real shape is 8 lines of single-value data. Switched to `line_field` with `duz`, `name`, `display_name`, `current_site`, `user_class`. Consumers now use `fetch_lines` and pass no params (the RPC takes none). API contract preserved: `Authentication.user_info(duz)` and `UserManagement.find(duz)` still return nil when the session user's duz doesn't match the requested duz.

2. **`site_info` (BEHOSICX SITEINFO)** — was 4 caret fields including a fictitious `current` flag (the mapping comment literally said _"best-effort pending wider trace capture"_). Real shape is 11 lines, single record. Switched to `line_field` with `domain`, `name`, `abbreviation`, `state`, `address`, `city`, `zip`, `ien`. `Site.current` returns the single hash; `Site.list` preserves Array-returning signature by wrapping. `Site.select` removed — BEHOSICX SITEINFO does not take params, broker raises `<PARAMETER>` when given any; switch-site needs a different RPC.

3. **`symptom_defaults` (ORWDAL32 DEF)** — was 3 caret fields character-for-character copy-pasted from `symptom_search` immediately above it. Real response is a typed tree: `~Category` headers and `iCODE^Label` items. Mapping switched to `text_blob`; `Symptom.defaults` now parses the tree into `[{ category:, items: [{ code:, label: }] }]`.

## Validation methodology

Probe script at `/tmp/validate_mappings.rb` (not committed). Each mapping's RPC is called, response classified into `MISSING / EMPTY / OTHER_ERROR / SHAPE_OK / SHAPE_SHORT`. After session-discipline fixes (skipping XUS auth RPCs that would reset the broker OPTION mid-run, and re-creating context after any probe that loses it), 76 RPCs are MISSING on staging (separate issue: install request), 5 fully validate, 11 validate after retry with DFN=3, 14 need params we couldn't supply, 3 had real shape mismatches — fixed here.

## Test plan

- [x] Full suite: `bundle exec rake test` — 844 runs, 2311 assertions, 0 failures
- [x] Lint: `bundle exec rubocop lib test` — clean
- [x] `user_info` shape verified against live staging via probe
- [x] `site_info` shape verified against live staging via probe
- [x] `symptom_defaults` shape verified against live staging via probe

## Linked issues

- Closes rr-19l (user_info field-position drift)
- Closes rr-5tm (site_info 11-line shape; switch-site bd to be filed when right RPC is identified)
- Closes rr-l26 (symptom_defaults typed tree)
- Related: rr-fyf (UserManagement.find arbitrary-DUZ lookup needs ORWU USERINFO as source of truth — separate refactor)
- Related: rr-6jr (staging operator install request for 76 MISSING packages)