### PR TITLE
Gate Device + Procedure ORWPCE callers on :orwpce_clinical_logs

### DIFF
--- a/lib/rpms_rpc/api/device.rb
+++ b/lib/rpms_rpc/api/device.rb
@@ -6,12 +6,14 @@ module RpmsRpc
 
     def for_patient(dfn)
       return [] if blank?(dfn) || dfn.to_i <= 0
+      return [] unless RpmsRpc.client.supports?(:orwpce_clinical_logs)
 
       DataMapper.device_list.fetch_many(dfn.to_s).map { |device| apply_defaults(device) }
     end
 
     def find(ien)
       return nil if blank?(ien) || ien.to_i <= 0
+      return nil unless RpmsRpc.client.supports?(:orwpce_clinical_logs)
 
       device = DataMapper.device_detail.fetch_one(ien.to_s, extras: { ien: ien.to_s })
       apply_defaults(device) if device

--- a/lib/rpms_rpc/api/procedure.rb
+++ b/lib/rpms_rpc/api/procedure.rb
@@ -9,6 +9,8 @@ module RpmsRpc
     extend self
 
     def for_patient(dfn)
+      return [] unless RpmsRpc.client.supports?(:orwpce_clinical_logs)
+
       DataMapper.procedure_list.fetch_many(dfn.to_s)
     end
 

--- a/lib/rpms_rpc/api/procedure.rb
+++ b/lib/rpms_rpc/api/procedure.rb
@@ -9,6 +9,7 @@ module RpmsRpc
     extend self
 
     def for_patient(dfn)
+      return [] if invalid_id?(dfn)
       return [] unless RpmsRpc.client.supports?(:orwpce_clinical_logs)
 
       DataMapper.procedure_list.fetch_many(dfn.to_s)

--- a/lib/rpms_rpc/server_capabilities.rb
+++ b/lib/rpms_rpc/server_capabilities.rb
@@ -104,6 +104,19 @@ module RpmsRpc
       orwra_radiology_reports: [
         "ORWRA REPORT",
         "ORWRA REPORT LIST"
+      ].freeze,
+
+      # Device#for_patient / #find + Procedure#for_patient — ORWPCE
+      # IMPLANT LIST/GET and ORWPCE PROCEDURE LIST are absent on the
+      # 2026-06-07 staging dump (the ORWPCE namespace IS installed with
+      # DIAG / PROC / VISIT / IMM / etc. — just not the IMPLANT/PROCEDURE
+      # log variants the gem consumes). Probe all three live-consumer
+      # RPCs (cluster-probe, all-reads). procedure_detail's ORWPCE
+      # PROCEDURE GET has no live caller and isn't probed.
+      orwpce_clinical_logs: [
+        "ORWPCE IMPLANT LIST",
+        "ORWPCE IMPLANT GET",
+        "ORWPCE PROCEDURE LIST"
       ].freeze
     }.freeze
 

--- a/test/rpms_rpc/api/device_test.rb
+++ b/test/rpms_rpc/api/device_test.rb
@@ -138,4 +138,18 @@ class DeviceTest < Minitest::Test
     assert_equal "Neurostimulator", device[:name]
     assert_equal "active", device[:status]
   end
+
+  # === :orwpce_clinical_logs capability gating =================================
+
+  def test_for_patient_returns_empty_when_orwpce_unsupported
+    RpmsRpc.client.seed_capability(:orwpce_clinical_logs, supported: false)
+    assert_equal [], RpmsRpc::Device.for_patient("1")
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWPCE IMPLANT LIST" }
+  end
+
+  def test_find_returns_nil_when_orwpce_unsupported
+    RpmsRpc.client.seed_capability(:orwpce_clinical_logs, supported: false)
+    assert_nil RpmsRpc::Device.find("201")
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWPCE IMPLANT GET" }
+  end
 end

--- a/test/rpms_rpc/api/procedure_test.rb
+++ b/test/rpms_rpc/api/procedure_test.rb
@@ -59,4 +59,11 @@ class ProcedureTest < Minitest::Test
     refute RpmsRpc::Procedure.add(DFN, VISIT_IEN, CPT, quantity: 0)[:success]
     refute RpmsRpc::Procedure.add(DFN, VISIT_IEN, CPT, quantity: -1)[:success]
   end
+
+  def test_for_patient_returns_empty_when_orwpce_unsupported
+    RpmsRpc.mock!
+    RpmsRpc.client.seed_capability(:orwpce_clinical_logs, supported: false)
+    assert_equal [], RpmsRpc::Procedure.for_patient(DFN)
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWPCE PROCEDURE LIST" }
+  end
 end

--- a/test/rpms_rpc/api/procedure_test.rb
+++ b/test/rpms_rpc/api/procedure_test.rb
@@ -66,4 +66,12 @@ class ProcedureTest < Minitest::Test
     assert_equal [], RpmsRpc::Procedure.for_patient(DFN)
     assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWPCE PROCEDURE LIST" }
   end
+
+  def test_for_patient_returns_empty_for_invalid_dfn_without_probing
+    RpmsRpc.mock!
+    [ nil, "", 0, -1, "abc" ].each do |bad|
+      assert_equal [], RpmsRpc::Procedure.for_patient(bad)
+    end
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWPCE PROCEDURE LIST" }
+  end
 end

--- a/test/rpms_rpc/server_capabilities_test.rb
+++ b/test/rpms_rpc/server_capabilities_test.rb
@@ -175,6 +175,23 @@ class RpmsRpc::ServerCapabilitiesTest < Minitest::Test
     assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :orwra_radiology_reports)
   end
 
+  def test_orwpce_clinical_logs_feature_is_registered
+    assert RpmsRpc::ServerCapabilities::FEATURE_RPCS.key?(:orwpce_clinical_logs),
+           "Registry must expose :orwpce_clinical_logs — gates Device for_patient / find + Procedure for_patient"
+  end
+
+  def test_orwpce_clinical_logs_probes_live_caller_rpcs
+    rpcs = RpmsRpc::ServerCapabilities::FEATURE_RPCS[:orwpce_clinical_logs]
+    assert_includes rpcs, "ORWPCE IMPLANT LIST"
+    assert_includes rpcs, "ORWPCE IMPLANT GET"
+    assert_includes rpcs, "ORWPCE PROCEDURE LIST"
+  end
+
+  def test_probe_returns_false_when_any_orwpce_rpc_missing
+    missing = ProbingClient.new(missing: [ "ORWPCE PROCEDURE LIST" ])
+    assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :orwpce_clinical_logs)
+  end
+
   def test_unknown_feature_raises_argument_error
     assert_raises(ArgumentError) do
       RpmsRpc::ServerCapabilities.probe(@client, :no_such_feature)


### PR DESCRIPTION
## Summary
- Adds `:orwpce_clinical_logs` to `ServerCapabilities::FEATURE_RPCS`, probing all three live-consumer reads: `ORWPCE IMPLANT LIST`, `ORWPCE IMPLANT GET`, `ORWPCE PROCEDURE LIST` (all-reads cluster pattern).
- `Device#for_patient(dfn)`: returns `[]` when unsupported.
- `Device#find(ien)`: returns `nil` when unsupported.
- `Procedure#for_patient(dfn)`: returns `[]` when unsupported.
- Six new tests (3 capability-registry + 3 gate-tripping).

Two engine modules (Device, Procedure) in one PR because they share the ORWPCE namespace and the gating shape is identical.

`ORWPCE IMPLANT LIST/GET` and `ORWPCE PROCEDURE LIST` are absent on the 2026-06-07 staging dump. The ORWPCE namespace IS installed (`DIAG`, `PROC`, `VISIT`, `IMM`, etc. are present) — just not these IMPLANT/PROCEDURE log variants. `procedure_detail`'s `ORWPCE PROCEDURE GET` has no live caller, so it's not probed.

Refs #126.

## Test plan
- [x] TDD red -> green for all 6 new tests
- [x] Full suite: 900 runs, 0 failures
- [x] Existing happy-path tests for Device.for_patient / find + Procedure.for_patient still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)