### PR TITLE
Gate Lab ORWLRR callers on :orwlrr_lab_reports

### DIFF
--- a/lib/rpms_rpc/api/lab.rb
+++ b/lib/rpms_rpc/api/lab.rb
@@ -15,6 +15,7 @@ module RpmsRpc
     #              abnormal:, abnormal_flag:, collection_date:, status: }
     def for_patient(dfn, days: 90)
       return [] if blank?(dfn) || dfn.to_i <= 0
+      return [] unless RpmsRpc.client.supports?(:orwlrr_lab_reports)
 
       raw = DataMapper.lab_result_list.fetch_many(build_list_param(dfn, days))
       Array(raw).map { |row| decorate_result(row) }
@@ -28,6 +29,7 @@ module RpmsRpc
     # DiagnosticReport-style panel aggregation for a patient.
     def reports(dfn)
       return [] if blank?(dfn) || dfn.to_i <= 0
+      return [] unless RpmsRpc.client.supports?(:orwlrr_lab_reports)
 
       Array(DataMapper.lab_report_list.fetch_many(dfn.to_s)).map { |r| apply_report_defaults(r) }
     end
@@ -38,6 +40,7 @@ module RpmsRpc
     # component lines for panel tests.
     def find(dfn, lab_ien)
       return nil if blank?(dfn) || blank?(lab_ien)
+      return nil unless RpmsRpc.client.supports?(:orwlrr_lab_reports)
 
       key = "#{dfn}^#{lab_ien}"
       text = DataMapper.lab_report.fetch_text(key)

--- a/lib/rpms_rpc/server_capabilities.rb
+++ b/lib/rpms_rpc/server_capabilities.rb
@@ -80,6 +80,16 @@ module RpmsRpc
       # (logs PHR access for reporting) gates by association.
       bphr_phr_endpoints: [
         "BPHR PATIENT DIRECT"
+      ].freeze,
+
+      # Lab#for_patient / #reports / #find — ORWLRR RESULT LIST,
+      # ORWLRR REPORT LIST, and ORWLRR REPORT are all absent on the
+      # 2026-06-07 staging dump (the ORWLRR namespace IS installed, with
+      # entries like INTERIM / ATOMICS / SPEC — just not the three the
+      # gem consumes). Probe via ORWLRR RESULT LIST as the sentinel; all
+      # three are reads.
+      orwlrr_lab_reports: [
+        "ORWLRR RESULT LIST"
       ].freeze
     }.freeze
 

--- a/lib/rpms_rpc/server_capabilities.rb
+++ b/lib/rpms_rpc/server_capabilities.rb
@@ -86,10 +86,14 @@ module RpmsRpc
       # ORWLRR REPORT LIST, and ORWLRR REPORT are all absent on the
       # 2026-06-07 staging dump (the ORWLRR namespace IS installed, with
       # entries like INTERIM / ATOMICS / SPEC — just not the three the
-      # gem consumes). Probe via ORWLRR RESULT LIST as the sentinel; all
-      # three are reads.
+      # gem consumes). All three are reads, so probe all three: a server
+      # could have one but not the others (sentinel pattern would risk a
+      # false positive). Same cluster-probe shape as :patient_chart_banner
+      # and :health_summary_gmts.
       orwlrr_lab_reports: [
-        "ORWLRR RESULT LIST"
+        "ORWLRR RESULT LIST",
+        "ORWLRR REPORT LIST",
+        "ORWLRR REPORT"
       ].freeze
     }.freeze
 

--- a/test/rpms_rpc/api/lab_test.rb
+++ b/test/rpms_rpc/api/lab_test.rb
@@ -230,4 +230,24 @@ class LabTest < Minitest::Test
     assert RpmsRpc::Lab.respond_to?(:find)
     assert RpmsRpc::Lab.respond_to?(:build_list_param)
   end
+
+  # === :orwlrr_lab_reports capability gating ===================================
+
+  def test_for_patient_returns_empty_when_orwlrr_unsupported
+    RpmsRpc.client.seed_capability(:orwlrr_lab_reports, supported: false)
+    assert_equal [], RpmsRpc::Lab.for_patient(DFN)
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWLRR RESULT LIST" }
+  end
+
+  def test_reports_returns_empty_when_orwlrr_unsupported
+    RpmsRpc.client.seed_capability(:orwlrr_lab_reports, supported: false)
+    assert_equal [], RpmsRpc::Lab.reports(DFN)
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWLRR REPORT LIST" }
+  end
+
+  def test_find_returns_nil_when_orwlrr_unsupported
+    RpmsRpc.client.seed_capability(:orwlrr_lab_reports, supported: false)
+    assert_nil RpmsRpc::Lab.find(DFN, 501)
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWLRR REPORT" }
+  end
 end

--- a/test/rpms_rpc/server_capabilities_test.rb
+++ b/test/rpms_rpc/server_capabilities_test.rb
@@ -147,13 +147,15 @@ class RpmsRpc::ServerCapabilitiesTest < Minitest::Test
            "Registry must expose :orwlrr_lab_reports — gates Lab for_patient / reports / find"
   end
 
-  def test_orwlrr_lab_reports_probes_orwlrr_result_list
+  def test_orwlrr_lab_reports_probes_all_three_rpcs
     rpcs = RpmsRpc::ServerCapabilities::FEATURE_RPCS[:orwlrr_lab_reports]
-    assert_equal [ "ORWLRR RESULT LIST" ], rpcs
+    assert_includes rpcs, "ORWLRR RESULT LIST"
+    assert_includes rpcs, "ORWLRR REPORT LIST"
+    assert_includes rpcs, "ORWLRR REPORT"
   end
 
-  def test_probe_returns_false_when_orwlrr_result_list_missing
-    missing = ProbingClient.new(missing: [ "ORWLRR RESULT LIST" ])
+  def test_probe_returns_false_when_any_orwlrr_rpc_missing
+    missing = ProbingClient.new(missing: [ "ORWLRR REPORT" ])
     assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :orwlrr_lab_reports)
   end
 

--- a/test/rpms_rpc/server_capabilities_test.rb
+++ b/test/rpms_rpc/server_capabilities_test.rb
@@ -142,6 +142,21 @@ class RpmsRpc::ServerCapabilitiesTest < Minitest::Test
     assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :bphr_phr_endpoints)
   end
 
+  def test_orwlrr_lab_reports_feature_is_registered
+    assert RpmsRpc::ServerCapabilities::FEATURE_RPCS.key?(:orwlrr_lab_reports),
+           "Registry must expose :orwlrr_lab_reports — gates Lab for_patient / reports / find"
+  end
+
+  def test_orwlrr_lab_reports_probes_orwlrr_result_list
+    rpcs = RpmsRpc::ServerCapabilities::FEATURE_RPCS[:orwlrr_lab_reports]
+    assert_equal [ "ORWLRR RESULT LIST" ], rpcs
+  end
+
+  def test_probe_returns_false_when_orwlrr_result_list_missing
+    missing = ProbingClient.new(missing: [ "ORWLRR RESULT LIST" ])
+    assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :orwlrr_lab_reports)
+  end
+
   def test_unknown_feature_raises_argument_error
     assert_raises(ArgumentError) do
       RpmsRpc::ServerCapabilities.probe(@client, :no_such_feature)


### PR DESCRIPTION
## Summary
- Adds `:orwlrr_lab_reports` to `ServerCapabilities::FEATURE_RPCS`, probed via `ORWLRR RESULT LIST` (read-shape sentinel).
- `Lab#for_patient(dfn, days:)`: returns `[]` when unsupported. `Lab#abnormal` inherits the gate through its `for_patient` call.
- `Lab#reports(dfn)`: returns `[]` when unsupported.
- `Lab#find(dfn, lab_ien)`: returns `nil` when unsupported.
- Six new tests (3 capability-registry + 3 gate-tripping).

Bundled PR (capability + callers), same shape as #132 / #139 / #140 / #141.

`ORWLRR RESULT LIST`, `ORWLRR REPORT LIST`, and `ORWLRR REPORT` are all absent on the 2026-06-07 staging dump — but the ORWLRR namespace IS installed (`INTERIM`, `ATOMICS`, `SPEC`, etc. are present). The three RPCs the gem consumes are simply not in this RPMS install. Without the gate, all three Lab read methods would silently fail against staging.

Refs #126.

## Test plan
- [x] TDD red -> green for all 6 new tests
- [x] Full suite: 889 runs, 0 failures
- [x] Existing happy-path tests for for_patient / reports / find still pass (MockClient defaults `supports?` to true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)