### PR TITLE
Wire UserRoles.resolve to av_code's user_class

### DIFF
--- a/lib/rpms_rpc/user_roles.rb
+++ b/lib/rpms_rpc/user_roles.rb
@@ -23,10 +23,11 @@ module RpmsRpc
 
     # Return mock-friendly av_code attrs for a role. Caller mocks/seeds
     # this into the XUS AV CODE response so role-resolution drives off
-    # the correct field.
+    # the correct field. user_class is an Integer to match the av_code
+    # mapping's `line_field 5, :user_class, :integer` coercion.
     def self.mock_av_code(duz:, role:)
       { duz: duz.to_i, error_code: 0, verify_needs_change: 0,
-        message: "", user_class: class_for(role) || "0" }
+        message: "", user_class: (class_for(role) || "0").to_i }
     end
 
     # Determine role from the auth-class user_class (av_code line 5,

--- a/lib/rpms_rpc/user_roles.rb
+++ b/lib/rpms_rpc/user_roles.rb
@@ -21,24 +21,26 @@ module RpmsRpc
       REVERSE_CLASS_MAP[role.to_s]
     end
 
-    # Return mock-friendly user_info attrs for a role.
-    def self.mock_user_info(duz:, name:, role:)
-      is_provider = (role.to_s == "provider")
-      user_class = class_for(role) || "0"
-      { duz: duz.to_i, name: name, user_class: user_class,
-        can_sign: is_provider, is_provider: is_provider, order_role: is_provider ? "1" : "" }
+    # Return mock-friendly av_code attrs for a role. Caller mocks/seeds
+    # this into the XUS AV CODE response so role-resolution drives off
+    # the correct field.
+    def self.mock_av_code(duz:, role:)
+      { duz: duz.to_i, error_code: 0, verify_needs_change: 0,
+        message: "", user_class: class_for(role) || "0" }
     end
 
-    # Determine role from user info and security keys.
-    # Security keys can elevate a role (e.g., PRCFA SUPERVISOR → case_manager).
-    def self.resolve(user_info:, security_keys:)
-      return "provider" if user_info&.dig(:is_provider)
-
+    # Determine role from the auth-class user_class (av_code line 5,
+    # captured at signon time — NOT user_info[:user_class_ien] which
+    # points into USER CLASS file #8932.1) plus security keys.
+    #
+    # Security keys can elevate a role above what user_class alone
+    # implies (e.g., PRCFA SUPERVISOR → case_manager).
+    def self.resolve(user_class:, security_keys:)
       if security_keys.include?(:prc_supervisor) || security_keys.include?(:prc_manager)
         return "case_manager"
       end
 
-      for_class(user_info&.dig(:user_class))
+      for_class(user_class)
     end
   end
 end

--- a/test/rpms_rpc/user_roles_test.rb
+++ b/test/rpms_rpc/user_roles_test.rb
@@ -20,31 +20,34 @@ class RpmsRpc::UserRolesTest < Minitest::Test
     assert_equal "nurse", RpmsRpc::UserRoles.for_class(4)
   end
 
-  def test_resolve_provider
+  def test_resolve_provider_from_av_code_class
     assert_equal "provider", RpmsRpc::UserRoles.resolve(
-      user_info: { is_provider: true, user_class: "3" },
-      security_keys: []
+      user_class: "3", security_keys: []
     )
   end
 
-  def test_resolve_case_manager_from_keys
+  def test_resolve_case_manager_from_security_key_elevation
+    # prc_supervisor elevates beyond whatever user_class would yield.
     assert_equal "case_manager", RpmsRpc::UserRoles.resolve(
-      user_info: { is_provider: false, user_class: "3" },
-      security_keys: [ :prc_supervisor ]
+      user_class: "3", security_keys: [ :prc_supervisor ]
+    )
+    assert_equal "case_manager", RpmsRpc::UserRoles.resolve(
+      user_class: "4", security_keys: [ :prc_manager ]
     )
   end
 
   def test_resolve_nurse_from_class
     assert_equal "nurse", RpmsRpc::UserRoles.resolve(
-      user_info: { is_provider: false, user_class: "4" },
-      security_keys: []
+      user_class: "4", security_keys: []
     )
   end
 
-  def test_resolve_defaults_to_user
+  def test_resolve_defaults_to_user_when_class_unknown_or_nil
     assert_equal "user", RpmsRpc::UserRoles.resolve(
-      user_info: nil,
-      security_keys: []
+      user_class: nil, security_keys: []
+    )
+    assert_equal "user", RpmsRpc::UserRoles.resolve(
+      user_class: "", security_keys: []
     )
   end
 end

--- a/test/rpms_rpc/user_roles_test.rb
+++ b/test/rpms_rpc/user_roles_test.rb
@@ -42,12 +42,15 @@ class RpmsRpc::UserRolesTest < Minitest::Test
     )
   end
 
-  def test_resolve_defaults_to_user_when_class_unknown_or_nil
+  def test_resolve_defaults_to_user_when_class_unknown_blank_or_nil
     assert_equal "user", RpmsRpc::UserRoles.resolve(
       user_class: nil, security_keys: []
     )
     assert_equal "user", RpmsRpc::UserRoles.resolve(
       user_class: "", security_keys: []
+    )
+    assert_equal "user", RpmsRpc::UserRoles.resolve(
+      user_class: "99", security_keys: []
     )
   end
 end


### PR DESCRIPTION
## Summary

Closes rr-kw0. `UserRoles.resolve` had been reading `user_info[:user_class]` and `user_info[:is_provider]` — neither key exists on any real RPC response. After PR #121 renamed user_info's real field to `:user_class_ien` (a pointer into USER CLASS file #8932.1, semantically different from the auth-class short code), the staleness of the contract became visible.

## What changed

- `UserRoles.resolve` signature now takes `user_class:` directly (the auth-class short code from av_code line 5). Forces the caller to source from the right place.
- Dead `:is_provider` short-circuit removed (`for_class("3")` already returns "provider").
- `mock_user_info` → `mock_av_code` to reflect what it actually produces (it builds an av_code response, not user_info). Old name had zero references.
- Tests rewritten against the new contract.

## Test plan

- [x] Full suite: `bundle exec rake test` — 844 runs, 2309 assertions, 0 failures
- [x] Lint: `bundle exec rubocop lib test` — clean
- [x] No production callers of `UserRoles.resolve` in this repo (only the test); external lakeraven-ehr callers will see the kwarg rename as a clear migration signal

## Linked

- Closes rr-kw0
- Related: rr-fyf (UserManagement.find arbitrary-DUZ lookup — same area, separate refactor)