### PR TITLE
Gate Radiology ORWRA callers on :orwra_radiology_reports

### DIFF
--- a/lib/rpms_rpc/api/radiology.rb
+++ b/lib/rpms_rpc/api/radiology.rb
@@ -14,6 +14,7 @@ module RpmsRpc
     #              impression:, imaging_study_ien:, report_text: }
     def for_patient(dfn)
       return [] if dfn.nil? || dfn.to_s.empty? || dfn.to_i <= 0
+      return [] unless RpmsRpc.client.supports?(:orwra_radiology_reports)
 
       Array(DataMapper.radiology_list.fetch_many(dfn.to_s)).map { |r| apply_defaults(r) }
     end
@@ -23,6 +24,7 @@ module RpmsRpc
     # want to apply site-specific parsing on the returned text.
     def find(ien)
       return nil if ien.nil? || ien.to_s.empty?
+      return nil unless RpmsRpc.client.supports?(:orwra_radiology_reports)
 
       text = DataMapper.radiology_report.fetch_text(ien.to_s)
       return nil if text.nil? || (text.respond_to?(:empty?) && text.empty?)

--- a/lib/rpms_rpc/server_capabilities.rb
+++ b/lib/rpms_rpc/server_capabilities.rb
@@ -94,6 +94,16 @@ module RpmsRpc
         "ORWLRR RESULT LIST",
         "ORWLRR REPORT LIST",
         "ORWLRR REPORT"
+      ].freeze,
+
+      # Radiology#for_patient / #find — ORWRA REPORT and ORWRA REPORT
+      # LIST are absent on the 2026-06-07 staging dump (the ORWRA
+      # namespace has ORWRA REPORT TEXT / REPORT TEXT1 — possible rename
+      # situation worth follow-up investigation). Both gem-consumed RPCs
+      # are reads, so probe both per the all-reads cluster pattern.
+      orwra_radiology_reports: [
+        "ORWRA REPORT",
+        "ORWRA REPORT LIST"
       ].freeze
     }.freeze
 

--- a/test/rpms_rpc/api/radiology_test.rb
+++ b/test/rpms_rpc/api/radiology_test.rb
@@ -92,4 +92,18 @@ class RadiologyTest < Minitest::Test
     assert RpmsRpc::Radiology.respond_to?(:for_patient)
     assert RpmsRpc::Radiology.respond_to?(:find)
   end
+
+  # === :orwra_radiology_reports capability gating ==============================
+
+  def test_for_patient_returns_empty_when_orwra_unsupported
+    RpmsRpc.client.seed_capability(:orwra_radiology_reports, supported: false)
+    assert_equal [], RpmsRpc::Radiology.for_patient(8791)
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWRA REPORT LIST" }
+  end
+
+  def test_find_returns_nil_when_orwra_unsupported
+    RpmsRpc.client.seed_capability(:orwra_radiology_reports, supported: false)
+    assert_nil RpmsRpc::Radiology.find(501)
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWRA REPORT" }
+  end
 end

--- a/test/rpms_rpc/server_capabilities_test.rb
+++ b/test/rpms_rpc/server_capabilities_test.rb
@@ -159,6 +159,22 @@ class RpmsRpc::ServerCapabilitiesTest < Minitest::Test
     assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :orwlrr_lab_reports)
   end
 
+  def test_orwra_radiology_reports_feature_is_registered
+    assert RpmsRpc::ServerCapabilities::FEATURE_RPCS.key?(:orwra_radiology_reports),
+           "Registry must expose :orwra_radiology_reports — gates Radiology for_patient / find"
+  end
+
+  def test_orwra_radiology_reports_probes_both_rpcs
+    rpcs = RpmsRpc::ServerCapabilities::FEATURE_RPCS[:orwra_radiology_reports]
+    assert_includes rpcs, "ORWRA REPORT"
+    assert_includes rpcs, "ORWRA REPORT LIST"
+  end
+
+  def test_probe_returns_false_when_any_orwra_rpc_missing
+    missing = ProbingClient.new(missing: [ "ORWRA REPORT" ])
+    assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :orwra_radiology_reports)
+  end
+
   def test_unknown_feature_raises_argument_error
     assert_raises(ArgumentError) do
       RpmsRpc::ServerCapabilities.probe(@client, :no_such_feature)


### PR DESCRIPTION
## Summary
- Adds `:orwra_radiology_reports` to `ServerCapabilities::FEATURE_RPCS`, probing both `ORWRA REPORT` and `ORWRA REPORT LIST` (all-reads cluster pattern, matching the post-Copilot-feedback ORWLRR shape from #142).
- `Radiology#for_patient(dfn)`: returns `[]` when unsupported.
- `Radiology#find(ien)`: returns `nil` when unsupported.
- Five new tests (3 capability-registry + 2 gate-tripping).

Bundled PR (capability + callers), same shape as #132 / #139 / #140 / #141 / #142.

`ORWRA REPORT` and `ORWRA REPORT LIST` are absent on the 2026-06-07 staging dump. The ORWRA namespace has `ORWRA REPORT TEXT` and `ORWRA REPORT TEXT1` — possible rename situation analogous to the BMC referral rename in #127 (`BMCRPC SRCHREF` → `BMC SEARCH REFERRAL`). Confirming whether `ORWRA REPORT TEXT` is functionally equivalent to what the gem expects from `ORWRA REPORT` needs contract investigation — explicitly out of scope for this gating PR.

Refs #126.

## Test plan
- [x] TDD red -> green for all 5 new tests
- [x] Full suite: 894 runs, 0 failures
- [x] Existing happy-path tests for for_patient / find still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)