### PR TITLE
Register :health_summary_gmts capability for GMTS namespace

### DIFF
--- a/lib/rpms_rpc/server_capabilities.rb
+++ b/lib/rpms_rpc/server_capabilities.rb
@@ -32,6 +32,17 @@ module RpmsRpc
       # fall back to per-key probes (ORWU HASKEY) when unsupported.
       user_security_keys_list: [
         "ORWU USERKEYS"
+      ].freeze,
+
+      # HealthSummary — GMTS-namespace health summary, flowsheet, and
+      # maintenance-items reads. The GMTS package is absent entirely on
+      # the 2026-06-07 staging dump (zero entries on file 8994); callers
+      # should gate via supports? and skip the read when unsupported.
+      health_summary_gmts: [
+        "GMTS PWH REPORT",
+        "GMTS FLOWSHEET LIST",
+        "GMTS FLOWSHEET DATA",
+        "GMTS MAINT ITEMS"
       ].freeze
     }.freeze
 

--- a/test/rpms_rpc/server_capabilities_test.rb
+++ b/test/rpms_rpc/server_capabilities_test.rb
@@ -60,6 +60,24 @@ class RpmsRpc::ServerCapabilitiesTest < Minitest::Test
     assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :user_security_keys_list)
   end
 
+  def test_health_summary_gmts_feature_is_registered
+    assert RpmsRpc::ServerCapabilities::FEATURE_RPCS.key?(:health_summary_gmts),
+           "Registry must expose :health_summary_gmts — gates HealthSummary GMTS-namespace RPCs"
+  end
+
+  def test_health_summary_gmts_maps_to_gmts_cluster
+    rpcs = RpmsRpc::ServerCapabilities::FEATURE_RPCS[:health_summary_gmts]
+    assert_includes rpcs, "GMTS PWH REPORT"
+    assert_includes rpcs, "GMTS FLOWSHEET LIST"
+    assert_includes rpcs, "GMTS FLOWSHEET DATA"
+    assert_includes rpcs, "GMTS MAINT ITEMS"
+  end
+
+  def test_probe_returns_false_when_any_gmts_rpc_missing
+    missing = ProbingClient.new(missing: [ "GMTS FLOWSHEET DATA" ])
+    assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :health_summary_gmts)
+  end
+
   def test_unknown_feature_raises_argument_error
     assert_raises(ArgumentError) do
       RpmsRpc::ServerCapabilities.probe(@client, :no_such_feature)


### PR DESCRIPTION
## Summary
- Adds `:health_summary_gmts` to `ServerCapabilities::FEATURE_RPCS`, mapped to the 4-RPC GMTS cluster (`GMTS PWH REPORT`, `GMTS FLOWSHEET LIST`, `GMTS FLOWSHEET DATA`, `GMTS MAINT ITEMS`).
- Three new tests: feature registered, mapping shape, probe-returns-false when any GMTS RPC missing.
- No call-site changes; engine wiring is a follow-up so this PR stays atomic.

The GMTS package is absent entirely from the 2026-06-07 staging file 8994 dump (zero entries). `HealthSummary#flowsheet_definitions`, `#flowsheet`, `#maintenance_items`, and `#health_summary_text` all call into this namespace today and will raise against any server without the package. With the capability registered, those callers can gate via `RpmsRpc.client.supports?(:health_summary_gmts)`.

Cluster-probe model matches `:patient_chart_banner` (one feature gates a related-RPC group).

Refs #126.

## Test plan
- [x] TDD red -> green for the three new tests
- [x] Full suite: 854 runs, 0 failures
- [ ] Follow-up PR: wire `HealthSummary` callers to gate on `supports?(:health_summary_gmts)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)