### PR TITLE
Gate Phr BPHR endpoints on :bphr_phr_endpoints

### DIFF
--- a/lib/rpms_rpc/api/phr.rb
+++ b/lib/rpms_rpc/api/phr.rb
@@ -86,6 +86,7 @@ module RpmsRpc
 
     def record_access(dfn, access_type: "VIEW", date: Date.today)
       return nil if invalid_id?(dfn)
+      return nil unless RpmsRpc.client.supports?(:bphr_phr_endpoints)
 
       param = "#{dfn}^#{access_type}^#{format_date(date)}"
       DataMapper.phr_record_access.fetch_scalar(param)
@@ -102,6 +103,7 @@ module RpmsRpc
 
     def direct_address(mapping_name, id)
       return nil if invalid_id?(id)
+      return nil unless RpmsRpc.client.supports?(:bphr_phr_endpoints)
 
       row = DataMapper[mapping_name].fetch_one(id.to_s)
       return nil if row.nil?

--- a/lib/rpms_rpc/api/phr.rb
+++ b/lib/rpms_rpc/api/phr.rb
@@ -84,10 +84,11 @@ module RpmsRpc
       direct_address(:phr_facility_direct, location_ien)
     end
 
-    def record_access(dfn, access_type: "VIEW", date: Date.today)
+    def record_access(dfn, access_type: "VIEW", date: nil)
       return nil if invalid_id?(dfn)
       return nil unless RpmsRpc.client.supports?(:bphr_phr_endpoints)
 
+      date ||= Date.today
       param = "#{dfn}^#{access_type}^#{format_date(date)}"
       DataMapper.phr_record_access.fetch_scalar(param)
     end

--- a/lib/rpms_rpc/server_capabilities.rb
+++ b/lib/rpms_rpc/server_capabilities.rb
@@ -71,6 +71,15 @@ module RpmsRpc
       # by association.
       xqal_alert_actions: [
         "XQAL NEW ALERTS"
+      ].freeze,
+
+      # Phr#patient_direct_address / #provider_direct_address /
+      # #facility_direct_domain / #record_access — BPHR namespace is
+      # absent entirely on the 2026-06-07 staging dump. Probe via the
+      # read-shape BPHR PATIENT DIRECT; the BPHR RECORD ACCESS write
+      # (logs PHR access for reporting) gates by association.
+      bphr_phr_endpoints: [
+        "BPHR PATIENT DIRECT"
       ].freeze
     }.freeze
 

--- a/test/rpms_rpc/api/phr_test.rb
+++ b/test/rpms_rpc/api/phr_test.rb
@@ -195,4 +195,30 @@ class PhrTest < Minitest::Test
     refute_nil call
     assert_equal [ "#{DFN}^DOWNLOAD^05/26/2026" ], call[:params]
   end
+
+  # === :bphr_phr_endpoints capability gating ===============================
+
+  def test_patient_direct_address_nil_when_bphr_unsupported
+    RpmsRpc.client.seed_capability(:bphr_phr_endpoints, supported: false)
+    assert_nil RpmsRpc::Phr.patient_direct_address(DFN)
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BPHR PATIENT DIRECT" }
+  end
+
+  def test_provider_direct_address_nil_when_bphr_unsupported
+    RpmsRpc.client.seed_capability(:bphr_phr_endpoints, supported: false)
+    assert_nil RpmsRpc::Phr.provider_direct_address(301)
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BPHR PROVIDER DIRECT" }
+  end
+
+  def test_facility_direct_domain_nil_when_bphr_unsupported
+    RpmsRpc.client.seed_capability(:bphr_phr_endpoints, supported: false)
+    assert_nil RpmsRpc::Phr.facility_direct_domain(55)
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BPHR FACILITY DIRECT" }
+  end
+
+  def test_record_access_nil_when_bphr_unsupported
+    RpmsRpc.client.seed_capability(:bphr_phr_endpoints, supported: false)
+    assert_nil RpmsRpc::Phr.record_access(DFN, access_type: "VIEW")
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BPHR RECORD ACCESS" }
+  end
 end

--- a/test/rpms_rpc/server_capabilities_test.rb
+++ b/test/rpms_rpc/server_capabilities_test.rb
@@ -126,6 +126,22 @@ class RpmsRpc::ServerCapabilitiesTest < Minitest::Test
     assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :xqal_alert_actions)
   end
 
+  def test_bphr_phr_endpoints_feature_is_registered
+    assert RpmsRpc::ServerCapabilities::FEATURE_RPCS.key?(:bphr_phr_endpoints),
+           "Registry must expose :bphr_phr_endpoints — gates Phr patient/provider/facility direct + record_access"
+  end
+
+  def test_bphr_phr_endpoints_probes_bphr_patient_direct
+    rpcs = RpmsRpc::ServerCapabilities::FEATURE_RPCS[:bphr_phr_endpoints]
+    assert_equal [ "BPHR PATIENT DIRECT" ], rpcs,
+                 "Read-only sentinel; BPHR RECORD ACCESS write gates by association"
+  end
+
+  def test_probe_returns_false_when_bphr_patient_direct_missing
+    missing = ProbingClient.new(missing: [ "BPHR PATIENT DIRECT" ])
+    assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :bphr_phr_endpoints)
+  end
+
   def test_unknown_feature_raises_argument_error
     assert_raises(ArgumentError) do
       RpmsRpc::ServerCapabilities.probe(@client, :no_such_feature)


### PR DESCRIPTION
## Summary
- Adds `:bphr_phr_endpoints` to `ServerCapabilities::FEATURE_RPCS`, probed via `BPHR PATIENT DIRECT` (read-shape; the `BPHR RECORD ACCESS` write gates by association).
- `Phr#patient_direct_address(dfn)`, `#provider_direct_address(duz)`, `#facility_direct_domain(location_ien)` — gate inside the shared `direct_address` private helper; all return `nil` when unsupported (matches the existing nil-on-no-result contract).
- `Phr#record_access(dfn, access_type:, date:)` — returns `nil` when unsupported (matches its existing invalid-id contract).
- Seven new tests (3 capability-registry + 4 gate-tripping).

Bundled PR (capability + callers), same shape as #132 / #139 / #140.

The BPHR namespace is absent entirely from the 2026-06-07 staging dump (zero entries). Without this gate, the four Phr methods would attempt RPCs that don't exist — silently returning nil today through the existing error paths, but generating spurious broker error frames and wasted round-trips.

Refs #126.

## Test plan
- [x] TDD red -> green for all 7 new tests
- [x] Full suite: 883 runs, 0 failures
- [x] Existing happy-path tests for direct_address methods + record_access still pass (MockClient defaults `supports?` to true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)