### PR TITLE
Fix practitioner_info shape + parameter passing (closes rr-fyf)

### DIFF
--- a/lib/rpms_rpc/api/practitioner.rb
+++ b/lib/rpms_rpc/api/practitioner.rb
@@ -4,10 +4,17 @@ module RpmsRpc
   module Practitioner
     extend self
 
+    # ORWU USERINFO takes no params and returns the authenticated
+    # session user's info, not an arbitrary IEN's. find(ien) succeeds
+    # iff ien matches the session user's DUZ; for arbitrary-IEN lookup
+    # see rr-fyf — no currently-mapped RPC supports that path.
     def find(ien)
       return nil if ien.nil? || ien.to_i <= 0
 
-      DataMapper.practitioner_info.fetch_one(ien.to_s, extras: { ien: ien.to_i })
+      result = DataMapper.practitioner_info.fetch_one
+      return nil if result.nil? || result[:duz].to_i != ien.to_i
+
+      result.merge(ien: result[:duz])
     end
 
     def search(name_pattern)

--- a/lib/rpms_rpc/api/user_management.rb
+++ b/lib/rpms_rpc/api/user_management.rb
@@ -17,15 +17,21 @@ module RpmsRpc
       duz = normalize_duz(duz)
       return nil if duz.nil?
 
-      # XUS GET USER INFO takes no params and returns the authenticated
-      # session user. For arbitrary-DUZ lookup the practitioner_info call
-      # below (ORWU USERINFO) is the source of truth; tracked in rr-fyf.
+      # Both ORWU USERINFO and XUS GET USER INFO return info about the
+      # AUTHENTICATED session user — neither RPC accepts a DUZ param.
+      # Passing one to ORWU USERINFO raises <PARAMETER>. So find(duz)
+      # can only succeed when duz matches the session user; arbitrary-
+      # DUZ lookup would need a different RPC (BHDPTRPC / DDR LISTER /
+      # direct File 200 read) that isn't currently mapped.
       user_info = DataMapper.user_info.fetch_lines
       return nil if user_info.nil? || user_info[:duz].to_i != duz
 
+      practitioner = DataMapper.practitioner_info.fetch_one
+      return nil if practitioner.nil? || practitioner[:duz].to_i != duz
+
       {
         user_info: user_info,
-        practitioner: DataMapper.practitioner_info.fetch_one(duz.to_s, extras: { ien: duz }),
+        practitioner: practitioner,
         security_keys: security_keys(duz).sort
       }
     end

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -257,18 +257,25 @@ module RpmsRpc
     # PRACTITIONER (ORWU*)
     # ========================================================================
 
-    # ORWU USERINFO — practitioner demographics
-    # Format: NAME^TITLE^SERVICE_SECTION^SPECIALTY^NPI^DEA^PHONE^PROVIDER_CLASS^SERVICE
+    # ORWU USERINFO — info about the AUTHENTICATED session user. Takes
+    # no params; broker raises <PARAMETER> when given any. Returns a
+    # single 25-piece caret-delimited line. Live shape against staging
+    # (DUZ=1 PROVIDER,TEST):
+    #   "1^PROVIDER,TEST^3^...^DEMO.IHS.GOV^...^8904^"
+    # The prior declaration aligned NAME^TITLE^SERVICE_SECTION^... at
+    # position 0; in reality position 0 is DUZ and the rest of the
+    # "demographic" fields (title, service_section, specialty, npi,
+    # dea_number, phone, provider_class) were invented — those are not
+    # in this response at all. Only fields with verified semantics are
+    # declared here; intermediate positions are small integer codes
+    # whose meaning would need the kernel data dictionary to interpret.
     DataMapper.define(:practitioner_info) do |m|
       m.rpc "ORWU USERINFO"
-      m.field 0, :name
-      m.field 1, :title
-      m.field 2, :service_section
-      m.field 3, :specialty
-      m.field 4, :npi
-      m.field 5, :dea_number
-      m.field 6, :phone
-      m.field 7, :provider_class
+      m.field 0,  :duz,           :integer
+      m.field 1,  :name
+      m.field 2,  :user_class,    :integer
+      m.field 12, :kernel_domain
+      m.field 23, :site_ien,      :integer
     end
 
     # ORWU NEWPERS — practitioner search results (multi-line)

--- a/test/rpms_rpc/api/clinical_test.rb
+++ b/test/rpms_rpc/api/clinical_test.rb
@@ -11,7 +11,12 @@ require "rpms_rpc/api/referral"
 class ClinicalTest < Minitest::Test
   def setup
     RpmsRpc.mock! do |m|
-      m.seed(:practitioner_info, "101", { name: "MARTINEZ,SARAH", title: "MD", specialty: "Cardiology", npi: "1234567890" })
+      # ORWU USERINFO returns the authenticated session user only; mock
+      # under empty key to match the dispatch (fetch_one with no params).
+      m.seed(:practitioner_info, "", {
+        duz: 101, name: "MARTINEZ,SARAH", user_class: 3,
+        kernel_domain: "DEMO.IHS.GOV", site_ien: 8904
+      })
       m.seed_collection(:practitioner_list,
         [ { ien: 101, name: "MARTINEZ,SARAH", title: "MD" } ],
         filter_field: :name)
@@ -30,12 +35,14 @@ class ClinicalTest < Minitest::Test
   # PRACTITIONER
   # =============================================================================
 
-  def test_practitioner_find
+  def test_practitioner_find_returns_session_user_when_ien_matches
     result = RpmsRpc::Practitioner.find(101)
 
     refute_nil result
     assert_equal "MARTINEZ,SARAH", result[:name]
-    assert_equal "1234567890", result[:npi]
+    assert_equal 101, result[:duz]
+    assert_equal 101, result[:ien]
+    assert_equal 3, result[:user_class]
   end
 
   def test_practitioner_find_nil_for_unknown

--- a/test/rpms_rpc/api/user_management_test.rb
+++ b/test/rpms_rpc/api/user_management_test.rb
@@ -24,15 +24,9 @@ class UserManagementTest < Minitest::Test
         user_class_ien: 30
       })
 
-      m.seed(:practitioner_info, DUZ.to_s, {
-        name: "PROVIDER,TEST",
-        title: "MD",
-        service_section: "Primary Care",
-        specialty: "Family Medicine",
-        npi: "1234567890",
-        dea_number: "AB1234567",
-        phone: "907-555-0100",
-        provider_class: "Physician"
+      m.seed(:practitioner_info, "", {
+        duz: DUZ, name: "PROVIDER,TEST", user_class: 3,
+        kernel_domain: "DEMO.IHS.GOV", site_ien: 8904
       })
 
       m.seed_keyed_collection(:user_keys, DUZ.to_s, [

--- a/test/rpms_rpc/mappings_test.rb
+++ b/test/rpms_rpc/mappings_test.rb
@@ -177,15 +177,17 @@ class RpmsRpc::MappingsTest < Minitest::Test
   # -- ORWU USERINFO ---------------------------------------------------------
 
   def test_practitioner_info
+    # Live shape from staging (DUZ=1 PROVIDER,TEST). 25 caret pieces;
+    # only positions [0]=duz, [1]=name, [2]=user_class, [12]=domain,
+    # [23]=site_ien have verified semantics.
     result = RpmsRpc::DataMapper[:practitioner_info].parse_one(
-      "MARTINEZ,SARAH^MD^Internal Medicine^Cardiology^1234567890^AB1234567^907-555-9999^Physician",
-      extras: { ien: 101 }
+      "1^PROVIDER,TEST^3^1^1^5^0^99999^20^1^1^5^DEMO.IHS.GOV^0^180^^^^0^0^^1^0^8904^"
     )
-    assert_equal 101, result[:ien]
-    assert_equal "MARTINEZ,SARAH", result[:name]
-    assert_equal "Cardiology", result[:specialty]
-    assert_equal "1234567890", result[:npi]
-    assert_equal "Physician", result[:provider_class]
+    assert_equal 1, result[:duz]
+    assert_equal "PROVIDER,TEST", result[:name]
+    assert_equal 3, result[:user_class]
+    assert_equal "DEMO.IHS.GOV", result[:kernel_domain]
+    assert_equal 8904, result[:site_ien]
   end
 
   # -- ORWU NEWPERS ----------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes rr-fyf. ORWU USERINFO takes no params and returns info about the AUTHENTICATED session user — not an arbitrary IEN/DUZ. The prior wrapper passed DUZ as a positional param; staging raises `<PARAMETER>USERINFO^ORWU`. The mapping was also off-by-one: declared NAME at field 0 but the live response puts DUZ at 0 and NAME at 1, with every other declared field (title, service_section, specialty, npi, dea_number, phone, provider_class) entirely fictional.

## Live shape (DUZ=1 PROVIDER,TEST against staging)

```
"1^PROVIDER,TEST^3^...^DEMO.IHS.GOV^...^8904^"  (25 pieces)
```

Verified positions kept:
- `[0]` duz, `[1]` name, `[2]` user_class (matches av_code's auth-class), `[12]` kernel_domain, `[23]` site_ien

Other small-integer codes at positions 3-11, 13-22, 24 are uninterpretable without the kernel data dictionary; intentionally not declared.

## API impact

`Practitioner.find(ien)` and `UserManagement.find(duz)` now call without params and return `nil` when the session user's DUZ doesn't match the requested IEN/DUZ. Arbitrary-IEN lookup needs a different RPC that isn't currently mapped (BHDPTRPC / DDR LISTER / direct File 200 read).

## Downstream coordination

`lakeraven-ehr` depends on `RpmsRpc::Practitioner.find` via `PractitionerGateway`. The `test_helper.rb` seeds two practitioners (IEN 101 and 102) which no longer represents reality. A **companion PR is required** there to update the test fixtures + acknowledge the session-user-only limitation. Same atomic-merge pattern as #123/#353.

## Test plan

- [x] Full suite: `bundle exec rake test` — 844 runs, 2312 assertions, 0 failures
- [x] Lint: `bundle exec rubocop lib test` — clean
- [x] Shape verified against live staging probe (DUZ=1)
- [x] Parameter-arity confirmed: any positional arg raises `<PARAMETER>USERINFO^ORWU`

## Linked

- Closes rr-fyf
- Related: rr-6jr (install request — BHDPTRPC includes the practitioner-detail RPC family that could replace this once available)