### PR TITLE
Gate XU KEY admin on :xu_key_admin capability

### DIFF
--- a/lib/rpms_rpc/api/user_management.rb
+++ b/lib/rpms_rpc/api/user_management.rb
@@ -45,6 +45,8 @@ module RpmsRpc
     end
 
     def list_all_keys
+      return [] unless RpmsRpc.client.supports?(:xu_key_admin)
+
       DataMapper.key_list.fetch_many
     end
 
@@ -62,6 +64,10 @@ module RpmsRpc
 
       key_name = key_name.to_s.strip
       return { success: false, error: "Key name required" } if key_name.empty?
+
+      unless RpmsRpc.client.supports?(:xu_key_admin)
+        return { success: false, error: "XU KEY admin not available on this server" }
+      end
 
       rpc_name = DataMapper[mapping_name].rpc_name
       response = RpmsRpc.client.call_rpc(rpc_name, duz.to_s, key_name)

--- a/lib/rpms_rpc/server_capabilities.rb
+++ b/lib/rpms_rpc/server_capabilities.rb
@@ -43,6 +43,14 @@ module RpmsRpc
         "GMTS FLOWSHEET LIST",
         "GMTS FLOWSHEET DATA",
         "GMTS MAINT ITEMS"
+      ].freeze,
+
+      # UserManagement#list_all_keys / #grant_key / #revoke_key — XU KEY
+      # namespace is absent entirely on the 2026-06-07 staging dump. Probe
+      # via the read-only XU KEY LIST; the GRANT/REVOKE writes gate by
+      # association so an unsupported broker never receives them.
+      xu_key_admin: [
+        "XU KEY LIST"
       ].freeze
     }.freeze
 

--- a/test/rpms_rpc/api/user_management_test.rb
+++ b/test/rpms_rpc/api/user_management_test.rb
@@ -158,4 +158,28 @@ class UserManagementTest < Minitest::Test
     assert_equal({ ien: 1, name: "XUPROGMODE" }, keys.first)
     assert_equal({ ien: 2, name: "PROVIDER" }, keys.last)
   end
+
+  def test_list_all_keys_returns_empty_when_xu_key_admin_unsupported
+    RpmsRpc.client.seed_capability(:xu_key_admin, supported: false)
+    assert_equal [], RpmsRpc::UserManagement.list_all_keys
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "XU KEY LIST" }
+  end
+
+  def test_grant_key_short_circuits_when_xu_key_admin_unsupported
+    RpmsRpc.client.seed_capability(:xu_key_admin, supported: false)
+    result = RpmsRpc::UserManagement.grant_key(DUZ, "PROVIDER")
+
+    assert_equal false, result[:success]
+    assert_match(/not available/i, result[:error].to_s)
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "XU KEY GRANT" }
+  end
+
+  def test_revoke_key_short_circuits_when_xu_key_admin_unsupported
+    RpmsRpc.client.seed_capability(:xu_key_admin, supported: false)
+    result = RpmsRpc::UserManagement.revoke_key(DUZ, "PROVIDER")
+
+    assert_equal false, result[:success]
+    assert_match(/not available/i, result[:error].to_s)
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "XU KEY REVOKE" }
+  end
 end

--- a/test/rpms_rpc/server_capabilities_test.rb
+++ b/test/rpms_rpc/server_capabilities_test.rb
@@ -78,6 +78,22 @@ class RpmsRpc::ServerCapabilitiesTest < Minitest::Test
     assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :health_summary_gmts)
   end
 
+  def test_xu_key_admin_feature_is_registered
+    assert RpmsRpc::ServerCapabilities::FEATURE_RPCS.key?(:xu_key_admin),
+           "Registry must expose :xu_key_admin — gates UserManagement list_all_keys / grant_key / revoke_key"
+  end
+
+  def test_xu_key_admin_probes_read_only_xu_key_list
+    rpcs = RpmsRpc::ServerCapabilities::FEATURE_RPCS[:xu_key_admin]
+    assert_equal [ "XU KEY LIST" ], rpcs,
+                 "Probe set must be read-only; XU KEY GRANT/REVOKE are writes and gate-by-association"
+  end
+
+  def test_probe_returns_false_when_xu_key_list_missing
+    missing = ProbingClient.new(missing: [ "XU KEY LIST" ])
+    assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :xu_key_admin)
+  end
+
   def test_unknown_feature_raises_argument_error
     assert_raises(ArgumentError) do
       RpmsRpc::ServerCapabilities.probe(@client, :no_such_feature)


### PR DESCRIPTION
## Summary
- Adds `:xu_key_admin` to `ServerCapabilities::FEATURE_RPCS`, probed via the read-only `XU KEY LIST` (the GRANT/REVOKE writes gate by association — never reach an unsupported broker).
- `UserManagement#list_all_keys`: returns `[]` when unsupported.
- `UserManagement#grant_key(duz, key_name)`: returns `{success: false, error: "XU KEY admin not available on this server"}` when unsupported (matches existing `Invalid DUZ` / `Key name required` failure shape).
- `UserManagement#revoke_key(duz, key_name)`: same.
- Six new tests: 3 capability-registry tests + 3 gate-tripping tests covering list_all_keys, grant_key, revoke_key.

Bundled as a single PR (capability + callers) since both halves are tightly coupled and ship together.

The XU KEY namespace is absent entirely from the 2026-06-07 staging file 8994 dump (zero entries on file 8994). Without this gate, `grant_key`/`revoke_key` would attempt writes against a broker that doesn't know the RPC.

Refs #126.

## Test plan
- [x] TDD red -> green for all 6 new tests
- [x] Full suite: 864 runs, 0 failures
- [x] Existing happy-path tests for list_all_keys / grant_key / revoke_key still pass (MockClient defaults `supports?` to true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)