### PR TITLE
Gate user_security_keys callers on :user_security_keys_list

### DIFF
--- a/lib/rpms_rpc/api/authentication.rb
+++ b/lib/rpms_rpc/api/authentication.rb
@@ -57,6 +57,7 @@ module RpmsRpc
 
     def user_security_keys(duz)
       return [] if invalid_id?(duz)
+      return [] unless RpmsRpc.client.supports?(:user_security_keys_list)
 
       Array(DataMapper.user_keys.fetch_many(duz.to_s)).filter_map { |row| presence(row[:key_name]) }
     end

--- a/lib/rpms_rpc/api/user_management.rb
+++ b/lib/rpms_rpc/api/user_management.rb
@@ -51,6 +51,8 @@ module RpmsRpc
     private
 
     def security_keys(duz)
+      return [] unless RpmsRpc.client.supports?(:user_security_keys_list)
+
       DataMapper.user_keys.fetch_many(duz.to_s).filter_map { |row| presence(row[:key_name]) }
     end
 

--- a/test/rpms_rpc/api/authentication_test.rb
+++ b/test/rpms_rpc/api/authentication_test.rb
@@ -105,6 +105,12 @@ class AuthenticationTest < Minitest::Test
     assert_equal [], RpmsRpc::Authentication.user_security_keys(-1)
   end
 
+  def test_user_security_keys_returns_empty_when_capability_unsupported
+    RpmsRpc.client.seed_capability(:user_security_keys_list, supported: false)
+    assert_equal [], RpmsRpc::Authentication.user_security_keys(301)
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWU USERKEYS" }
+  end
+
   def test_has_security_key_uses_duz_and_key_name
     RpmsRpc.mock! do |m|
       m.seed_scalar(:user_has_key, "301", true)

--- a/test/rpms_rpc/api/user_management_test.rb
+++ b/test/rpms_rpc/api/user_management_test.rb
@@ -96,6 +96,15 @@ class UserManagementTest < Minitest::Test
     assert_nil RpmsRpc::UserManagement.find(999_998)
   end
 
+  def test_find_returns_empty_security_keys_when_capability_unsupported
+    RpmsRpc.client.seed_capability(:user_security_keys_list, supported: false)
+    summary = RpmsRpc::UserManagement.find(DUZ)
+
+    refute_nil summary
+    assert_equal [], summary[:security_keys]
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWU USERKEYS" }
+  end
+
   def test_grant_key_calls_rpc_and_returns_success_message
     result = RpmsRpc::UserManagement.grant_key(DUZ, "PROVIDER")
 


### PR DESCRIPTION
## Summary
- `Authentication#user_security_keys(duz)`: short-circuits to `[]` when `RpmsRpc.client.supports?(:user_security_keys_list)` is false.
- `UserManagement#security_keys(duz)` (used by `find(duz)`): same gate.
- Two new tests verify the gate trips and `ORWU USERKEYS` is not sent.

Builds on #128. On staging the broker returns a literal "Remote Procedure 'ORWU USERKEYS' doesn't exist on the server." reply that `fetch_many` previously parsed as a single garbage key — that path is gone now.

Closes local bead `rr-cns` ("ORWU USERKEYS RPC is not registered on RPMS broker; security_keys lookup fails"). Refs #126.

## Test plan
- [x] TDD red -> green for both gate tests
- [x] Full suite: 851 runs, 0 failures
- [x] Existing happy-path tests still pass (MockClient defaults `supports?` to true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)