### PR TITLE
Register :user_security_keys_list capability for ORWU USERKEYS

### DIFF
--- a/lib/rpms_rpc/server_capabilities.rb
+++ b/lib/rpms_rpc/server_capabilities.rb
@@ -24,6 +24,14 @@ module RpmsRpc
         "BEHOPTCX PTINFO",
         "BEHOPTPC GETBDP",
         "BEHOCACV CWAD"
+      ].freeze,
+
+      # Authentication#user_security_keys / UserManagement#security_keys —
+      # list of security keys held by a user. ORWU USERKEYS is absent on
+      # the 2026-06-07 staging dump; callers should gate via supports? and
+      # fall back to per-key probes (ORWU HASKEY) when unsupported.
+      user_security_keys_list: [
+        "ORWU USERKEYS"
       ].freeze
     }.freeze
 

--- a/test/rpms_rpc/server_capabilities_test.rb
+++ b/test/rpms_rpc/server_capabilities_test.rb
@@ -45,6 +45,21 @@ class RpmsRpc::ServerCapabilitiesTest < Minitest::Test
     assert_includes rpcs, "BEHOCACV CWAD"
   end
 
+  def test_user_security_keys_list_feature_is_registered
+    assert RpmsRpc::ServerCapabilities::FEATURE_RPCS.key?(:user_security_keys_list),
+           "Registry must expose :user_security_keys_list — gates Authentication#user_security_keys / UserManagement#security_keys"
+  end
+
+  def test_user_security_keys_list_maps_to_orwu_userkeys
+    rpcs = RpmsRpc::ServerCapabilities::FEATURE_RPCS[:user_security_keys_list]
+    assert_equal [ "ORWU USERKEYS" ], rpcs
+  end
+
+  def test_probe_returns_false_when_orwu_userkeys_missing
+    missing = ProbingClient.new(missing: [ "ORWU USERKEYS" ])
+    assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :user_security_keys_list)
+  end
+
   def test_unknown_feature_raises_argument_error
     assert_raises(ArgumentError) do
       RpmsRpc::ServerCapabilities.probe(@client, :no_such_feature)


### PR DESCRIPTION
## Summary
- Adds `:user_security_keys_list` to `ServerCapabilities::FEATURE_RPCS`, probed via `ORWU USERKEYS`.
- Three new tests: feature registered, maps to `ORWU USERKEYS`, probe returns false when broker reports the RPC missing.
- No call-site changes; engine wiring is a follow-up so this PR stays atomic.

`ORWU USERKEYS` is absent on the 2026-06-07 staging file 8994 dump despite the `ORWU` namespace being installed. `Authentication#user_security_keys` and `UserManagement#security_keys` both call it directly today and will raise on servers without it. With this capability registered, those callers can gate via `RpmsRpc.client.supports?(:user_security_keys_list)` and degrade to per-key `ORWU HASKEY` probes when unsupported.

Refs #126.

## Test plan
- [x] TDD red -> green for the three new tests
- [x] Full suite: 849 runs, 0 failures
- [ ] Follow-up PR: wire `Authentication#user_security_keys` and `UserManagement#security_keys` to gate on `supports?` and fall back to `ORWU HASKEY` over a static key list

🤖 Generated with [Claude Code](https://claude.com/claude-code)