### PR TITLE
Gate Communication XQAL alert callers on :xqal_alert_actions

### DIFF
--- a/lib/rpms_rpc/api/communication.rb
+++ b/lib/rpms_rpc/api/communication.rb
@@ -87,6 +87,7 @@ module RpmsRpc
 
     def get_alerts(duz)
       return [] if invalid_id?(duz)
+      return [] unless RpmsRpc.client.supports?(:xqal_alert_actions)
 
       Array(DataMapper.xqal_alert.fetch_many(duz.to_s)).map { |alert| apply_alert_defaults(alert) }
     end
@@ -98,6 +99,7 @@ module RpmsRpc
     def mark_alert_read(alert_ien, duz)
       return { success: false, error: "Alert IEN required" } if invalid_id?(alert_ien)
       return { success: false, error: "User DUZ required" } if invalid_id?(duz)
+      return { success: false, error: "XQAL alert actions not available on this server" } unless RpmsRpc.client.supports?(:xqal_alert_actions)
 
       parsed = DataMapper.xqal_mark_read.fetch_one("#{alert_ien}^#{duz}")
 
@@ -111,6 +113,7 @@ module RpmsRpc
       return { success: false, error: "Alert IEN required" } if invalid_id?(alert_ien)
       return { success: false, error: "From DUZ required" } if invalid_id?(from_duz)
       return { success: false, error: "To DUZ required" } if invalid_id?(to_duz)
+      return { success: false, error: "XQAL alert actions not available on this server" } unless RpmsRpc.client.supports?(:xqal_alert_actions)
 
       parsed = DataMapper.xqal_forward.fetch_one(
         [ alert_ien, from_duz, to_duz, escape_multiline(comment) ].join("^")

--- a/lib/rpms_rpc/server_capabilities.rb
+++ b/lib/rpms_rpc/server_capabilities.rb
@@ -60,6 +60,17 @@ module RpmsRpc
       # so an unsupported broker never receives them.
       pso_prescription_orders: [
         "PSO ERX STATUS"
+      ].freeze,
+
+      # Communication#get_alerts / #mark_alert_read / #forward_alert —
+      # XQAL NEW ALERTS, MARK READ, and FORWARD are all absent on the
+      # 2026-06-07 staging dump. (Only XQAL GUI ALERTS is present; that's
+      # a different CPRS-GUI-format read API the gem doesn't currently
+      # consume — re-routing is a separate concern.) Probe via XQAL NEW
+      # ALERTS as the read sentinel; the MARK READ / FORWARD writes gate
+      # by association.
+      xqal_alert_actions: [
+        "XQAL NEW ALERTS"
       ].freeze
     }.freeze
 

--- a/test/rpms_rpc/api/communication_test.rb
+++ b/test/rpms_rpc/api/communication_test.rb
@@ -204,6 +204,32 @@ class CommunicationTest < Minitest::Test
     assert_equal false, RpmsRpc::Communication.forward_alert(501, from_duz: DUZ, to_duz: 0)[:success]
   end
 
+  # === :xqal_alert_actions capability gating ===============================
+
+  def test_get_alerts_returns_empty_when_xqal_unsupported
+    RpmsRpc.client.seed_capability(:xqal_alert_actions, supported: false)
+    assert_equal [], RpmsRpc::Communication.get_alerts(DUZ)
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "XQAL NEW ALERTS" }
+  end
+
+  def test_mark_alert_read_short_circuits_when_xqal_unsupported
+    RpmsRpc.client.seed_capability(:xqal_alert_actions, supported: false)
+    result = RpmsRpc::Communication.mark_alert_read(501, DUZ)
+
+    assert_equal false, result[:success]
+    assert_match(/not available/i, result[:error].to_s)
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "XQAL MARK READ" }
+  end
+
+  def test_forward_alert_short_circuits_when_xqal_unsupported
+    RpmsRpc.client.seed_capability(:xqal_alert_actions, supported: false)
+    result = RpmsRpc::Communication.forward_alert(501, from_duz: DUZ, to_duz: 302)
+
+    assert_equal false, result[:success]
+    assert_match(/not available/i, result[:error].to_s)
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "XQAL FORWARD" }
+  end
+
   private
 
   def message_attrs(overrides = {})

--- a/test/rpms_rpc/server_capabilities_test.rb
+++ b/test/rpms_rpc/server_capabilities_test.rb
@@ -110,6 +110,22 @@ class RpmsRpc::ServerCapabilitiesTest < Minitest::Test
     assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :pso_prescription_orders)
   end
 
+  def test_xqal_alert_actions_feature_is_registered
+    assert RpmsRpc::ServerCapabilities::FEATURE_RPCS.key?(:xqal_alert_actions),
+           "Registry must expose :xqal_alert_actions — gates Communication get_alerts / mark_alert_read / forward_alert"
+  end
+
+  def test_xqal_alert_actions_probes_xqal_new_alerts
+    rpcs = RpmsRpc::ServerCapabilities::FEATURE_RPCS[:xqal_alert_actions]
+    assert_equal [ "XQAL NEW ALERTS" ], rpcs,
+                 "Read-only sentinel; XQAL MARK READ / FORWARD writes gate by association"
+  end
+
+  def test_probe_returns_false_when_xqal_new_alerts_missing
+    missing = ProbingClient.new(missing: [ "XQAL NEW ALERTS" ])
+    assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :xqal_alert_actions)
+  end
+
   def test_unknown_feature_raises_argument_error
     assert_raises(ArgumentError) do
       RpmsRpc::ServerCapabilities.probe(@client, :no_such_feature)


### PR DESCRIPTION
## Summary
- Adds `:xqal_alert_actions` to `ServerCapabilities::FEATURE_RPCS`, probed via `XQAL NEW ALERTS` (the read-shape sentinel; `XQAL MARK READ` and `XQAL FORWARD` writes gate by association).
- `Communication#get_alerts(duz)`: returns `[]` when unsupported.
- `Communication#mark_alert_read(alert_ien, duz)`: returns `{success: false, error: "XQAL alert actions not available on this server"}` when unsupported.
- `Communication#forward_alert(alert_ien, from_duz:, to_duz:, comment:)`: same shape.
- Six new tests (3 capability-registry + 3 gate-tripping).

Bundled PR (capability + callers), same shape as #132 / #139.

`XQAL NEW ALERTS`, `XQAL MARK READ`, and `XQAL FORWARD` are all absent on the 2026-06-07 staging dump. The XQAL namespace is *partially* present (`XQAL GUI ALERTS` exists, in `XQALGUI` routine — different CPRS-GUI-format read API the gem doesn't currently use). Re-routing to `XQAL GUI ALERTS` is a separate concern that depends on understanding its contract; this PR just gates the existing callers so they degrade gracefully today.

Refs #126.

## Test plan
- [x] TDD red -> green for all 6 new tests
- [x] Full suite: 876 runs, 0 failures
- [x] Existing happy-path tests for get_alerts / mark_alert_read / forward_alert still pass (MockClient defaults `supports?` to true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)