### PR TITLE
Expose BMC CHS referral RPCs (rr-bby)

### DIFF
--- a/lib/rpms_rpc/api/referral.rb
+++ b/lib/rpms_rpc/api/referral.rb
@@ -27,6 +27,84 @@ module RpmsRpc
       DataMapper.referral_delete.fetch_one(ien.to_s, reason)
     end
 
+    def add(*params)
+      bmc_scalar_result(:bmc_add_referral, *params)
+    end
+
+    def add_secondary(*params)
+      bmc_scalar_result(:bmc_add_secondary_referral, *params)
+    end
+
+    def update(ien, *params)
+      bmc_scalar_result(:bmc_update_referral, ien, *params)
+    end
+
+    def print(ien, *params)
+      bmc_scalar_result(:bmc_print_referral, ien.to_s, *params)
+    end
+
+    def update_status(ien, status, *params)
+      bmc_scalar_result(:bmc_referral_status_update, ien.to_s, status.to_s, *params)
+    end
+
+    def update_consultation_status(consultation_ien, status, *params)
+      bmc_scalar_result(:bmc_consultation_status_update, consultation_ien.to_s, status.to_s, *params)
+    end
+
+    def purposes(*params)
+      bmc_many(:bmc_purpose_of_referral_list, *params)
+    end
+
+    def reference_data(*params)
+      bmc_many(:bmc_reference_data, *params)
+    end
+
+    def users_providers(*params)
+      bmc_many(:bmc_users_providers, *params)
+    end
+
+    def providers(*params)
+      bmc_many(:bmc_providers, *params)
+    end
+
+    def search_referred_to(*params)
+      bmc_many(:bmc_search_referred_to, *params)
+    end
+
+    def rcis_templates(*params)
+      bmc_many(:bmc_rcis_template_list, *params)
+    end
+
+    def rcis_template_detail(template_ien, *params)
+      bmc_text(:bmc_rcis_template_detail, template_ien.to_s, *params)
+    end
+
+    def patient_eligibility_status(dfn, *params)
+      return nil unless bmc_supported?
+
+      DataMapper.bmc_patient_eligibility_status.fetch_one(dfn.to_s, *params)
+    end
+
+    def patient_face_sheet(dfn, *params)
+      bmc_text(:bmc_patient_face_sheet, dfn.to_s, *params)
+    end
+
+    def patient_health_summary(dfn, *params)
+      bmc_text(:bmc_patient_health_summary, dfn.to_s, *params)
+    end
+
+    def health_summary_types(*params)
+      bmc_many(:bmc_health_summary_type, *params)
+    end
+
+    def check_year_site_param(*params)
+      bmc_scalar_result(:bmc_check_year_site_param, *params)
+    end
+
+    def add_c32_print_log(*params)
+      bmc_scalar_result(:bmc_add_c32_print_log, *params)
+    end
+
     def create(dfn, params)
       raise ArgumentError, "params must be a Hash" unless params.is_a?(Hash)
       return failure if invalid_id?(dfn)
@@ -50,6 +128,42 @@ module RpmsRpc
 
     def invalid_id?(value)
       value.nil? || value.to_s.strip.empty? || value.to_i <= 0
+    end
+
+    def bmc_supported?
+      RpmsRpc.client.supports?(:bmc_referral_workflow)
+    end
+
+    def bmc_many(mapping_name, *params)
+      return [] unless bmc_supported?
+
+      DataMapper[mapping_name].fetch_many(*params.map(&:to_s))
+    end
+
+    def bmc_text(mapping_name, *params)
+      return nil unless bmc_supported?
+
+      DataMapper[mapping_name].fetch_text(*params.map(&:to_s))
+    end
+
+    def bmc_scalar_result(mapping_name, *params)
+      return unsupported_result unless bmc_supported?
+
+      raw = DataMapper[mapping_name].fetch_scalar(*params.map(&:to_s))
+      result_from_raw(raw)
+    end
+
+    def result_from_raw(raw)
+      line = raw.to_s.strip
+      return { success: false, raw: raw } if line.empty?
+
+      success = line.start_with?("1") || line.match?(/\A[1-9]\d*\z/)
+      message = line.sub(/\A[01]\^?/, "").strip
+      { success: success, message: message.empty? ? nil : message, raw: raw }
+    end
+
+    def unsupported_result
+      { success: false, error: "BMC referral workflow not available on this server", raw: nil }
     end
   end
 end

--- a/lib/rpms_rpc/api/referral.rb
+++ b/lib/rpms_rpc/api/referral.rb
@@ -158,7 +158,7 @@ module RpmsRpc
       return { success: false, raw: raw } if line.empty?
 
       success = line.start_with?("1") || line.match?(/\A[1-9]\d*\z/)
-      message = line.sub(/\A[01]\^?/, "").strip
+      message = line.sub(/\A[01]\^/, "").strip
       { success: success, message: message.empty? ? nil : message, raw: raw }
     end
 

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -489,6 +489,143 @@ module RpmsRpc
       m.field 5, :provider
     end
 
+    # BMC ADD C32 PRINT LOG — records health-summary print activity.
+    DataMapper.define(:bmc_add_c32_print_log) do |m|
+      m.rpc "BMC ADD C32 PRINT LOG"
+      m.scalar :result
+    end
+
+    # BMC ADD REFERRAL — creates a primary CHS/RCIS referral.
+    DataMapper.define(:bmc_add_referral) do |m|
+      m.rpc "BMC ADD REFERRAL"
+      m.scalar :result
+    end
+
+    # BMC ADD SECONDARY REFERRAL — creates a secondary referral on an existing request.
+    DataMapper.define(:bmc_add_secondary_referral) do |m|
+      m.rpc "BMC ADD SECONDARY REFERRAL"
+      m.scalar :result
+    end
+
+    # BMC CHK YEAR SITE PARAM — validates fiscal-year/site RCIS setup.
+    DataMapper.define(:bmc_check_year_site_param) do |m|
+      m.rpc "BMC CHK YEAR SITE PARAM"
+      m.scalar :result
+    end
+
+    # BMC CONSULTATION STATUS UPDATE — updates the linked consultation status.
+    DataMapper.define(:bmc_consultation_status_update) do |m|
+      m.rpc "BMC CONSULTATION STATUS UPDATE"
+      m.scalar :result
+    end
+
+    # BMC GET PURPOSE OF REF API — referral purpose lookup.
+    # Common shape: IEN^NAME^CODE; extra pieces remain available through raw RPC calls.
+    DataMapper.define(:bmc_purpose_of_referral_list) do |m|
+      m.rpc "BMC GET PURPOSE OF REF API"
+      m.field 0, :ien
+      m.field 1, :name
+      m.field 2, :code
+    end
+
+    # BMC GET RCIS TEMPLATE DETAIL — template detail text/lines.
+    DataMapper.define(:bmc_rcis_template_detail) do |m|
+      m.rpc "BMC GET RCIS TEMPLATE DETAIL"
+      m.text_blob :detail
+    end
+
+    # BMC GET RCIS TEMPLATE LIST — RCIS template lookup.
+    # Common shape: IEN^NAME^TYPE.
+    DataMapper.define(:bmc_rcis_template_list) do |m|
+      m.rpc "BMC GET RCIS TEMPLATE LIST"
+      m.field 0, :ien
+      m.field 1, :name
+      m.field 2, :type
+    end
+
+    # BMC GET REFERENCE DATA — RCIS reference-data lookup.
+    # Common shape: IEN^NAME^CODE.
+    DataMapper.define(:bmc_reference_data) do |m|
+      m.rpc "BMC GET REFERENCE DATA"
+      m.field 0, :ien
+      m.field 1, :name
+      m.field 2, :code
+    end
+
+    # BMC GET USERS/PROVIDERS — user/provider lookup.
+    # Common shape: DUZ^NAME^TITLE.
+    DataMapper.define(:bmc_users_providers) do |m|
+      m.rpc "BMC GET USERS/PROVIDERS"
+      m.field 0, :duz
+      m.field 1, :name
+      m.field 2, :title
+    end
+
+    # BMC HEALTH SUMMARY TYPE — health-summary type lookup.
+    # Common shape: IEN^NAME^ABBREVIATION.
+    DataMapper.define(:bmc_health_summary_type) do |m|
+      m.rpc "BMC HEALTH SUMMARY TYPE"
+      m.field 0, :ien
+      m.field 1, :name
+      m.field 2, :abbreviation
+    end
+
+    # BMC PATIENT ELIGIBILITY STATUS — CHS/RCIS eligibility status.
+    DataMapper.define(:bmc_patient_eligibility_status) do |m|
+      m.rpc "BMC PATIENT ELIGIBILITY STATUS"
+      m.field 0, :eligible, :boolean
+      m.field 1, :status
+      m.field 2, :message
+    end
+
+    # BMC PATIENT FACE SHEET — patient context text/lines.
+    DataMapper.define(:bmc_patient_face_sheet) do |m|
+      m.rpc "BMC PATIENT FACE SHEET"
+      m.text_blob :face_sheet
+    end
+
+    # BMC PATIENT HEALTH SUMMARY — patient health-summary text/lines.
+    DataMapper.define(:bmc_patient_health_summary) do |m|
+      m.rpc "BMC PATIENT HEALTH SUMMARY"
+      m.text_blob :health_summary
+    end
+
+    # BMC PRINT REFERRAL — print operation result.
+    DataMapper.define(:bmc_print_referral) do |m|
+      m.rpc "BMC PRINT REFERRAL"
+      m.scalar :result
+    end
+
+    # BMC PROVIDERS — provider lookup.
+    # Common shape: DUZ^NAME^TITLE.
+    DataMapper.define(:bmc_providers) do |m|
+      m.rpc "BMC PROVIDERS"
+      m.field 0, :duz
+      m.field 1, :name
+      m.field 2, :title
+    end
+
+    # BMC REFERRAL STATUS UPDATE — updates the referral status.
+    DataMapper.define(:bmc_referral_status_update) do |m|
+      m.rpc "BMC REFERRAL STATUS UPDATE"
+      m.scalar :result
+    end
+
+    # BMC SEARCH REFERRED TO — referred-to facility/provider lookup.
+    # Common shape: IEN^NAME^TYPE.
+    DataMapper.define(:bmc_search_referred_to) do |m|
+      m.rpc "BMC SEARCH REFERRED TO"
+      m.field 0, :ien
+      m.field 1, :name
+      m.field 2, :type
+    end
+
+    # BMC UPDATE REFERRAL — updates an existing CHS/RCIS referral.
+    DataMapper.define(:bmc_update_referral) do |m|
+      m.rpc "BMC UPDATE REFERRAL"
+      m.scalar :result
+    end
+
     # BMCRPC GTSITPRM — RCIS site parameters
     # Format per line: KEY^VALUE
     DataMapper.define(:site_params) do |m|

--- a/lib/rpms_rpc/server_capabilities.rb
+++ b/lib/rpms_rpc/server_capabilities.rb
@@ -127,6 +127,13 @@ module RpmsRpc
       orwrp_report_types: [
         "ORWRP TYPES",
         "ORWRP TYPE COMPONENTS"
+      ].freeze,
+
+      # Referral/RCIS workflows — IHS BMC package. Probe with a read-only
+      # reference-data RPC only; create/update/status/print calls are writes or
+      # can have side effects, so API methods gate them by this association.
+      bmc_referral_workflow: [
+        "BMC GET REFERENCE DATA"
       ].freeze
     }.freeze
 

--- a/test/rpms_rpc/api/referral_test.rb
+++ b/test/rpms_rpc/api/referral_test.rb
@@ -100,6 +100,20 @@ class ReferralTest < Minitest::Test
     assert_equal [ DFN, "44" ], call[:params]
   end
 
+  def test_add_referral_bare_ien_response_preserves_value
+    # A BMC RPC that returns a bare IEN like "10" (no STATUS^MESSAGE caret)
+    # must not be parsed as `message: "0"`. Only strip a leading 0/1 when
+    # followed by `^`.
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:bmc_add_referral, "8791", "10")
+    end
+
+    result = RpmsRpc::Referral.add(DFN, "44")
+
+    assert result[:success]
+    assert_equal "10", result[:message]
+  end
+
   def test_update_referral_status_calls_bmc_status_rpc
     RpmsRpc.mock! do |m|
       m.seed_scalar(:bmc_referral_status_update, "3001", "1^UPDATED")

--- a/test/rpms_rpc/api/referral_test.rb
+++ b/test/rpms_rpc/api/referral_test.rb
@@ -86,4 +86,84 @@ class ReferralTest < Minitest::Test
     end
     refute RpmsRpc::Referral.create(DFN, { provider_ien: 1 })[:success]
   end
+
+  def test_add_referral_calls_bmc_add_referral
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:bmc_add_referral, "8791", "1^3001")
+    end
+
+    result = RpmsRpc::Referral.add(DFN, "44")
+
+    assert result[:success]
+    assert_equal "3001", result[:message]
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BMC ADD REFERRAL" }
+    assert_equal [ DFN, "44" ], call[:params]
+  end
+
+  def test_update_referral_status_calls_bmc_status_rpc
+    RpmsRpc.mock! do |m|
+      m.seed_scalar(:bmc_referral_status_update, "3001", "1^UPDATED")
+    end
+
+    result = RpmsRpc::Referral.update_status(3001, "APPROVED", "routine")
+
+    assert result[:success]
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BMC REFERRAL STATUS UPDATE" }
+    assert_equal [ "3001", "APPROVED", "routine" ], call[:params]
+  end
+
+  def test_reference_data_returns_bmc_lookup_rows
+    RpmsRpc.mock! do |m|
+      m.seed_collection(:bmc_reference_data, [
+        { ien: "10", name: "CARDIOLOGY", code: "CARD" }
+      ])
+    end
+
+    rows = RpmsRpc::Referral.reference_data("PURPOSE")
+
+    assert_equal 1, rows.length
+    assert_equal({ ien: "10", name: "CARDIOLOGY", code: "CARD" }, rows.first)
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "BMC GET REFERENCE DATA" }
+    assert_equal [ "PURPOSE" ], call[:params]
+  end
+
+  def test_rcis_template_detail_returns_text_blob
+    RpmsRpc.mock! do |m|
+      m.seed_text(:bmc_rcis_template_detail, "7", "line one\nline two")
+    end
+
+    assert_equal "line one\nline two", RpmsRpc::Referral.rcis_template_detail(7)
+  end
+
+  def test_patient_eligibility_status_returns_structured_status
+    RpmsRpc.mock! do |m|
+      m.seed(:bmc_patient_eligibility_status, DFN, {
+        eligible: true,
+        status: "ELIGIBLE",
+        message: "Active CHS eligibility"
+      })
+    end
+
+    result = RpmsRpc::Referral.patient_eligibility_status(DFN)
+
+    assert_equal true, result[:eligible]
+    assert_equal "ELIGIBLE", result[:status]
+  end
+
+  def test_bmc_calls_short_circuit_when_capability_unsupported
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:bmc_referral_workflow, supported: false)
+      m.seed_scalar(:bmc_add_referral, DFN, "1^3001")
+      m.seed_collection(:bmc_reference_data, [
+        { ien: "10", name: "CARDIOLOGY", code: "CARD" }
+      ])
+    end
+
+    result = RpmsRpc::Referral.add(DFN)
+
+    refute result[:success]
+    assert_match(/not available/i, result[:error])
+    assert_equal [], RpmsRpc::Referral.reference_data("PURPOSE")
+    assert_nil RpmsRpc.client.received_calls.find { |c| c[:rpc].start_with?("BMC ") }
+  end
 end

--- a/test/rpms_rpc/mappings_test.rb
+++ b/test/rpms_rpc/mappings_test.rb
@@ -536,6 +536,34 @@ class RpmsRpc::MappingsTest < Minitest::Test
     assert_equal "BMC GET REFERRAL", RpmsRpc::DataMapper[:referral_detail].rpc_name
   end
 
+  def test_bmc_referral_workflow_rpc_names_are_registered
+    expected = {
+      bmc_add_c32_print_log: "BMC ADD C32 PRINT LOG",
+      bmc_add_referral: "BMC ADD REFERRAL",
+      bmc_add_secondary_referral: "BMC ADD SECONDARY REFERRAL",
+      bmc_check_year_site_param: "BMC CHK YEAR SITE PARAM",
+      bmc_consultation_status_update: "BMC CONSULTATION STATUS UPDATE",
+      bmc_purpose_of_referral_list: "BMC GET PURPOSE OF REF API",
+      bmc_rcis_template_detail: "BMC GET RCIS TEMPLATE DETAIL",
+      bmc_rcis_template_list: "BMC GET RCIS TEMPLATE LIST",
+      bmc_reference_data: "BMC GET REFERENCE DATA",
+      bmc_users_providers: "BMC GET USERS/PROVIDERS",
+      bmc_health_summary_type: "BMC HEALTH SUMMARY TYPE",
+      bmc_patient_eligibility_status: "BMC PATIENT ELIGIBILITY STATUS",
+      bmc_patient_face_sheet: "BMC PATIENT FACE SHEET",
+      bmc_patient_health_summary: "BMC PATIENT HEALTH SUMMARY",
+      bmc_print_referral: "BMC PRINT REFERRAL",
+      bmc_providers: "BMC PROVIDERS",
+      bmc_referral_status_update: "BMC REFERRAL STATUS UPDATE",
+      bmc_search_referred_to: "BMC SEARCH REFERRED TO",
+      bmc_update_referral: "BMC UPDATE REFERRAL"
+    }
+
+    expected.each do |mapping, rpc_name|
+      assert_equal rpc_name, RpmsRpc::DataMapper[mapping].rpc_name
+    end
+  end
+
   # -- Registry completeness -------------------------------------------------
 
   def test_all_expected_mappings_registered
@@ -572,6 +600,13 @@ class RpmsRpc::MappingsTest < Minitest::Test
       vfc_eligibility vfc_eligibility_list vaccine_lot_list vaccine_lot_detail
       vendor_list vendor_detail preferred_vendor_list vendor_service_list
       vendor_contract_list vendor_rate_list
+      bmc_add_c32_print_log bmc_add_referral bmc_add_secondary_referral
+      bmc_check_year_site_param bmc_consultation_status_update
+      bmc_purpose_of_referral_list bmc_rcis_template_detail bmc_rcis_template_list
+      bmc_reference_data bmc_users_providers bmc_health_summary_type
+      bmc_patient_eligibility_status bmc_patient_face_sheet bmc_patient_health_summary
+      bmc_print_referral bmc_providers bmc_referral_status_update
+      bmc_search_referred_to bmc_update_referral
     ]
 
     expected.each do |name|

--- a/test/rpms_rpc/server_capabilities_test.rb
+++ b/test/rpms_rpc/server_capabilities_test.rb
@@ -208,6 +208,22 @@ class RpmsRpc::ServerCapabilitiesTest < Minitest::Test
     assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :orwrp_report_types)
   end
 
+  def test_bmc_referral_workflow_feature_is_registered
+    assert RpmsRpc::ServerCapabilities::FEATURE_RPCS.key?(:bmc_referral_workflow),
+           "Registry must expose :bmc_referral_workflow — gates Referral BMC/RCIS RPCs"
+  end
+
+  def test_bmc_referral_workflow_probes_read_only_reference_data
+    rpcs = RpmsRpc::ServerCapabilities::FEATURE_RPCS[:bmc_referral_workflow]
+    assert_equal [ "BMC GET REFERENCE DATA" ], rpcs,
+                 "Probe set must avoid BMC referral write/print/status RPCs"
+  end
+
+  def test_probe_returns_false_when_bmc_reference_data_missing
+    missing = ProbingClient.new(missing: [ "BMC GET REFERENCE DATA" ])
+    assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :bmc_referral_workflow)
+  end
+
   def test_unknown_feature_raises_argument_error
     assert_raises(ArgumentError) do
       RpmsRpc::ServerCapabilities.probe(@client, :no_such_feature)


### PR DESCRIPTION
## Summary
- Add BMC referral/RCIS mappings and Referral API methods for CHS workflow
- Register `:bmc_referral_workflow` capability (probes read-only `BMC GET REFERENCE DATA`)
- Salvaged from swarm recovery stash; excludes unrelated user_management hunks

## Test plan
- [x] `bundle exec rake test` — 916 runs, 0 failures

## Related
- Swarm bead rr-bby
- PR #155 (ORWOR), PR #156 (coverage matrix) from same recovery batch


Made with [Cursor](https://cursor.com)