### PR TITLE
Gate HealthSummary GMTS callers on :health_summary_gmts

### DIFF
--- a/lib/rpms_rpc/api/health_summary.rb
+++ b/lib/rpms_rpc/api/health_summary.rb
@@ -85,11 +85,14 @@ module RpmsRpc
 
     def personal_wellness_report(dfn)
       return { sections: [], error: "Invalid patient DFN" } if invalid_id?(dfn)
+      return { sections: [], error: "GMTS health summary not available on this server" } unless RpmsRpc.client.supports?(:health_summary_gmts)
 
       parse_pwh_report(DataMapper.health_summary_report.fetch_text(dfn.to_s))
     end
 
     def flowsheet_definitions
+      return [] unless RpmsRpc.client.supports?(:health_summary_gmts)
+
       DataMapper.flowsheet_list.fetch_many
     end
 
@@ -108,12 +111,14 @@ module RpmsRpc
 
     def health_maintenance(dfn)
       return [] if invalid_id?(dfn)
+      return [] unless RpmsRpc.client.supports?(:health_summary_gmts)
 
       DataMapper.maint_items.fetch_many(dfn.to_s)
     end
 
     def flowsheet(dfn, flowsheet_ien:, start_date: Date.today - 365, end_date: Date.today)
       return { items: [], error: "Invalid patient DFN" } if invalid_id?(dfn) || invalid_id?(flowsheet_ien)
+      return { items: [], error: "GMTS health summary not available on this server" } unless RpmsRpc.client.supports?(:health_summary_gmts)
 
       response = RpmsRpc.client.call_rpc(
         DataMapper.flowsheet_data.rpc_name,

--- a/test/rpms_rpc/api/health_summary_test.rb
+++ b/test/rpms_rpc/api/health_summary_test.rb
@@ -249,4 +249,36 @@ class HealthSummaryApiTest < Minitest::Test
     assert_equal "PRB", RpmsRpc::HealthSummary::COMPONENT_TYPES[:problems]
     assert_equal "IMM", RpmsRpc::HealthSummary::COMPONENT_TYPES[:immunizations]
   end
+
+  # -- :health_summary_gmts capability gating --------------------------------
+
+  def test_personal_wellness_report_short_circuits_when_gmts_unsupported
+    RpmsRpc.client.seed_capability(:health_summary_gmts, supported: false)
+    result = RpmsRpc::HealthSummary.personal_wellness_report(DFN)
+
+    assert_equal [], result[:sections]
+    assert_match(/not (?:installed|available)/i, result[:error].to_s)
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "GMTS PWH REPORT" }
+  end
+
+  def test_flowsheet_definitions_returns_empty_when_gmts_unsupported
+    RpmsRpc.client.seed_capability(:health_summary_gmts, supported: false)
+    assert_equal [], RpmsRpc::HealthSummary.flowsheet_definitions
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "GMTS FLOWSHEET LIST" }
+  end
+
+  def test_health_maintenance_returns_empty_when_gmts_unsupported
+    RpmsRpc.client.seed_capability(:health_summary_gmts, supported: false)
+    assert_equal [], RpmsRpc::HealthSummary.health_maintenance(DFN)
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "GMTS MAINT ITEMS" }
+  end
+
+  def test_flowsheet_short_circuits_when_gmts_unsupported
+    RpmsRpc.client.seed_capability(:health_summary_gmts, supported: false)
+    result = RpmsRpc::HealthSummary.flowsheet(DFN, flowsheet_ien: 701)
+
+    assert_equal [], result[:items]
+    assert_match(/not (?:installed|available)/i, result[:error].to_s)
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "GMTS FLOWSHEET DATA" }
+  end
 end


### PR DESCRIPTION
## Summary
- `personal_wellness_report(dfn)`: returns `{sections: [], error: "GMTS health summary not available on this server"}` when capability is false.
- `flowsheet_definitions`: returns `[]` when unsupported.
- `health_maintenance(dfn)`: returns `[]` when unsupported.
- `flowsheet(dfn, flowsheet_ien:, …)`: returns `{items: [], error: "GMTS health summary not available on this server"}` when unsupported.
- Four new tests cover each gate; existing happy-path tests untouched (MockClient defaults `supports?` to true).

Builds on #130 (capability registration). Closes the path where these methods would raise against any RPMS server without the GMTS package — including the 2026-06-07 staging dump where GMTS has zero entries on file 8994.

Refs #126.

## Test plan
- [x] TDD red -> green for all 4 gates
- [x] Full suite: 858 runs, 0 failures
- [x] Hash-shape returns include actionable error text; array-shape returns degrade silently consistent with the gem's existing pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)