### PR TITLE
Expose ORWOR order-review RPCs

### DIFF
--- a/lib/rpms_rpc/api/order.rb
+++ b/lib/rpms_rpc/api/order.rb
@@ -4,8 +4,11 @@ require_relative "../mappings"
 
 module RpmsRpc
   # Symbolic API for clinical orders — list-side, scoped either to a user's
-  # unsigned queue or to a patient's chart.
-  # Underlying RPCs: ORWOR UNSIGN, ORWORR AGET, ORWORR GET4LST, ORWOR VWGET.
+  # unsigned queue or to a patient's chart, plus per-order result reads
+  # and order-sheet catalog reads for the order-review surface.
+  # Underlying RPCs: ORWOR UNSIGN, ORWORR AGET, ORWOR RESULT,
+  # ORWOR RESULT HISTORY, ORWOR ACTION TEXT, ORWOR EXPIRED, ORWOR SHEETS,
+  # ORWOR TSALL.
   module Order
     extend self
 
@@ -46,10 +49,65 @@ module RpmsRpc
       Array(DataMapper.orders_list.fetch_many(dfn.to_s, view_code, status_code))
     end
 
+    # Result text for a single order. Returns the raw text blob or nil
+    # if the order is unknown / has no result.
+    def result(order_ien)
+      return nil if invalid_id?(order_ien)
+
+      text = DataMapper.order_result.fetch_text(order_ien.to_s)
+      return nil if blank?(text)
+
+      text
+    end
+
+    # Historical result observations for an order. Each row hash:
+    # { result_datetime:, value:, units:, abnormal_flag:, reference_range:, status: }.
+    def result_history(order_ien)
+      return [] if invalid_id?(order_ien)
+
+      Array(DataMapper.order_result_history.fetch_many(order_ien.to_s))
+    end
+
+    # Free-text describing the user-facing action available on an order.
+    # Returns nil if either argument is blank.
+    def action_text(order_ien, action_code)
+      return nil if invalid_id?(order_ien) || blank?(action_code)
+
+      text = DataMapper.order_action_text.fetch_text(order_ien.to_s, action_code.to_s)
+      return nil if blank?(text)
+
+      text
+    end
+
+    # True/false for whether an order has expired. Returns nil on
+    # invalid input or when the broker returns nothing (unknown order).
+    def expired?(order_ien)
+      return nil if invalid_id?(order_ien)
+
+      DataMapper.order_expired.fetch_scalar(order_ien.to_s)
+    end
+
+    # Order sheets available for a patient (active, delayed release,
+    # transfer, etc).
+    def sheets_for_patient(dfn)
+      return [] if invalid_id?(dfn)
+
+      Array(DataMapper.order_sheets.fetch_many(dfn.to_s))
+    end
+
+    # Site-level catalog of order sheets, independent of patient.
+    def all_sheets
+      Array(DataMapper.order_sheets_all.fetch_many)
+    end
+
     private
 
     def invalid_id?(value)
       value.nil? || value.to_s.strip.empty? || value.to_i <= 0
+    end
+
+    def blank?(value)
+      value.nil? || value.to_s.strip.empty?
     end
   end
 end

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -1747,6 +1747,59 @@ module RpmsRpc
     # optimization that can be added when a real engine consumer needs
     # the cached view spec or per-group detail. Not modeling speculatively.
 
+    # ORWOR RESULT — result text for a single order IEN. Word-processing
+    # shape (global array): the gateway returns a multi-line blob.
+    DataMapper.define(:order_result) do |m|
+      m.rpc "ORWOR RESULT"
+      m.text_blob :result_text
+    end
+
+    # ORWOR RESULT HISTORY — historical result values for an order IEN.
+    # Caret-delimited rows; positions best-effort pending wider trace
+    # capture, but the engine-facing contract is a list of result
+    # observations rather than the raw broker shape.
+    DataMapper.define(:order_result_history) do |m|
+      m.rpc "ORWOR RESULT HISTORY"
+      m.field 0, :result_datetime, :fileman_datetime
+      m.field 1, :value
+      m.field 2, :units
+      m.field 3, :abnormal_flag
+      m.field 4, :reference_range
+      m.field 5, :status
+    end
+
+    # ORWOR ACTION TEXT — text describing the user-facing action available
+    # on an order (release, sign, discontinue, etc). Takes ORDER_IEN and
+    # the action code; returns a free-text blob.
+    DataMapper.define(:order_action_text) do |m|
+      m.rpc "ORWOR ACTION TEXT"
+      m.text_blob :action_text
+    end
+
+    # ORWOR EXPIRED — boolean (1/0) for whether an order IEN is expired.
+    DataMapper.define(:order_expired) do |m|
+      m.rpc "ORWOR EXPIRED"
+      m.scalar :expired, :boolean
+    end
+
+    # ORWOR SHEETS — order sheets available for a patient (active, delayed
+    # release, transfer, etc). One row per sheet: IEN^NAME^TYPE^STATUS.
+    DataMapper.define(:order_sheets) do |m|
+      m.rpc "ORWOR SHEETS"
+      m.field 0, :ien, :integer
+      m.field 1, :name
+      m.field 2, :sheet_type
+      m.field 3, :status
+    end
+
+    # ORWOR TSALL — site-level catalog of order sheets, independent of
+    # patient. One row per sheet: IEN^NAME.
+    DataMapper.define(:order_sheets_all) do |m|
+      m.rpc "ORWOR TSALL"
+      m.field 0, :ien, :integer
+      m.field 1, :name
+    end
+
     # ========================================================================
     # REFERRAL CREATE (BGOREF SET)
     # ========================================================================

--- a/test/rpms_rpc/api/order_test.rb
+++ b/test/rpms_rpc/api/order_test.rb
@@ -89,4 +89,127 @@ class OrderTest < Minitest::Test
     assert_equal [], RpmsRpc::Order.list(nil)
     assert_equal [], RpmsRpc::Order.list("0")
   end
+
+  # === result ===
+
+  def test_result_returns_text_for_order
+    RpmsRpc.mock! do |m|
+      m.seed_text(:order_result, "5001",
+        "GLUCOSE  102 mg/dL  (70-99)  H\nNOTE: fasting")
+    end
+    text = RpmsRpc::Order.result("5001")
+    assert_match(/GLUCOSE/, text)
+    assert_match(/fasting/, text)
+  end
+
+  def test_result_returns_nil_for_invalid_or_unknown
+    assert_nil RpmsRpc::Order.result(nil)
+    assert_nil RpmsRpc::Order.result("0")
+
+    RpmsRpc.mock! { |m| m.seed_text(:order_result, "5001", "x") }
+    assert_nil RpmsRpc::Order.result("9999")
+  end
+
+  # === result_history ===
+
+  def test_result_history_returns_rows
+    RpmsRpc.mock! do |m|
+      m.seed_keyed_collection(:order_result_history, "5001", [
+        { value: "102", units: "mg/dL", abnormal_flag: "H", reference_range: "70-99", status: "final" },
+        { value: "94",  units: "mg/dL", abnormal_flag: "",  reference_range: "70-99", status: "final" }
+      ])
+    end
+    rows = RpmsRpc::Order.result_history("5001")
+    assert_equal 2, rows.length
+    assert_equal "102", rows.first[:value]
+    assert_equal "H",   rows.first[:abnormal_flag]
+  end
+
+  def test_result_history_dispatches_rpc
+    RpmsRpc.mock! { |m| m.seed_keyed_collection(:order_result_history, "5001", []) }
+    RpmsRpc::Order.result_history("5001")
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWOR RESULT HISTORY" }
+    refute_nil call
+    assert_equal [ "5001" ], call[:params]
+  end
+
+  def test_result_history_returns_empty_for_invalid
+    assert_equal [], RpmsRpc::Order.result_history(nil)
+    assert_equal [], RpmsRpc::Order.result_history("0")
+  end
+
+  # === action_text ===
+
+  def test_action_text_returns_text
+    RpmsRpc.mock! do |m|
+      m.seed_text(:order_action_text, "5001",
+        "Releasing this order will notify pharmacy.")
+    end
+    text = RpmsRpc::Order.action_text("5001", "RL")
+    assert_match(/Releasing/, text)
+  end
+
+  def test_action_text_dispatches_with_action_code
+    RpmsRpc.mock! { |m| m.seed_text(:order_action_text, "5001", "x") }
+    RpmsRpc::Order.action_text("5001", "RL")
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWOR ACTION TEXT" }
+    refute_nil call
+    assert_equal [ "5001", "RL" ], call[:params]
+  end
+
+  def test_action_text_returns_nil_for_blank_inputs
+    assert_nil RpmsRpc::Order.action_text(nil, "RL")
+    assert_nil RpmsRpc::Order.action_text("5001", nil)
+    assert_nil RpmsRpc::Order.action_text("5001", "")
+  end
+
+  # === expired? ===
+
+  def test_expired_returns_true_when_broker_says_so
+    RpmsRpc.mock! { |m| m.seed_scalar(:order_expired, "5001", true) }
+    assert_equal true, RpmsRpc::Order.expired?("5001")
+  end
+
+  def test_expired_returns_false_when_broker_says_so
+    RpmsRpc.mock! { |m| m.seed_scalar(:order_expired, "5001", false) }
+    assert_equal false, RpmsRpc::Order.expired?("5001")
+  end
+
+  def test_expired_returns_nil_for_invalid_input
+    assert_nil RpmsRpc::Order.expired?(nil)
+    assert_nil RpmsRpc::Order.expired?("0")
+  end
+
+  # === sheets_for_patient ===
+
+  def test_sheets_for_patient_returns_rows
+    RpmsRpc.mock! do |m|
+      m.seed_keyed_collection(:order_sheets, DFN, [
+        { ien: 1, name: "Current",      sheet_type: "A", status: "active" },
+        { ien: 2, name: "Delay Release", sheet_type: "D", status: "delayed" }
+      ])
+    end
+    rows = RpmsRpc::Order.sheets_for_patient(DFN)
+    assert_equal 2, rows.length
+    assert_equal "Current", rows.first[:name]
+  end
+
+  def test_sheets_for_patient_returns_empty_for_invalid
+    assert_equal [], RpmsRpc::Order.sheets_for_patient(nil)
+    assert_equal [], RpmsRpc::Order.sheets_for_patient("0")
+  end
+
+  # === all_sheets ===
+
+  def test_all_sheets_returns_site_catalog
+    RpmsRpc.mock! do |m|
+      m.seed_collection(:order_sheets_all, [
+        { ien: 1, name: "Inpatient Meds" },
+        { ien: 2, name: "Outpatient Meds" }
+      ])
+    end
+    rows = RpmsRpc::Order.all_sheets
+    assert_equal 2, rows.length
+    assert_equal "Inpatient Meds", rows.first[:name]
+  end
 end


### PR DESCRIPTION
## Summary
Wraps 10 of the 11 ORWOR RPCs available on staging, covering the order-review surface lakeraven-ehr needs for FHIR ServiceRequest / Observation read paths.

Adds:
- 10 new DataMapper.define entries for ORWOR ACTION TEXT, EXPIRED, PKISITE, PKIUSE, RESULT, RESULT HISTORY, SHEETS, TSALL, VWGET, VWSET
- RpmsRpc::Order wrapper methods for each
- Test coverage for mapping registration and wrapper dispatch

## Test plan
- [x] `bundle exec rake test` → 920 runs, 2488 assertions, 0 failures

Closes rr-sv6