### PR TITLE
Rename referral_search / referral_detail to broker NAMEs

### DIFF
--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -475,10 +475,12 @@ module RpmsRpc
     # SERVICE REQUESTS / REFERRALS (BMCRPC*)
     # ========================================================================
 
-    # BMCRPC SRCHREF — referral search (multi-line)
+    # BMC SEARCH REFERRAL — referral search (multi-line)
     # Format: IEN^PATIENT_DFN^STATUS^TYPE^DATE^PROVIDER
+    # Verified on staging file 8994 (2026-06-07): NAME is
+    # "BMC SEARCH REFERRAL", tag SRCHREF, routine BMCRPC1.
     DataMapper.define(:referral_search) do |m|
-      m.rpc "BMCRPC SRCHREF"
+      m.rpc "BMC SEARCH REFERRAL"
       m.field 0, :ien
       m.field 1, :patient_dfn, :integer
       m.field 2, :status
@@ -1119,9 +1121,11 @@ module RpmsRpc
     # REFERRAL DETAIL & WRITE RPCs (BMCRPC*)
     # ========================================================================
 
-    # BMCRPC GTRFBYID — single referral detail
+    # BMC GET REFERRAL — single referral detail
+    # Verified on staging file 8994 (2026-06-07): NAME is
+    # "BMC GET REFERRAL", tag GTRFBYID, routine BMCRPC1.
     DataMapper.define(:referral_detail) do |m|
-      m.rpc "BMCRPC GTRFBYID"
+      m.rpc "BMC GET REFERRAL"
       m.field 0, :ien
       m.field 1, :patient_dfn, :integer
       m.field 2, :status

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -472,7 +472,7 @@ module RpmsRpc
     end
 
     # ========================================================================
-    # SERVICE REQUESTS / REFERRALS (BMCRPC*)
+    # SERVICE REQUESTS / REFERRALS (BMC* / BMCRPC*)
     # ========================================================================
 
     # BMC SEARCH REFERRAL — referral search (multi-line)
@@ -1118,7 +1118,7 @@ module RpmsRpc
     end
 
     # ========================================================================
-    # REFERRAL DETAIL & WRITE RPCs (BMCRPC*)
+    # REFERRAL DETAIL & WRITE RPCs (BMC* / BMCRPC*)
     # ========================================================================
 
     # BMC GET REFERRAL — single referral detail

--- a/test/rpms_rpc/mappings_test.rb
+++ b/test/rpms_rpc/mappings_test.rb
@@ -522,20 +522,18 @@ class RpmsRpc::MappingsTest < Minitest::Test
     assert_equal "Patient portal enabled", result[:message]
   end
 
-  # -- RPC names verified against live staging broker (2026-06-07) -----------
-  # File 8994 dump on staging RPMS (i-0cef6ae75fc88bb2a, BMC v4.0*13) shows
-  # the CHS/PRC referral RPCs registered with English-name NAMEs and the old
-  # BMCRPC* tags only as routine entry points. The gem previously declared
-  # NAME = routine+tag, which never matched the real broker.
+  # -- RPC names verified against staging file 8994 (2026-06-07) -------------
+  # BMC v4.0*13 registers the CHS/PRC referral RPCs with English-name NAMEs;
+  # the old BMCRPC* tags appear only as routine entry points. The gem
+  # previously declared NAME = routine+tag, which never matched the real
+  # broker.
 
   def test_referral_search_uses_broker_rpc_name
-    assert_equal "BMC SEARCH REFERRAL",
-      RpmsRpc::DataMapper[:referral_search].rpc_name
+    assert_equal "BMC SEARCH REFERRAL", RpmsRpc::DataMapper[:referral_search].rpc_name
   end
 
   def test_referral_detail_uses_broker_rpc_name
-    assert_equal "BMC GET REFERRAL",
-      RpmsRpc::DataMapper[:referral_detail].rpc_name
+    assert_equal "BMC GET REFERRAL", RpmsRpc::DataMapper[:referral_detail].rpc_name
   end
 
   # -- Registry completeness -------------------------------------------------

--- a/test/rpms_rpc/mappings_test.rb
+++ b/test/rpms_rpc/mappings_test.rb
@@ -522,6 +522,22 @@ class RpmsRpc::MappingsTest < Minitest::Test
     assert_equal "Patient portal enabled", result[:message]
   end
 
+  # -- RPC names verified against live staging broker (2026-06-07) -----------
+  # File 8994 dump on staging RPMS (i-0cef6ae75fc88bb2a, BMC v4.0*13) shows
+  # the CHS/PRC referral RPCs registered with English-name NAMEs and the old
+  # BMCRPC* tags only as routine entry points. The gem previously declared
+  # NAME = routine+tag, which never matched the real broker.
+
+  def test_referral_search_uses_broker_rpc_name
+    assert_equal "BMC SEARCH REFERRAL",
+      RpmsRpc::DataMapper[:referral_search].rpc_name
+  end
+
+  def test_referral_detail_uses_broker_rpc_name
+    assert_equal "BMC GET REFERRAL",
+      RpmsRpc::DataMapper[:referral_detail].rpc_name
+  end
+
   # -- Registry completeness -------------------------------------------------
 
   def test_all_expected_mappings_registered


### PR DESCRIPTION
## Summary
- `referral_search` now uses `BMC SEARCH REFERRAL` (was `BMCRPC SRCHREF`)
- `referral_detail` now uses `BMC GET REFERRAL` (was `BMCRPC GTRFBYID`)
- Adds two tests that assert the rpc_name strings, anchored to the 2026-06-07 file 8994 dump from staging

The gem's previous strings concatenated routine prefix + tag (`BMCRPC1` + `SRCHREF`), which is the M call target rather than the RPC NAME registered on file 8994. Verified against the live BMC v4.0\*13 install on staging.

Scope is limited to the two confirmed-on-broker entries. The remaining `BMCRPC GT*` (budget, vendor, contract, payment, obligation) entries are absent from file 8994 on staging and need separate triage — they may live in a not-yet-installed CHS/PRC sub-package or be artifacts of older mappings.

Refs #126.

## Test plan
- [x] TDD red → green for `test_referral_search_uses_broker_rpc_name`
- [x] TDD red → green for `test_referral_detail_uses_broker_rpc_name`
- [x] Full suite: 846 runs, 0 failures
- [ ] Live broker probe (post-merge) — confirm `BMC SEARCH REFERRAL` returns expected referral list shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)