### PR TITLE
Expose ORWPCE PCE V-file + visit/note wiring RPCs

### DIFF
--- a/lib/rpms_rpc/api/clinical_event.rb
+++ b/lib/rpms_rpc/api/clinical_event.rb
@@ -101,7 +101,8 @@ module RpmsRpc
     # -- Writes ------------------------------------------------------------
 
     def save(visit_ien, payload)
-      return unsupported_result if invalid_id?(visit_ien) || payload.to_s.strip.empty?
+      return validation_error("invalid visit_ien") if invalid_id?(visit_ien)
+      return validation_error("payload required") if payload.to_s.strip.empty?
       return unsupported_result unless workflow_supported?
 
       raw = DataMapper.pce_save.fetch_scalar(visit_ien.to_s, payload.to_s)
@@ -109,7 +110,8 @@ module RpmsRpc
     end
 
     def delete(visit_ien, event_ien)
-      return unsupported_result if invalid_id?(visit_ien) || invalid_id?(event_ien)
+      return validation_error("invalid visit_ien") if invalid_id?(visit_ien)
+      return validation_error("invalid event_ien") if invalid_id?(event_ien)
       return unsupported_result unless workflow_supported?
 
       raw = DataMapper.pce_delete.fetch_scalar(visit_ien.to_s, event_ien.to_s)
@@ -117,7 +119,7 @@ module RpmsRpc
     end
 
     def force(visit_ien)
-      return unsupported_result if invalid_id?(visit_ien)
+      return validation_error("invalid visit_ien") if invalid_id?(visit_ien)
       return unsupported_result unless workflow_supported?
 
       raw = DataMapper.pce_force.fetch_scalar(visit_ien.to_s)
@@ -167,6 +169,10 @@ module RpmsRpc
 
     def unsupported_result
       { success: false, error: "ORWPCE PCE workflow not available on this server", raw: nil }
+    end
+
+    def validation_error(reason)
+      { success: false, error: reason, raw: nil }
     end
 
     def success_result(raw)

--- a/lib/rpms_rpc/api/clinical_event.rb
+++ b/lib/rpms_rpc/api/clinical_event.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require_relative "../mappings"
+
+module RpmsRpc
+  # Symbolic API for the ORWPCE PCE V-file surface. Engine-facing subset
+  # of the broader ORWPCE namespace — covers visit lookup, type-table
+  # reads (exam / health-factor / immunization / skin-test / treatment /
+  # education / set-of-codes), V-file writes (SAVE / DELETE / FORCE),
+  # and encounter wiring (ASKPCE / ANYTIME / PCE4NOTE / NOTEVSTR) for
+  # note ↔ visit binding.
+  #
+  # Separated from RpmsRpc::Procedure / RpmsRpc::Device (also ORWPCE)
+  # because the V-file event surface is its own contract — wraps and
+  # gating differ. Probed via :orwpce_pce_workflow capability
+  # (read-only ORWPCE GET VISIT).
+  #
+  # Companion to RpmsRpc::Encounter — Encounter#open hydrates the BEHOENCX
+  # IHS visit context; ClinicalEvent operates on the stock-VistA PCE
+  # event surface inside that visit.
+  module ClinicalEvent
+    extend self
+
+    # -- Reads -------------------------------------------------------------
+
+    def get_visit(visit_ien)
+      return nil if invalid_id?(visit_ien)
+      return nil unless workflow_supported?
+
+      DataMapper.pce_get_visit.fetch_one(visit_ien.to_s)
+    end
+
+    def exam_types
+      return [] unless workflow_supported?
+
+      Array(DataMapper.pce_exam_types.fetch_many)
+    end
+
+    def health_factor_types
+      return [] unless workflow_supported?
+
+      Array(DataMapper.pce_health_factor_types.fetch_many)
+    end
+
+    def immunization_types
+      return [] unless workflow_supported?
+
+      Array(DataMapper.pce_immunization_types.fetch_many)
+    end
+
+    def skin_test_types
+      return [] unless workflow_supported?
+
+      Array(DataMapper.pce_skin_test_types.fetch_many)
+    end
+
+    def treatment_types
+      return [] unless workflow_supported?
+
+      Array(DataMapper.pce_treatment_types.fetch_many)
+    end
+
+    def education_topics
+      return [] unless workflow_supported?
+
+      Array(DataMapper.pce_education_topics.fetch_many)
+    end
+
+    def set_of_codes(set_name)
+      return [] if set_name.to_s.strip.empty?
+      return [] unless workflow_supported?
+
+      Array(DataMapper.pce_set_of_codes.fetch_many(set_name.to_s))
+    end
+
+    def excluded
+      return [] unless workflow_supported?
+
+      Array(DataMapper.pce_excluded.fetch_many)
+    end
+
+    def active_codes
+      return [] unless workflow_supported?
+
+      Array(DataMapper.pce_active_codes.fetch_many)
+    end
+
+    def active_providers
+      return [] unless workflow_supported?
+
+      Array(DataMapper.pce_active_providers.fetch_many)
+    end
+
+    def active_problems(dfn)
+      return [] if invalid_id?(dfn)
+      return [] unless workflow_supported?
+
+      Array(DataMapper.pce_active_problems.fetch_many(dfn.to_s))
+    end
+
+    # -- Writes ------------------------------------------------------------
+
+    def save(visit_ien, payload)
+      return unsupported_result if invalid_id?(visit_ien) || payload.to_s.strip.empty?
+      return unsupported_result unless workflow_supported?
+
+      raw = DataMapper.pce_save.fetch_scalar(visit_ien.to_s, payload.to_s)
+      success_result(raw)
+    end
+
+    def delete(visit_ien, event_ien)
+      return unsupported_result if invalid_id?(visit_ien) || invalid_id?(event_ien)
+      return unsupported_result unless workflow_supported?
+
+      raw = DataMapper.pce_delete.fetch_scalar(visit_ien.to_s, event_ien.to_s)
+      success_result(raw)
+    end
+
+    def force(visit_ien)
+      return unsupported_result if invalid_id?(visit_ien)
+      return unsupported_result unless workflow_supported?
+
+      raw = DataMapper.pce_force.fetch_scalar(visit_ien.to_s)
+      success_result(raw)
+    end
+
+    # -- Encounter wiring --------------------------------------------------
+
+    def ask_pce(visit_ien)
+      return nil if invalid_id?(visit_ien)
+      return nil unless workflow_supported?
+
+      DataMapper.pce_ask_pce.fetch_scalar(visit_ien.to_s)
+    end
+
+    def anytime
+      return nil unless workflow_supported?
+
+      DataMapper.pce_anytime.fetch_scalar
+    end
+
+    def for_note(note_ien)
+      return [] if invalid_id?(note_ien)
+      return [] unless workflow_supported?
+
+      Array(DataMapper.pce_for_note.fetch_many(note_ien.to_s))
+    end
+
+    def note_visit_string(note_ien)
+      return nil if invalid_id?(note_ien)
+      return nil unless workflow_supported?
+
+      DataMapper.pce_note_visit_string.fetch_scalar(note_ien.to_s)
+    end
+
+    private
+
+    def workflow_supported?
+      RpmsRpc.client.supports?(:orwpce_pce_workflow)
+    rescue NotConfiguredError
+      false
+    end
+
+    def invalid_id?(value)
+      value.nil? || value.to_s.strip.empty? || value.to_i <= 0
+    end
+
+    def unsupported_result
+      { success: false, error: "ORWPCE PCE workflow not available on this server", raw: nil }
+    end
+
+    def success_result(raw)
+      line = raw.to_s.strip
+      return { success: false, raw: raw } if line.empty?
+
+      # Stock-VistA convention: leading non-zero IEN or "1^message" = success.
+      # Mirrors PR #157 lesson — only strip status flag when followed by ^.
+      success = line.match?(/\A[1-9]\d*\z/) || line.start_with?("1^")
+      message = line.sub(/\A[01]\^/, "").strip
+      { success: success, message: message.empty? ? nil : message, raw: raw }
+    end
+  end
+end

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -518,6 +518,123 @@ module RpmsRpc
       m.field 4, :status
     end
 
+    # ORWPCE PCE coverage — engine-facing subset of the PCE V-file
+    # surface (visit lookup, type-table reads, V-file writes, encounter
+    # wiring for note → visit binding). Wire field positions below are
+    # best-effort pending broker trace capture; refine when traces land.
+
+    # Reads — visit + type lookups
+
+    DataMapper.define(:pce_get_visit) do |m|
+      m.rpc "ORWPCE GET VISIT"
+      m.field 0, :ien
+      m.field 1, :datetime, :fileman_date
+      m.field 2, :location
+      m.field 3, :provider
+    end
+
+    DataMapper.define(:pce_exam_types) do |m|
+      m.rpc "ORWPCE GET EXAM TYPE"
+      m.field 0, :ien
+      m.field 1, :name
+    end
+
+    DataMapper.define(:pce_health_factor_types) do |m|
+      m.rpc "ORWPCE GET HEALTH FACTORS TY"
+      m.field 0, :ien
+      m.field 1, :name
+      m.field 2, :category
+    end
+
+    DataMapper.define(:pce_immunization_types) do |m|
+      m.rpc "ORWPCE GET IMMUNIZATION TYPE"
+      m.field 0, :ien
+      m.field 1, :name
+    end
+
+    DataMapper.define(:pce_skin_test_types) do |m|
+      m.rpc "ORWPCE GET SKIN TEST TYPE"
+      m.field 0, :ien
+      m.field 1, :name
+    end
+
+    DataMapper.define(:pce_treatment_types) do |m|
+      m.rpc "ORWPCE GET TREATMENT TYPE"
+      m.field 0, :ien
+      m.field 1, :name
+    end
+
+    DataMapper.define(:pce_education_topics) do |m|
+      m.rpc "ORWPCE GET EDUCATION TOPICS"
+      m.field 0, :ien
+      m.field 1, :name
+    end
+
+    DataMapper.define(:pce_set_of_codes) do |m|
+      m.rpc "ORWPCE GET SET OF CODES"
+      m.field 0, :code
+      m.field 1, :display
+    end
+
+    DataMapper.define(:pce_excluded) do |m|
+      m.rpc "ORWPCE GET EXCLUDED"
+      m.field 0, :code
+      m.field 1, :display
+    end
+
+    DataMapper.define(:pce_active_codes) do |m|
+      m.rpc "ORWPCE ACTIVE CODE"
+      m.field 0, :code
+      m.field 1, :display
+    end
+
+    DataMapper.define(:pce_active_providers) do |m|
+      m.rpc "ORWPCE ACTIVE PROV"
+      m.field 0, :duz, :string, pointer: { file: 200 }
+      m.field 1, :name
+    end
+
+    DataMapper.define(:pce_active_problems) do |m|
+      m.rpc "ORWPCE ACTPROB"
+      m.field 0, :ien
+      m.field 1, :description
+      m.field 2, :icd_code
+    end
+
+    # Writes — V-file mutations
+
+    DataMapper.define(:pce_save) do |m|
+      m.rpc "ORWPCE SAVE"
+    end
+
+    DataMapper.define(:pce_delete) do |m|
+      m.rpc "ORWPCE DELETE"
+    end
+
+    DataMapper.define(:pce_force) do |m|
+      m.rpc "ORWPCE FORCE"
+    end
+
+    # Encounter wiring — note ↔ visit binding
+
+    DataMapper.define(:pce_ask_pce) do |m|
+      m.rpc "ORWPCE ASKPCE"
+    end
+
+    DataMapper.define(:pce_anytime) do |m|
+      m.rpc "ORWPCE ANYTIME"
+    end
+
+    DataMapper.define(:pce_for_note) do |m|
+      m.rpc "ORWPCE PCE4NOTE"
+      m.field 0, :event_type
+      m.field 1, :description
+    end
+
+    DataMapper.define(:pce_note_visit_string) do |m|
+      m.rpc "ORWPCE NOTEVSTR"
+    end
+
     # ORWPCE IMPLANT LIST — implanted device list (multi-line)
     # Format: IEN^UDI^DEVICE_ID^STATUS^DEVICE_NAME^MANUFACTURER^MODEL^SERIAL^LOT^MFG_DATE^EXP_DATE^TYPE_CODE^TYPE_DISPLAY^DISTINCT_ID
     DataMapper.define(:device_list) do |m|

--- a/lib/rpms_rpc/mappings.rb
+++ b/lib/rpms_rpc/mappings.rb
@@ -605,24 +605,29 @@ module RpmsRpc
 
     DataMapper.define(:pce_save) do |m|
       m.rpc "ORWPCE SAVE"
+      m.scalar :result
     end
 
     DataMapper.define(:pce_delete) do |m|
       m.rpc "ORWPCE DELETE"
+      m.scalar :result
     end
 
     DataMapper.define(:pce_force) do |m|
       m.rpc "ORWPCE FORCE"
+      m.scalar :result
     end
 
     # Encounter wiring — note ↔ visit binding
 
     DataMapper.define(:pce_ask_pce) do |m|
       m.rpc "ORWPCE ASKPCE"
+      m.scalar :answer
     end
 
     DataMapper.define(:pce_anytime) do |m|
       m.rpc "ORWPCE ANYTIME"
+      m.scalar :answer
     end
 
     DataMapper.define(:pce_for_note) do |m|
@@ -633,6 +638,7 @@ module RpmsRpc
 
     DataMapper.define(:pce_note_visit_string) do |m|
       m.rpc "ORWPCE NOTEVSTR"
+      m.scalar :visit_string
     end
 
     # ORWPCE IMPLANT LIST — implanted device list (multi-line)

--- a/lib/rpms_rpc/server_capabilities.rb
+++ b/lib/rpms_rpc/server_capabilities.rb
@@ -142,6 +142,15 @@ module RpmsRpc
       # not be invoked just to test capability.
       orqqpl_problem_workflow: [
         "ORQQPL DETAIL"
+      ].freeze,
+
+      # ORWPCE PCE V-file event surface — stock VistA. Probe with a
+      # read-only RPC (GET VISIT) only; SAVE / DELETE / FORCE are V-file
+      # writes and must not be invoked just to test capability. Separate
+      # from :orwpce_clinical_logs (procedure/implant lists) because the
+      # PCE event surface is its own contract.
+      orwpce_pce_workflow: [
+        "ORWPCE GET VISIT"
       ].freeze
     }.freeze
 

--- a/test/rpms_rpc/api/clinical_event_test.rb
+++ b/test/rpms_rpc/api/clinical_event_test.rb
@@ -151,7 +151,7 @@ class ClinicalEventTest < Minitest::Test
     assert_match(/not available/, result[:error])
   end
 
-  def test_save_rejects_blank_payload
+  def test_save_rejects_blank_payload_with_validation_error
     RpmsRpc.mock! do |m|
       m.seed_capability(:orwpce_pce_workflow, supported: true)
     end
@@ -159,6 +159,45 @@ class ClinicalEventTest < Minitest::Test
     result = RpmsRpc::ClinicalEvent.save(VISIT_IEN, "")
 
     refute result[:success]
+    assert_match(/payload required/, result[:error])
+    refute_match(/workflow not available/, result[:error],
+                 "blank payload on supported server must not report capability failure")
+  end
+
+  def test_save_rejects_invalid_visit_with_validation_error
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orwpce_pce_workflow, supported: true)
+    end
+
+    result = RpmsRpc::ClinicalEvent.save("0", "PAYLOAD")
+
+    refute result[:success]
+    assert_match(/invalid visit_ien/, result[:error])
+  end
+
+  def test_delete_rejects_invalid_ids_with_validation_error
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orwpce_pce_workflow, supported: true)
+    end
+
+    result = RpmsRpc::ClinicalEvent.delete("0", EVENT_IEN)
+    refute result[:success]
+    assert_match(/invalid visit_ien/, result[:error])
+
+    result = RpmsRpc::ClinicalEvent.delete(VISIT_IEN, "0")
+    refute result[:success]
+    assert_match(/invalid event_ien/, result[:error])
+  end
+
+  def test_force_rejects_invalid_visit_with_validation_error
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orwpce_pce_workflow, supported: true)
+    end
+
+    result = RpmsRpc::ClinicalEvent.force("0")
+
+    refute result[:success]
+    assert_match(/invalid visit_ien/, result[:error])
   end
 
   def test_delete_dispatches_orwpce_delete
@@ -229,5 +268,62 @@ class ClinicalEventTest < Minitest::Test
     end
 
     assert_nil RpmsRpc::ClinicalEvent.note_visit_string("12345")
+  end
+
+  # -- Compact dispatch + gating coverage for remaining read helpers --------
+
+  TYPE_LOOKUPS = {
+    exam_types:         { mapping: :pce_exam_types,         rpc: "ORWPCE GET EXAM TYPE",         row: { ien: "1", name: "Hearing" } },
+    immunization_types: { mapping: :pce_immunization_types, rpc: "ORWPCE GET IMMUNIZATION TYPE", row: { ien: "1", name: "Influenza" } },
+    skin_test_types:    { mapping: :pce_skin_test_types,    rpc: "ORWPCE GET SKIN TEST TYPE",    row: { ien: "1", name: "PPD" } },
+    treatment_types:    { mapping: :pce_treatment_types,    rpc: "ORWPCE GET TREATMENT TYPE",    row: { ien: "1", name: "Dressing" } },
+    education_topics:   { mapping: :pce_education_topics,   rpc: "ORWPCE GET EDUCATION TOPICS",  row: { ien: "1", name: "Smoking" } },
+    excluded:           { mapping: :pce_excluded,           rpc: "ORWPCE GET EXCLUDED",          row: { code: "X", display: "Excluded" } },
+    active_codes:       { mapping: :pce_active_codes,       rpc: "ORWPCE ACTIVE CODE",           row: { code: "A", display: "Active" } },
+    active_providers:   { mapping: :pce_active_providers,   rpc: "ORWPCE ACTIVE PROV",           row: { duz: "10", name: "DOE,JANE" } }
+  }.freeze
+
+  TYPE_LOOKUPS.each do |method, spec|
+    define_method("test_#{method}_dispatches_#{spec[:mapping]}") do
+      RpmsRpc.mock! do |m|
+        m.seed_capability(:orwpce_pce_workflow, supported: true)
+        m.seed_collection(spec[:mapping], [ spec[:row] ])
+      end
+
+      rows = RpmsRpc::ClinicalEvent.public_send(method)
+
+      assert_equal 1, rows.length
+      call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == spec[:rpc] }
+      refute_nil call, "Expected #{spec[:rpc]} to be dispatched"
+    end
+
+    define_method("test_#{method}_returns_empty_when_unsupported") do
+      RpmsRpc.mock! do |m|
+        m.seed_capability(:orwpce_pce_workflow, supported: false)
+      end
+
+      assert_equal [], RpmsRpc::ClinicalEvent.public_send(method)
+    end
+  end
+
+  def test_anytime_dispatches_orwpce_anytime
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orwpce_pce_workflow, supported: true)
+      m.seed_scalar(:pce_anytime, "", "1")
+    end
+
+    answer = RpmsRpc::ClinicalEvent.anytime
+
+    assert_equal "1", answer
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWPCE ANYTIME" }
+    refute_nil call
+  end
+
+  def test_anytime_returns_nil_when_unsupported
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orwpce_pce_workflow, supported: false)
+    end
+
+    assert_nil RpmsRpc::ClinicalEvent.anytime
   end
 end

--- a/test/rpms_rpc/api/clinical_event_test.rb
+++ b/test/rpms_rpc/api/clinical_event_test.rb
@@ -1,0 +1,233 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "rpms_rpc/version"
+require "rpms_rpc/mock_client"
+require "rpms_rpc/api/clinical_event"
+
+class ClinicalEventTest < Minitest::Test
+  VISIT_IEN = "7001"
+  EVENT_IEN = "9100"
+  DFN = "8791"
+
+  def teardown
+    RpmsRpc.reset!
+  end
+
+  # -- Reads ----------------------------------------------------------------
+
+  def test_get_visit_returns_visit_row
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orwpce_pce_workflow, supported: true)
+      m.seed_keyed_collection(:pce_get_visit, VISIT_IEN, [
+        { ien: VISIT_IEN, location: "PCH", provider: "DOE,JANE" }
+      ])
+    end
+
+    row = RpmsRpc::ClinicalEvent.get_visit(VISIT_IEN)
+
+    refute_nil row
+    assert_equal VISIT_IEN, row[:ien]
+    assert_equal "PCH", row[:location]
+  end
+
+  def test_get_visit_returns_nil_when_unsupported
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orwpce_pce_workflow, supported: false)
+    end
+
+    assert_nil RpmsRpc::ClinicalEvent.get_visit(VISIT_IEN)
+  end
+
+  def test_get_visit_returns_nil_for_invalid_visit
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orwpce_pce_workflow, supported: true)
+    end
+
+    assert_nil RpmsRpc::ClinicalEvent.get_visit(nil)
+    assert_nil RpmsRpc::ClinicalEvent.get_visit("0")
+  end
+
+  def test_health_factor_types_dispatches_orwpce_get_health_factors_ty
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orwpce_pce_workflow, supported: true)
+      m.seed_collection(:pce_health_factor_types, [
+        { ien: "1", name: "Smoker", category: "TOBACCO" }
+      ])
+    end
+
+    rows = RpmsRpc::ClinicalEvent.health_factor_types
+
+    assert_equal 1, rows.length
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWPCE GET HEALTH FACTORS TY" }
+    refute_nil call
+  end
+
+  def test_health_factor_types_short_circuits_when_unsupported
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orwpce_pce_workflow, supported: false)
+    end
+
+    assert_equal [], RpmsRpc::ClinicalEvent.health_factor_types
+  end
+
+  def test_active_problems_dispatches_orwpce_actprob_with_dfn
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orwpce_pce_workflow, supported: true)
+      m.seed_keyed_collection(:pce_active_problems, DFN, [
+        { ien: "5001", description: "HTN", icd_code: "I10" }
+      ])
+    end
+
+    rows = RpmsRpc::ClinicalEvent.active_problems(DFN)
+
+    assert_equal 1, rows.length
+    assert_equal "HTN", rows.first[:description]
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWPCE ACTPROB" }
+    refute_nil call
+    assert_equal [ DFN ], call[:params]
+  end
+
+  def test_set_of_codes_returns_empty_for_blank_set_name
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orwpce_pce_workflow, supported: true)
+    end
+
+    assert_equal [], RpmsRpc::ClinicalEvent.set_of_codes("")
+    assert_equal [], RpmsRpc::ClinicalEvent.set_of_codes("   ")
+  end
+
+  # -- Writes ---------------------------------------------------------------
+
+  def test_save_success_via_orwpce_save
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orwpce_pce_workflow, supported: true)
+      m.seed_scalar(:pce_save, VISIT_IEN, "1^SAVED")
+    end
+
+    result = RpmsRpc::ClinicalEvent.save(VISIT_IEN, "PAYLOAD")
+
+    assert result[:success]
+    assert_equal "SAVED", result[:message]
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWPCE SAVE" }
+    refute_nil call
+    assert_equal [ VISIT_IEN, "PAYLOAD" ], call[:params]
+  end
+
+  def test_save_bare_ien_response_preserves_value
+    # Defensive: ORWPCE SAVE returning a bare IEN must not be parsed as "0".
+    # Mirrors PR #157 lesson.
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orwpce_pce_workflow, supported: true)
+      m.seed_scalar(:pce_save, VISIT_IEN, "10")
+    end
+
+    result = RpmsRpc::ClinicalEvent.save(VISIT_IEN, "PAYLOAD")
+
+    assert result[:success]
+    assert_equal "10", result[:message]
+  end
+
+  def test_save_failure_response
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orwpce_pce_workflow, supported: true)
+      m.seed_scalar(:pce_save, VISIT_IEN, "0^visit not editable")
+    end
+
+    result = RpmsRpc::ClinicalEvent.save(VISIT_IEN, "PAYLOAD")
+
+    refute result[:success]
+    assert_equal "visit not editable", result[:message]
+  end
+
+  def test_save_short_circuits_when_unsupported
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orwpce_pce_workflow, supported: false)
+    end
+
+    result = RpmsRpc::ClinicalEvent.save(VISIT_IEN, "PAYLOAD")
+
+    refute result[:success]
+    assert_match(/not available/, result[:error])
+  end
+
+  def test_save_rejects_blank_payload
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orwpce_pce_workflow, supported: true)
+    end
+
+    result = RpmsRpc::ClinicalEvent.save(VISIT_IEN, "")
+
+    refute result[:success]
+  end
+
+  def test_delete_dispatches_orwpce_delete
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orwpce_pce_workflow, supported: true)
+      m.seed_scalar(:pce_delete, VISIT_IEN, "1")
+    end
+
+    result = RpmsRpc::ClinicalEvent.delete(VISIT_IEN, EVENT_IEN)
+
+    assert result[:success]
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWPCE DELETE" }
+    refute_nil call
+    assert_equal [ VISIT_IEN, EVENT_IEN ], call[:params]
+  end
+
+  def test_force_dispatches_orwpce_force
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orwpce_pce_workflow, supported: true)
+      m.seed_scalar(:pce_force, VISIT_IEN, "1")
+    end
+
+    result = RpmsRpc::ClinicalEvent.force(VISIT_IEN)
+
+    assert result[:success]
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWPCE FORCE" }
+    refute_nil call
+  end
+
+  # -- Encounter wiring -----------------------------------------------------
+
+  def test_ask_pce_returns_scalar_value
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orwpce_pce_workflow, supported: true)
+      m.seed_scalar(:pce_ask_pce, VISIT_IEN, "1")
+    end
+
+    assert_equal "1", RpmsRpc::ClinicalEvent.ask_pce(VISIT_IEN)
+  end
+
+  def test_for_note_dispatches_orwpce_pce4note
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orwpce_pce_workflow, supported: true)
+      m.seed_keyed_collection(:pce_for_note, "12345", [
+        { event_type: "HF", description: "Smoker counseled" }
+      ])
+    end
+
+    rows = RpmsRpc::ClinicalEvent.for_note("12345")
+
+    assert_equal 1, rows.length
+    call = RpmsRpc.client.received_calls.find { |c| c[:rpc] == "ORWPCE PCE4NOTE" }
+    refute_nil call
+  end
+
+  def test_note_visit_string_returns_scalar
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orwpce_pce_workflow, supported: true)
+      m.seed_scalar(:pce_note_visit_string, "12345", "PCH;1234567")
+    end
+
+    assert_equal "PCH;1234567", RpmsRpc::ClinicalEvent.note_visit_string("12345")
+  end
+
+  def test_note_visit_string_short_circuits_when_unsupported
+    RpmsRpc.mock! do |m|
+      m.seed_capability(:orwpce_pce_workflow, supported: false)
+    end
+
+    assert_nil RpmsRpc::ClinicalEvent.note_visit_string("12345")
+  end
+end

--- a/test/rpms_rpc/mappings_test.rb
+++ b/test/rpms_rpc/mappings_test.rb
@@ -615,6 +615,12 @@ class RpmsRpc::MappingsTest < Minitest::Test
       problem_replace problem_save_view problem_service_filter_list
       problem_service_search problem_update problem_user_categories
       problem_user_list problem_verify
+      pce_get_visit pce_exam_types pce_health_factor_types
+      pce_immunization_types pce_skin_test_types pce_treatment_types
+      pce_education_topics pce_set_of_codes pce_excluded
+      pce_active_codes pce_active_providers pce_active_problems
+      pce_save pce_delete pce_force
+      pce_ask_pce pce_anytime pce_for_note pce_note_visit_string
     ]
 
     expected.each do |name|

--- a/test/rpms_rpc/server_capabilities_test.rb
+++ b/test/rpms_rpc/server_capabilities_test.rb
@@ -240,6 +240,22 @@ class RpmsRpc::ServerCapabilitiesTest < Minitest::Test
     assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :orqqpl_problem_workflow)
   end
 
+  def test_orwpce_pce_workflow_feature_is_registered
+    assert RpmsRpc::ServerCapabilities::FEATURE_RPCS.key?(:orwpce_pce_workflow),
+           "Registry must expose :orwpce_pce_workflow — gates ClinicalEvent PCE V-file RPCs"
+  end
+
+  def test_orwpce_pce_workflow_probes_read_only_get_visit
+    rpcs = RpmsRpc::ServerCapabilities::FEATURE_RPCS[:orwpce_pce_workflow]
+    assert_equal [ "ORWPCE GET VISIT" ], rpcs,
+                 "Probe set must avoid ORWPCE write RPCs (SAVE, DELETE, FORCE)"
+  end
+
+  def test_probe_returns_false_when_orwpce_get_visit_missing
+    missing = ProbingClient.new(missing: [ "ORWPCE GET VISIT" ])
+    assert_equal false, RpmsRpc::ServerCapabilities.probe(missing, :orwpce_pce_workflow)
+  end
+
   def test_unknown_feature_raises_argument_error
     assert_raises(ArgumentError) do
       RpmsRpc::ServerCapabilities.probe(@client, :no_such_feature)


### PR DESCRIPTION
## Summary
Wraps the engine-facing subset of ORWPCE per the rr-0df bead — 19 of the 46 missing ORWPCE RPCs. ORWPCE is the stock-VistA PCE V-file event surface required for FHIR Encounter/Observation writes, note ↔ visit binding, and the V-file event lifecycle on lakeraven-ehr.

Adds:
- 19 DataMapper.define entries: reads + writes + encounter wiring
- New `RpmsRpc::ClinicalEvent` module wrapping all 19. Separate from `RpmsRpc::Procedure` / `RpmsRpc::Device` (also ORWPCE) because the PCE V-file event surface is its own contract
- `:orwpce_pce_workflow` capability gated by `ORWPCE GET VISIT` probe (read-only; mirrors PR #157 BMC + PR #158 ORQQPL patterns)
- `success_result` helper applies the PR #157 lesson — bare-IEN responses pass through intact

The remaining 27 ORWPCE RPCs are CPRS-internal probes (`ISCLINIC`, `HASCPT`, `GAFOK`, etc.) and view helpers — out of engine-facing scope; can land in a follow-up if a specific caller needs them.

## Test plan
- [x] `bundle exec rake test` → 968 runs, 2661 assertions, 0 failures, 0 errors, 0 skips
- [x] `bundle exec rubocop` on new files → clean

Closes rr-0df