### PR TITLE
Fix patient_id_info shape: 13 hallucinated fields → 6 real identifier fields

### DIFF
--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -29,19 +29,24 @@ module RpmsRpc
       m.field 14, :age,       :integer
     end
 
-    # ORWPT ID INFO — extended patient demographics
-    # Format: NAME^SEX^DOB^SSN^RACE^ADDRESS^CITY^STATE^ZIP^PHONE^TRIBAL_NUM^SERVICE_AREA^COVERAGE
+    # ORWPT ID INFO — patient identifier projection. Live shape against
+    # staging (DFN=3 / MOUSE,MICKEY M):
+    #   "000009999^2100214^M^N^^7819^^MOUSE,MICKEY M"
+    #     [0] ssn       [1] dob (fileman) [2] sex      [3] race_code
+    #     [4] reserved  [5] site_ien      [6] reserved [7] name
+    # Despite the "ID INFO" name, this RPC does NOT return address,
+    # city, state, zip, phone, tribal enrollment, service area, or
+    # coverage — those fields were hallucinated in the prior mapping.
+    # IHS demographic detail lives in the BHDPTRPC family of RPCs (not
+    # installed on staging — see rr-6jr).
     DataMapper.define(:patient_id_info) do |m|
       m.rpc "ORWPT ID INFO"
-      m.field 4,  :race
-      m.field 5,  :address_line1
-      m.field 6,  :city
-      m.field 7,  :state
-      m.field 8,  :zip_code
-      m.field 9,  :phone
-      m.field 10, :tribal_enrollment_number
-      m.field 11, :service_area
-      m.field 12, :coverage_type
+      m.field 0, :ssn
+      m.field 1, :dob, :fileman_date
+      m.field 2, :sex
+      m.field 3, :race_code
+      m.field 5, :site_ien, :integer
+      m.field 7, :name
     end
 
     # ORWPT LIST ALL — patient search results (multi-line)

--- a/test/rpms_rpc/api/patient_test.rb
+++ b/test/rpms_rpc/api/patient_test.rb
@@ -10,7 +10,10 @@ class PatientTest < Minitest::Test
   def setup
     RpmsRpc.mock! do |m|
       m.seed(:patient_select, "1", { name: "DOE,JOHN", sex: "M", dob: Date.new(1980, 1, 15), ssn: "111223333", age: 45 })
-      m.seed(:patient_id_info, "1", { race: "AMERICAN INDIAN", address_line1: "123 Main St", city: "Anchorage", state: "AK" })
+      m.seed(:patient_id_info, "1", {
+        ssn: "111223333", dob: Date.new(1980, 1, 15), sex: "M",
+        race_code: "I", site_ien: 7819, name: "DOE,JOHN"
+      })
       m.seed(:patient_ssn, "111-22-3333", { dfn: 1, name: "DOE,JOHN", ssn: "111-22-3333" })
       m.seed_collection(:patient_list,
         [ { dfn: 1, name: "DOE,JOHN", sex: "M" }, { dfn: 2, name: "SMITH,JANE", sex: "F" } ],
@@ -34,12 +37,14 @@ class PatientTest < Minitest::Test
     assert_equal "M", result[:sex]
   end
 
-  def test_find_merges_extended_demographics
+  def test_find_merges_identifier_fields
     result = RpmsRpc::Patient.find(1)
 
-    assert_equal "AMERICAN INDIAN", result[:race]
-    assert_equal "123 Main St", result[:address_line1]
-    assert_equal "Anchorage", result[:city]
+    # ORWPT ID INFO contributes the site IEN and race code to the merge.
+    # Extended demographics (address, city, state, phone, tribal, etc.)
+    # come from the BHDPTRPC family — not present on staging; see rr-6jr.
+    assert_equal "I", result[:race_code]
+    assert_equal 7819, result[:site_ien]
   end
 
   def test_find_returns_nil_for_unknown

--- a/test/rpms_rpc/mappings_test.rb
+++ b/test/rpms_rpc/mappings_test.rb
@@ -21,32 +21,35 @@ class RpmsRpc::MappingsTest < Minitest::Test
 
   # -- ORWPT ID INFO ---------------------------------------------------------
 
-  def test_patient_id_info_parses_extended_fields
+  def test_patient_id_info_parses_identifier_fields
     m = RpmsRpc::DataMapper[:patient_id_info]
-    result = m.parse_one("DOE,JOHN^M^2800115^111223333^AMERICAN INDIAN^123 Main St^Anchorage^AK^99501^907-555-1234^ANLC-12345^Anchorage^IHS")
+    # Live shape from staging: SSN^DOB^SEX^RACE_CODE^^SITE_IEN^^NAME
+    result = m.parse_one("000009999^2100214^M^N^^7819^^MOUSE,MICKEY M")
 
-    assert_equal "AMERICAN INDIAN", result[:race]
-    assert_equal "123 Main St", result[:address_line1]
-    assert_equal "Anchorage", result[:city]
-    assert_equal "AK", result[:state]
-    assert_equal "99501", result[:zip_code]
-    assert_equal "907-555-1234", result[:phone]
-    assert_equal "ANLC-12345", result[:tribal_enrollment_number]
-    assert_equal "Anchorage", result[:service_area]
-    assert_equal "IHS", result[:coverage_type]
+    assert_equal "000009999", result[:ssn]
+    assert_equal Date.new(1910, 2, 14), result[:dob]
+    assert_equal "M", result[:sex]
+    assert_equal "N", result[:race_code]
+    assert_equal 7819, result[:site_ien]
+    assert_equal "MOUSE,MICKEY M", result[:name]
   end
 
   # -- SELECT + ID INFO merge ------------------------------------------------
 
   def test_patient_merge
-    base = RpmsRpc::DataMapper[:patient_select].parse_one("DOE,JOHN^M^2800115^111223333^^^^^^^^^^^45", extras: { dfn: 1 })
-    ext = RpmsRpc::DataMapper[:patient_id_info].parse_one("DOE,JOHN^M^2800115^111223333^AMERICAN INDIAN^123 Main St^Anchorage^AK^99501^907-555-1234")
+    base = RpmsRpc::DataMapper[:patient_select].parse_one(
+      "MOUSE,MICKEY M^M^2100214^000009999^0^7819^^^0^^0^0^^^116^0",
+      extras: { dfn: 3 }
+    )
+    ext = RpmsRpc::DataMapper[:patient_id_info].parse_one(
+      "000009999^2100214^M^N^^7819^^MOUSE,MICKEY M"
+    )
     merged = base.merge(ext)
 
-    assert_equal 1, merged[:dfn]
-    assert_equal "DOE,JOHN", merged[:name]
-    assert_equal "AMERICAN INDIAN", merged[:race]
-    assert_equal "907-555-1234", merged[:phone]
+    assert_equal 3, merged[:dfn]
+    assert_equal "MOUSE,MICKEY M", merged[:name]
+    assert_equal "N", merged[:race_code]
+    assert_equal 7819, merged[:site_ien]
   end
 
   # -- ORWPT LIST ALL --------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes rr-q8u. Live staging probe shows ORWPT ID INFO returns 8 caret pieces of patient identifier data (SSN, DOB, sex, race code, site IEN, name), not the 13-piece NAME^SEX^DOB^SSN^RACE^ADDRESS^CITY^STATE^ZIP^PHONE^TRIBAL^SERVICE_AREA^COVERAGE shape the mapping declared. The "state = patient name" bug from the bd issue is exact: declared `m.field 7, :state` happened to hit position 7 where the name actually lives.

## Live shape (DFN=3 MOUSE,MICKEY M)

```
"000009999^2100214^M^N^^7819^^MOUSE,MICKEY M"
 [0] ssn         [1] dob       [2] sex      [3] race_code
 [4] reserved    [5] site_ien  [6] reserved [7] name
```

## What changed

- `patient_id_info` now declares only the six real fields. Address, city, state, zip, phone, tribal enrollment, service area, coverage type were entirely invented and are gone — IHS demographic detail lives in the BHDPTRPC family (not installed on staging; tracked in rr-6jr).
- `Patient.find`'s merge now produces a consistent identifier hash (no more name-in-state slot).
- Mapping + Patient API tests rewritten against the live fixture.

## Test plan

- [x] Full suite: `bundle exec rake test` — 844 runs, 2307 assertions, 0 failures
- [x] Lint: `bundle exec rubocop lib test` — clean
- [x] Shape verified against live staging probe with DFN=3, 100, 101, 2

## Linked

- Closes rr-q8u
- Related rr-6jr (staging install request — BHDPTRPC is the source for the demographics this mapping pretended to surface)
- Related to the prior shape-mismatch PR #121 (same root cause: aspirational mappings never verified against any broker)