### PR TITLE
Gate HealthSummary ORWRP callers on :orwrp_report_types

### DIFF
--- a/lib/rpms_rpc/api/health_summary.rb
+++ b/lib/rpms_rpc/api/health_summary.rb
@@ -73,12 +73,15 @@ module RpmsRpc
     end
 
     def types
+      return DEFAULT_TYPES.map(&:dup) unless RpmsRpc.client.supports?(:orwrp_report_types)
+
       rows = DataMapper.report_types.fetch_many
       rows.empty? ? DEFAULT_TYPES.map(&:dup) : rows
     end
 
     def type_components(ien)
       return [] if invalid_id?(ien)
+      return [] unless RpmsRpc.client.supports?(:orwrp_report_types)
 
       DataMapper.report_type_components.fetch_many(ien.to_s)
     end

--- a/lib/rpms_rpc/server_capabilities.rb
+++ b/lib/rpms_rpc/server_capabilities.rb
@@ -117,6 +117,16 @@ module RpmsRpc
         "ORWPCE IMPLANT LIST",
         "ORWPCE IMPLANT GET",
         "ORWPCE PROCEDURE LIST"
+      ].freeze,
+
+      # HealthSummary#types / #type_components — ORWRP TYPES and
+      # ORWRP TYPE COMPONENTS are absent on the 2026-06-07 staging dump.
+      # Both are reads, so probe both (cluster-probe pattern). When
+      # unsupported, types falls back to DEFAULT_TYPES (existing
+      # graceful-degradation pattern); type_components returns [].
+      orwrp_report_types: [
+        "ORWRP TYPES",
+        "ORWRP TYPE COMPONENTS"
       ].freeze
     }.freeze
 

--- a/test/rpms_rpc/api/health_summary_test.rb
+++ b/test/rpms_rpc/api/health_summary_test.rb
@@ -281,4 +281,20 @@ class HealthSummaryApiTest < Minitest::Test
     assert_match(/not (?:installed|available)/i, result[:error].to_s)
     assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "GMTS FLOWSHEET DATA" }
   end
+
+  # === :orwrp_report_types capability gating ================================
+
+  def test_types_falls_back_to_defaults_when_orwrp_unsupported
+    RpmsRpc.client.seed_capability(:orwrp_report_types, supported: false)
+    types = RpmsRpc::HealthSummary.types
+
+    assert_equal RpmsRpc::HealthSummary::DEFAULT_TYPES, types
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWRP TYPES" }
+  end
+
+  def test_type_components_returns_empty_when_orwrp_unsupported
+    RpmsRpc.client.seed_capability(:orwrp_report_types, supported: false)
+    assert_equal [], RpmsRpc::HealthSummary.type_components(101)
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWRP TYPE COMPONENTS" }
+  end
 end

--- a/test/rpms_rpc/server_capabilities_test.rb
+++ b/test/rpms_rpc/server_capabilities_test.rb
@@ -192,6 +192,22 @@ class RpmsRpc::ServerCapabilitiesTest < Minitest::Test
     assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :orwpce_clinical_logs)
   end
 
+  def test_orwrp_report_types_feature_is_registered
+    assert RpmsRpc::ServerCapabilities::FEATURE_RPCS.key?(:orwrp_report_types),
+           "Registry must expose :orwrp_report_types — gates HealthSummary types / type_components"
+  end
+
+  def test_orwrp_report_types_probes_both_rpcs
+    rpcs = RpmsRpc::ServerCapabilities::FEATURE_RPCS[:orwrp_report_types]
+    assert_includes rpcs, "ORWRP TYPES"
+    assert_includes rpcs, "ORWRP TYPE COMPONENTS"
+  end
+
+  def test_probe_returns_false_when_any_orwrp_rpc_missing
+    missing = ProbingClient.new(missing: [ "ORWRP TYPE COMPONENTS" ])
+    assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :orwrp_report_types)
+  end
+
   def test_unknown_feature_raises_argument_error
     assert_raises(ArgumentError) do
       RpmsRpc::ServerCapabilities.probe(@client, :no_such_feature)


### PR DESCRIPTION
## Summary
- Adds `:orwrp_report_types` to `ServerCapabilities::FEATURE_RPCS`, probing both `ORWRP TYPES` and `ORWRP TYPE COMPONENTS` (all-reads cluster pattern).
- `HealthSummary#types`: falls back to `DEFAULT_TYPES` when unsupported (matches the existing empty-rows-fallback contract; no error path needed).
- `HealthSummary#type_components(ien)`: returns `[]` when unsupported.
- Five new tests (3 capability-registry + 2 gate-tripping).

Bundled PR. Both RPCs are reads, both are absent on the 2026-06-07 staging dump.

`HealthSummary.types` already had a graceful-degradation path for "fetch_many returned empty"; this PR generalizes it to also cover "broker doesn't have the RPC at all" without hitting the wire.

Refs #126.

## Test plan
- [x] TDD red -> green for all 5 new tests
- [x] Full suite: 906 runs, 0 failures
- [x] Existing happy-path tests for types / type_components still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)