### PR TITLE
Gate Eprescribing PSO callers on :pso_prescription_orders

### DIFF
--- a/lib/rpms_rpc/api/eprescribing.rb
+++ b/lib/rpms_rpc/api/eprescribing.rb
@@ -39,6 +39,7 @@ module RpmsRpc
     #   { success: false, error: "..." }
     def transmit(attrs)
       return { success: false, error: "attrs hash is required" } unless attrs.is_a?(Hash)
+      return { success: false, error: "PSO prescription orders not available on this server" } unless RpmsRpc.client.supports?(:pso_prescription_orders)
 
       param = build_rx_param(attrs)
       result = DataMapper.prescription_new.fetch_one(param)
@@ -56,6 +57,7 @@ module RpmsRpc
     # plus { error: "..." } when status is "error".
     def status(transmission_id)
       return { status: "error", error: "transmission_id is required" } if blank?(transmission_id)
+      return { status: "error", error: "PSO prescription orders not available on this server" } unless RpmsRpc.client.supports?(:pso_prescription_orders)
 
       result = DataMapper.erx_status.fetch_one(transmission_id.to_s)
       return { status: "error", error: "Empty response from RPMS" } if result.nil?
@@ -73,6 +75,7 @@ module RpmsRpc
     #   { success: false, error: "..." }
     def cancel(transmission_id, reason: nil)
       return { success: false, error: "transmission_id is required" } if blank?(transmission_id)
+      return { success: false, error: "PSO prescription orders not available on this server" } unless RpmsRpc.client.supports?(:pso_prescription_orders)
 
       param  = blank?(reason) ? transmission_id.to_s : "#{transmission_id}^#{reason}"
       result = DataMapper.prescription_cancel.fetch_one(param)

--- a/lib/rpms_rpc/server_capabilities.rb
+++ b/lib/rpms_rpc/server_capabilities.rb
@@ -51,6 +51,15 @@ module RpmsRpc
       # association so an unsupported broker never receives them.
       xu_key_admin: [
         "XU KEY LIST"
+      ].freeze,
+
+      # Eprescribing#transmit / #status / #cancel — PSO namespace is absent
+      # entirely on the 2026-06-07 staging dump (no PSO entries on file
+      # 8994). Probe via PSO ERX STATUS as the read-leaning sentinel; PSO
+      # NEW RX and PSO CANCEL RX are clinical writes and gate by association
+      # so an unsupported broker never receives them.
+      pso_prescription_orders: [
+        "PSO ERX STATUS"
       ].freeze
     }.freeze
 

--- a/test/rpms_rpc/api/eprescribing_test.rb
+++ b/test/rpms_rpc/api/eprescribing_test.rb
@@ -221,4 +221,33 @@ class EprescribingTest < Minitest::Test
   def test_build_rx_param_joins_attrs_in_pso_new_rx_order
     assert_equal RX_COMPOSITE, RpmsRpc::Eprescribing.build_rx_param(RX_ATTRS)
   end
+
+  # === :pso_prescription_orders capability gating ==========================
+
+  def test_transmit_short_circuits_when_pso_unsupported
+    RpmsRpc.client.seed_capability(:pso_prescription_orders, supported: false)
+    result = RpmsRpc::Eprescribing.transmit(RX_ATTRS)
+
+    assert_equal false, result[:success]
+    assert_match(/not available/i, result[:error].to_s)
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "PSO NEW RX" }
+  end
+
+  def test_status_short_circuits_when_pso_unsupported
+    RpmsRpc.client.seed_capability(:pso_prescription_orders, supported: false)
+    result = RpmsRpc::Eprescribing.status("TX001")
+
+    assert_equal "error", result[:status]
+    assert_match(/not available/i, result[:error].to_s)
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "PSO ERX STATUS" }
+  end
+
+  def test_cancel_short_circuits_when_pso_unsupported
+    RpmsRpc.client.seed_capability(:pso_prescription_orders, supported: false)
+    result = RpmsRpc::Eprescribing.cancel("TX001")
+
+    assert_equal false, result[:success]
+    assert_match(/not available/i, result[:error].to_s)
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "PSO CANCEL RX" }
+  end
 end

--- a/test/rpms_rpc/server_capabilities_test.rb
+++ b/test/rpms_rpc/server_capabilities_test.rb
@@ -94,6 +94,22 @@ class RpmsRpc::ServerCapabilitiesTest < Minitest::Test
     assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :xu_key_admin)
   end
 
+  def test_pso_prescription_orders_feature_is_registered
+    assert RpmsRpc::ServerCapabilities::FEATURE_RPCS.key?(:pso_prescription_orders),
+           "Registry must expose :pso_prescription_orders — gates Eprescribing.transmit / status / cancel"
+  end
+
+  def test_pso_prescription_orders_probes_pso_erx_status
+    rpcs = RpmsRpc::ServerCapabilities::FEATURE_RPCS[:pso_prescription_orders]
+    assert_equal [ "PSO ERX STATUS" ], rpcs,
+                 "Probe set picks PSO ERX STATUS as the read-leaning sentinel; PSO NEW RX / CANCEL RX gate by association"
+  end
+
+  def test_probe_returns_false_when_pso_erx_status_missing
+    missing = ProbingClient.new(missing: [ "PSO ERX STATUS" ])
+    assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :pso_prescription_orders)
+  end
+
   def test_unknown_feature_raises_argument_error
     assert_raises(ArgumentError) do
       RpmsRpc::ServerCapabilities.probe(@client, :no_such_feature)


### PR DESCRIPTION
## Summary
- Adds `:pso_prescription_orders` to `ServerCapabilities::FEATURE_RPCS`, probed via the read-leaning `PSO ERX STATUS` (the `NEW RX` / `CANCEL RX` clinical writes gate by association — never reach an unsupported broker).
- `Eprescribing#transmit(attrs)`: returns `{success: false, error: "PSO prescription orders not available on this server"}` when unsupported.
- `Eprescribing#status(transmission_id)`: returns `{status: "error", error: "PSO prescription orders not available on this server"}` when unsupported.
- `Eprescribing#cancel(transmission_id, reason:)`: returns `{success: false, error: "PSO prescription orders not available on this server"}` when unsupported.
- Six new tests (3 capability-registry + 3 gate-tripping).

Bundled PR (capability + callers), same shape as #132.

The PSO namespace is absent entirely from the 2026-06-07 staging file 8994 dump (zero entries). Without this gate, `transmit` / `cancel` would attempt clinical writes against a broker that doesn't know the RPCs — pharmacy is a clinical-safety domain where silent broker failures are worse than explicit "not available" responses.

Refs #126.

## Test plan
- [x] TDD red -> green for all 6 new tests
- [x] Full suite: 870 runs, 0 failures
- [x] Existing happy-path tests for transmit / status / cancel still pass (MockClient defaults `supports?` to true)
- [x] Probe RPC is read-leaning: `PSO ERX STATUS` returns transmission status rather than mutating state

🤖 Generated with [Claude Code](https://claude.com/claude-code)