### PR TITLE
Expose ORQQPL problem-list mutation + lookup RPCs

### DIFF
--- a/lib/rpms_rpc/api/problem.rb
+++ b/lib/rpms_rpc/api/problem.rb
@@ -62,6 +62,86 @@ module RpmsRpc
       Array(DataMapper.problem_filter.fetch_many(dfn.to_s, code))
     end
 
+    # ORQQPL stock-VistA reads. Use these when the engine wants the
+    # stock-VistA lookup/audit surface rather than the IHS BGOPROB writes
+    # above. Returns nil / [] for invalid identifiers without raising.
+
+    def lex_search(text)
+      return [] if text.to_s.strip.empty?
+      return unsupported_list unless workflow_supported?
+
+      Array(DataMapper.problem_lex_search.fetch_many(text.to_s))
+    end
+
+    def clinic_search(clinic_ien)
+      return [] if invalid_id?(clinic_ien)
+      return unsupported_list unless workflow_supported?
+
+      Array(DataMapper.problem_clinic_search.fetch_many(clinic_ien.to_s))
+    end
+
+    def details(ien)
+      return nil if invalid_id?(ien)
+      return unsupported_detail unless workflow_supported?
+
+      DataMapper.problem_detail.fetch_one(ien.to_s)
+    end
+
+    def audit_history(ien)
+      return [] if invalid_id?(ien)
+      return unsupported_list unless workflow_supported?
+
+      Array(DataMapper.problem_audit_history.fetch_many(ien.to_s))
+    end
+
+    def comments(ien)
+      return [] if invalid_id?(ien)
+      return unsupported_list unless workflow_supported?
+
+      Array(DataMapper.problem_comments.fetch_many(ien.to_s))
+    end
+
+    def init_patient(dfn)
+      return nil if invalid_id?(dfn)
+      return unsupported_detail unless workflow_supported?
+
+      DataMapper.problem_init_patient.fetch_one(dfn.to_s)
+    end
+
+    def provider_list(dfn)
+      return [] if invalid_id?(dfn)
+      return unsupported_list unless workflow_supported?
+
+      Array(DataMapper.problem_provider_list.fetch_many(dfn.to_s))
+    end
+
+    def edit_load(ien)
+      return nil if invalid_id?(ien)
+      return unsupported_detail unless workflow_supported?
+
+      DataMapper.problem_edit_load.fetch_one(ien.to_s)
+    end
+
+    # ORQQPL stock-VistA state-change writes that don't overlap with the
+    # IHS BGOPROB API above. Inactivate and verify are clean adds; ADD
+    # SAVE / EDIT SAVE / DELETE / UPDATE / REPLACE are wired in mappings.rb
+    # for direct DataMapper use but not given Ruby-side wrappers here
+    # because they shadow the existing add/update/delete methods.
+
+    def inactivate(ien)
+      return unsupported_result unless workflow_supported?
+
+      raw = DataMapper.problem_inactivate.fetch_scalar(ien.to_s)
+      success_result(raw)
+    end
+
+    def verify(ien)
+      return unsupported_result unless workflow_supported?
+
+      raw = DataMapper.problem_verify.fetch_scalar(ien.to_s)
+      success_result(raw)
+    end
+
     private
 
     def write(dfn, action, ien, fields)
@@ -88,6 +168,34 @@ module RpmsRpc
 
     def invalid_id?(value)
       value.nil? || value.to_s.strip.empty? || value.to_i <= 0
+    end
+
+    def workflow_supported?
+      RpmsRpc.client.supports?(:orqqpl_problem_workflow)
+    rescue NotConfiguredError
+      false
+    end
+
+    def unsupported_list
+      []
+    end
+
+    def unsupported_detail
+      nil
+    end
+
+    def unsupported_result
+      { success: false, error: "ORQQPL problem workflow not available on this server", raw: nil }
+    end
+
+    def success_result(raw)
+      line = raw.to_s.strip
+      return { success: false, raw: raw } if line.empty?
+
+      # Stock-VistA convention: leading non-zero IEN OR "1^message" = success.
+      success = line.match?(/\A[1-9]\d*\z/) || line.start_with?("1^")
+      message = line.sub(/\A[01]\^/, "").strip
+      { success: success, message: message.empty? ? nil : message, raw: raw }
     end
   end
 end

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -136,6 +136,139 @@ module RpmsRpc
       m.field 6, :provider_duz, :string, pointer: { file: 200 }
     end
 
+    # ORQQPL coverage — problem-list mutations + lookups + audit. Wire field
+    # formats below are best-effort pending broker trace capture; mapping
+    # names + RPC bindings are deliberate so the API layer can dispatch
+    # without re-deriving names. Callers using fetch_scalar / fetch_many on
+    # these mappings will get raw strings + simple keyed rows respectively.
+
+    DataMapper.define(:problem_add_save) do |m|
+      m.rpc "ORQQPL ADD SAVE"
+    end
+
+    # Best-effort field positions pending broker trace capture for
+    # problem_audit_history / problem_comments / problem_detail /
+    # problem_clinic_search / problem_lex_search / problem_provider_list /
+    # problem_edit_load — wire formats below mirror the closest analogous
+    # ORQQPL RPC (problem_list) and the standard VistA "IEN^DESCRIPTION..."
+    # convention. Refine when trace capture lands.
+
+    DataMapper.define(:problem_audit_history) do |m|
+      m.rpc "ORQQPL AUDIT HIST"
+      m.field 0, :event
+      m.field 1, :date, :fileman_date
+      m.field 2, :actor
+    end
+
+    DataMapper.define(:problem_check_duplicate) do |m|
+      m.rpc "ORQQPL CHECK DUP"
+    end
+
+    DataMapper.define(:problem_clinic_filter_list) do |m|
+      m.rpc "ORQQPL CLIN FILTER LIST"
+    end
+
+    DataMapper.define(:problem_clinic_search) do |m|
+      m.rpc "ORQQPL CLIN SRCH"
+      m.field 0, :ien
+      m.field 1, :description
+    end
+
+    DataMapper.define(:problem_delete) do |m|
+      m.rpc "ORQQPL DELETE"
+    end
+
+    DataMapper.define(:problem_detail) do |m|
+      m.rpc "ORQQPL DETAIL"
+      m.field 0, :ien
+      m.field 1, :status
+      m.field 2, :description
+    end
+
+    DataMapper.define(:problem_edit_load) do |m|
+      m.rpc "ORQQPL EDIT LOAD"
+      m.field 0, :ien
+      m.field 1, :status
+      m.field 2, :description
+    end
+
+    DataMapper.define(:problem_edit_save) do |m|
+      m.rpc "ORQQPL EDIT SAVE"
+    end
+
+    DataMapper.define(:problem_inactivate) do |m|
+      m.rpc "ORQQPL INACTIVATE"
+    end
+
+    DataMapper.define(:problem_init_patient) do |m|
+      m.rpc "ORQQPL INIT PT"
+      m.field 0, :dfn
+      m.field 1, :name
+    end
+
+    DataMapper.define(:problem_init_user) do |m|
+      m.rpc "ORQQPL INIT USER"
+    end
+
+    DataMapper.define(:problem_comments) do |m|
+      m.rpc "ORQQPL PROB COMMENTS"
+      m.field 0, :date, :fileman_date
+      m.field 1, :author
+      m.field 2, :comment
+    end
+
+    DataMapper.define(:problem_lex_search) do |m|
+      m.rpc "ORQQPL PROBLEM LEX SEARCH"
+      m.field 0, :code, :string, terminology: :icd10
+      m.field 1, :description
+    end
+
+    DataMapper.define(:problem_problem_list) do |m|
+      m.rpc "ORQQPL PROBLEM LIST"
+    end
+
+    DataMapper.define(:problem_provider_filter_list) do |m|
+      m.rpc "ORQQPL PROV FILTER LIST"
+    end
+
+    DataMapper.define(:problem_provider_list) do |m|
+      m.rpc "ORQQPL PROVIDER LIST"
+      m.field 0, :duz, :string, pointer: { file: 200 }
+      m.field 1, :name
+    end
+
+    DataMapper.define(:problem_replace) do |m|
+      m.rpc "ORQQPL REPLACE"
+    end
+
+    DataMapper.define(:problem_save_view) do |m|
+      m.rpc "ORQQPL SAVEVIEW"
+    end
+
+    DataMapper.define(:problem_service_filter_list) do |m|
+      m.rpc "ORQQPL SERV FILTER LIST"
+    end
+
+    DataMapper.define(:problem_service_search) do |m|
+      m.rpc "ORQQPL SRVC SRCH"
+    end
+
+    DataMapper.define(:problem_update) do |m|
+      m.rpc "ORQQPL UPDATE"
+    end
+
+    DataMapper.define(:problem_user_categories) do |m|
+      m.rpc "ORQQPL USER PROB CATS"
+    end
+
+    DataMapper.define(:problem_user_list) do |m|
+      m.rpc "ORQQPL USER PROB LIST"
+    end
+
+    DataMapper.define(:problem_verify) do |m|
+      m.rpc "ORQQPL VERIFY"
+    end
+
     # ORQQVI VITALS — patient vitals (multi-line)
     # Format: TYPE^VALUE^UNITS^DATE
     DataMapper.define(:vitals) do |m|

--- a/lib/rpms_rpc/server_capabilities.rb
+++ b/lib/rpms_rpc/server_capabilities.rb
@@ -134,6 +134,14 @@ module RpmsRpc
       # can have side effects, so API methods gate them by this association.
       bmc_referral_workflow: [
         "BMC GET REFERENCE DATA"
+      ].freeze,
+
+      # ORQQPL problem-list mutation + lookup surface — stock VistA.
+      # Probe with a read-only RPC (DETAIL) only; ADD SAVE, EDIT SAVE,
+      # DELETE, INACTIVATE, VERIFY, REPLACE, UPDATE are writes and must
+      # not be invoked just to test capability.
+      orqqpl_problem_workflow: [
+        "ORQQPL DETAIL"
       ].freeze
     }.freeze
 

--- a/test/rpms_rpc/api/problem_test.rb
+++ b/test/rpms_rpc/api/problem_test.rb
@@ -117,6 +117,165 @@ class ProblemTest < Minitest::Test
     assert_equal a, b, "payload must not depend on caller's Hash insertion order"
   end
 
+  # ORQQPL stock-VistA surface (rr-txz)
+
+  def test_lex_search_returns_matching_rows
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orqqpl_problem_workflow, supported: true)
+      m.seed_keyed_collection(:problem_lex_search, "diab", [
+        { code: "E11.9", description: "Type 2 diabetes mellitus" },
+        { code: "E10.9", description: "Type 1 diabetes mellitus" }
+      ])
+    end
+
+    rows = RpmsRpc::Problem.lex_search("diab")
+
+    assert_equal 2, rows.length
+    assert_equal "E11.9", rows.first[:code]
+  end
+
+  def test_lex_search_returns_empty_when_unsupported
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orqqpl_problem_workflow, supported: false)
+    end
+
+    assert_equal [], RpmsRpc::Problem.lex_search("anything")
+  end
+
+  def test_lex_search_returns_empty_for_blank_text
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orqqpl_problem_workflow, supported: true)
+    end
+
+    assert_equal [], RpmsRpc::Problem.lex_search("")
+    assert_equal [], RpmsRpc::Problem.lex_search("   ")
+  end
+
+  def test_details_returns_row_for_ien
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orqqpl_problem_workflow, supported: true)
+      m.seed_keyed_collection(:problem_detail, "5001", [
+        { ien: "5001", status: "ACTIVE", description: "HTN" }
+      ])
+    end
+
+    row = RpmsRpc::Problem.details("5001")
+
+    refute_nil row
+    assert_equal "5001", row[:ien]
+    assert_equal "HTN", row[:description]
+  end
+
+  def test_details_returns_nil_when_unsupported
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orqqpl_problem_workflow, supported: false)
+    end
+
+    assert_nil RpmsRpc::Problem.details("5001")
+  end
+
+  def test_details_returns_nil_for_invalid_ien
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orqqpl_problem_workflow, supported: true)
+    end
+
+    assert_nil RpmsRpc::Problem.details(nil)
+    assert_nil RpmsRpc::Problem.details("0")
+  end
+
+  def test_audit_history_dispatches_orqqpl_audit_hist
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orqqpl_problem_workflow, supported: true)
+      m.seed_keyed_collection(:problem_audit_history, "5001", [
+        { event: "ADDED", date: "20260615" }
+      ])
+    end
+
+    rows = RpmsRpc::Problem.audit_history("5001")
+
+    assert_equal 1, rows.length
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORQQPL AUDIT HIST" }
+    refute_nil call
+    assert_equal [ "5001" ], call[:params]
+  end
+
+  def test_comments_dispatches_orqqpl_prob_comments
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orqqpl_problem_workflow, supported: true)
+      m.seed_keyed_collection(:problem_comments, "5001", [
+        { comment: "follow-up needed" }
+      ])
+    end
+
+    rows = RpmsRpc::Problem.comments("5001")
+
+    assert_equal 1, rows.length
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORQQPL PROB COMMENTS" }
+    refute_nil call
+  end
+
+  def test_inactivate_success_via_orqqpl_inactivate
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orqqpl_problem_workflow, supported: true)
+      m.seed_scalar(:problem_inactivate, "5001", "1^INACTIVATED")
+    end
+
+    result = RpmsRpc::Problem.inactivate("5001")
+
+    assert result[:success]
+    assert_equal "INACTIVATED", result[:message]
+  end
+
+  def test_inactivate_bare_ien_response_preserves_value
+    # Defensive: an ORQQPL RPC that returns a bare IEN like "10" must
+    # not be parsed as `message: "0"` (mirrors PR #157 BMC fix).
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orqqpl_problem_workflow, supported: true)
+      m.seed_scalar(:problem_inactivate, "5001", "10")
+    end
+
+    result = RpmsRpc::Problem.inactivate("5001")
+
+    assert result[:success]
+    assert_equal "10", result[:message]
+  end
+
+  def test_inactivate_zero_response_yields_failure
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orqqpl_problem_workflow, supported: true)
+      m.seed_scalar(:problem_inactivate, "5001", "0^problem still active")
+    end
+
+    result = RpmsRpc::Problem.inactivate("5001")
+
+    refute result[:success]
+    assert_equal "problem still active", result[:message]
+  end
+
+  def test_inactivate_short_circuits_when_unsupported
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orqqpl_problem_workflow, supported: false)
+    end
+
+    result = RpmsRpc::Problem.inactivate("5001")
+
+    refute result[:success]
+    assert_match(/not available/, result[:error])
+  end
+
+  def test_verify_dispatches_orqqpl_verify
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orqqpl_problem_workflow, supported: true)
+      m.seed_scalar(:problem_verify, "5001", "1")
+    end
+
+    result = RpmsRpc::Problem.verify("5001")
+
+    assert result[:success]
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORQQPL VERIFY" }
+    refute_nil call
+  end
+
   def test_zero_or_blank_save_response_yields_failure
     RpmsRpc.mock! do |m|
       m.seed_scalar(:problem_edit, DFN, "0")

--- a/test/rpms_rpc/mappings_test.rb
+++ b/test/rpms_rpc/mappings_test.rb
@@ -607,6 +607,14 @@ class RpmsRpc::MappingsTest < Minitest::Test
       bmc_patient_eligibility_status bmc_patient_face_sheet bmc_patient_health_summary
       bmc_print_referral bmc_providers bmc_referral_status_update
       bmc_search_referred_to bmc_update_referral
+      problem_add_save problem_audit_history problem_check_duplicate
+      problem_clinic_filter_list problem_clinic_search problem_delete
+      problem_detail problem_edit_load problem_edit_save problem_inactivate
+      problem_init_patient problem_init_user problem_comments problem_lex_search
+      problem_problem_list problem_provider_filter_list problem_provider_list
+      problem_replace problem_save_view problem_service_filter_list
+      problem_service_search problem_update problem_user_categories
+      problem_user_list problem_verify
     ]
 
     expected.each do |name|

--- a/test/rpms_rpc/server_capabilities_test.rb
+++ b/test/rpms_rpc/server_capabilities_test.rb
@@ -224,6 +224,22 @@ class RpmsRpc::ServerCapabilitiesTest < Minitest::Test
     assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :bmc_referral_workflow)
   end
 
+  def test_orqqpl_problem_workflow_feature_is_registered
+    assert RpmsRpc::ServerCapabilities::FEATURE_RPCS.key?(:orqqpl_problem_workflow),
+           "Registry must expose :orqqpl_problem_workflow — gates Problem ORQQPL lookup/mutation RPCs"
+  end
+
+  def test_orqqpl_problem_workflow_probes_read_only_detail
+    rpcs = RpmsRpc::ServerCapabilities::FEATURE_RPCS[:orqqpl_problem_workflow]
+    assert_equal [ "ORQQPL DETAIL" ], rpcs,
+                 "Probe set must avoid ORQQPL write RPCs (ADD SAVE, EDIT SAVE, DELETE, INACTIVATE, VERIFY, REPLACE, UPDATE)"
+  end
+
+  def test_probe_returns_false_when_orqqpl_detail_missing
+    missing = ProbingClient.new(missing: [ "ORQQPL DETAIL" ])
+    assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :orqqpl_problem_workflow)
+  end
+
   def test_unknown_feature_raises_argument_error
     assert_raises(ArgumentError) do
       RpmsRpc::ServerCapabilities.probe(@client, :no_such_feature)


### PR DESCRIPTION
## Summary
Wraps all 25 ORQQPL RPCs missing from the gem. Stock-VistA problem-list surface required for the FHIR Condition write path on lakeraven-ehr + the audit/inactivation flow on corvid.

Adds:
- 25 DataMapper.define entries for the ORQQPL family
- RpmsRpc::Problem stock-VistA wrappers: lex_search, clinic_search, details, audit_history, comments, init_patient, provider_list, edit_load, inactivate, verify (ADD SAVE / EDIT SAVE / DELETE / UPDATE / REPLACE intentionally not given Ruby wrappers — they shadow existing IHS BGOPROB methods; callers dispatch via DataMapper directly)
- :orqqpl_problem_workflow capability gated by ORQQPL DETAIL probe (read-only, mirrors PR #157 BMC pattern)
- success_result helper bakes in the PR #157 lesson — bare-IEN responses pass through intact

## Test plan
- [x] `bundle exec rake test` → 947 runs, 2602 assertions, 0 failures, 0 errors, 0 skips
- [x] `bundle exec rubocop lib/rpms_rpc/api/problem.rb lib/rpms_rpc/mappings.rb lib/rpms_rpc/server_capabilities.rb` → clean

Closes rr-txz